### PR TITLE
fix: improve accuracy of package framerate detection

### DIFF
--- a/meteor/lib/mediaObjects.ts
+++ b/meteor/lib/mediaObjects.ts
@@ -71,9 +71,9 @@ export function buildPackageFormatString(
 			format += 'i'
 			break
 	}
-	if (stream.codec_time_base) {
-		const formattedTimebase = /(\d+)\/(\d+)/.exec(stream.codec_time_base) as RegExpExecArray
-		let fps = Number(formattedTimebase[2]) / Number(formattedTimebase[1])
+	if (stream.r_frame_rate) {
+		const formattedFramerate = /(\d+)\/(\d+)/.exec(stream.r_frame_rate) as RegExpExecArray
+		let fps = Number(formattedFramerate[1]) / Number(formattedFramerate[2])
 		fps = Math.floor(fps * 100 * 100) / 100
 		format += fps
 	}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Sofie sometimes detects the framerate of video packages incorrectly, particularly in the case of progressive scan files. This is because `buildPackageFormatString` looks at `codec_time_base` to determine a video's framerate. In certain video formats (such as XAVC MXF and H.264 MP4), `codec_time_base` is often double that of the video's actual framerate. Both ffmpeg and DaVinci Resolve export files which have this same characteristic. At first glance, it might seem that `codec_time_base` is counting fields instead of frames, but this also happens with progressive scan files. Beyond that, there are some progressive scan files I've encountered which have `codec_time_base` values like `499/50000`, despite having an `r_frame_rate` of `50/1`.

This discrepancy can result in false warnings in the rundown view where Sofie says that a package has the wrong media format, even though the package is actually of the correct format (or vice versa).

* **What is the new behavior (if this is a feature change)?**

In this PR, `buildPackageFormatString` has been changed to look at `r_frame_rate` instead of `codec_time_base` when determining a package's framerate.

* **Other information**:

`buildFormatString` has *not* been changed, as it doesn't seem to have access to `r_frame_rate` data. I'm not sure how much we care about this, seeing as `buildFormatString` seems to be for the older Media Manager and doesn't seem to be part of the Package Manager data flow.

Also of note is that this will cause interlaced packages to report their *frames* per second instead of their *fields* per second. If this is not desired, a conditional statement that checks `deepScan.field_order` could be added which retains the existing behavior for interlaced content. Such a change might look like this instead:

```typescript
if (stream.r_frame_rate) {
	const formattedFramerate = /(\d+)\/(\d+)/.exec(stream.r_frame_rate) as RegExpExecArray
	let fps = Number(formattedFramerate[1]) / Number(formattedFramerate[2])
	if (
		deepScan.field_order === PackageInfo.FieldOrder.TFF ||
		deepScan.field_order === PackageInfo.FieldOrder.BFF
	) {
		fps *= 2
	}
	fps = Math.floor(fps * 100 * 100) / 100
	format += fps
}
```