### PR TITLE
fix: dashboard panel scale affecting position

### DIFF
--- a/meteor/client/styles/shelf/dashboard.scss
+++ b/meteor/client/styles/shelf/dashboard.scss
@@ -16,6 +16,11 @@ $dashboard-button-height: 5.625em;
 	--dashboard-button-grid-height: 1.625em;
 	--dashboard-panel-margin-width: 0.938em;
 	--dashboard-panel-margin-height: 2.75em;
+	--dashboard-panel-scale: 1;
+
+	.dashboard__panel--font-scaled {
+		font-size: calc(var(--dashboard-panel-scale) * 1.5em);
+	}
 }
 
 .dashboard-panel {

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -133,7 +133,7 @@ export function dashboardElementStyle(el: DashboardPositionableElement): React.C
 				: getVerticalOffsetFromHeight(el),
 
 		// @ts-ignore
-		'--dashboard-panel-scale': el.scale || undefined,
+		'--dashboard-panel-scale': el.scale || 1,
 		'--dashboard-panel-scaled-font-size': (el.scale || 1) * 1.5 + 'em',
 	}
 }

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -132,9 +132,9 @@ export function dashboardElementStyle(el: DashboardPositionableElement): React.C
 					: `calc(${-1 * el.y - 1} * var(--dashboard-button-grid-height))`
 				: getVerticalOffsetFromHeight(el),
 
-		fontSize: el.scale ? el.scale * 1.5 + 'em' : undefined,
 		// @ts-ignore
 		'--dashboard-panel-scale': el.scale || undefined,
+		'--dashboard-panel-scaled-font-size': (el.scale || 1) * 1.5 + 'em',
 	}
 }
 

--- a/meteor/client/ui/Shelf/NextInfoPanel.tsx
+++ b/meteor/client/ui/Shelf/NextInfoPanel.tsx
@@ -54,9 +54,11 @@ export class NextInfoPanelInner extends MeteorReactComponent<INextInfoPanelProps
 					}
 				)}
 			>
-				<span className="next-info-panel__name">{showAny && this.props.panel.name} </span>
-				{segmentName && <span className="next-info-panel__segment">{segmentName}</span>}
-				{partTitle && <span className="next-info-panel__part">{partTitle}</span>}
+				<div style={{ fontSize: isDashboardLayout ? 'var(--dashboard-panel-scaled-font-size)' : undefined }}>
+					<span className="next-info-panel__name">{showAny && this.props.panel.name} </span>
+					{segmentName && <span className="next-info-panel__segment">{segmentName}</span>}
+					{partTitle && <span className="next-info-panel__part">{partTitle}</span>}
+				</div>
 			</div>
 		)
 	}

--- a/meteor/client/ui/Shelf/NextInfoPanel.tsx
+++ b/meteor/client/ui/Shelf/NextInfoPanel.tsx
@@ -54,7 +54,7 @@ export class NextInfoPanelInner extends MeteorReactComponent<INextInfoPanelProps
 					}
 				)}
 			>
-				<div style={{ fontSize: isDashboardLayout ? 'var(--dashboard-panel-scaled-font-size)' : undefined }}>
+				<div className="dashboard__panel--font-scaled">
 					<span className="next-info-panel__name">{showAny && this.props.panel.name} </span>
 					{segmentName && <span className="next-info-panel__segment">{segmentName}</span>}
 					{partTitle && <span className="next-info-panel__part">{partTitle}</span>}

--- a/meteor/client/ui/Shelf/PieceCountdownPanel.tsx
+++ b/meteor/client/ui/Shelf/PieceCountdownPanel.tsx
@@ -85,6 +85,7 @@ export class PieceCountdownPanelInner extends MeteorReactComponent<
 					className={ClassNames('piece-countdown-panel__timecode', {
 						overtime: Math.floor(this.state.displayTimecode / 1000) > 0,
 					})}
+					style={{ fontSize: isDashboardLayout ? 'var(--dashboard-panel-scaled-font-size)' : undefined }}
 				>
 					{RundownUtils.formatDiffToTimecode(
 						this.state.displayTimecode || 0,

--- a/meteor/client/ui/Shelf/PieceCountdownPanel.tsx
+++ b/meteor/client/ui/Shelf/PieceCountdownPanel.tsx
@@ -82,10 +82,9 @@ export class PieceCountdownPanelInner extends MeteorReactComponent<
 				}}
 			>
 				<span
-					className={ClassNames('piece-countdown-panel__timecode', {
+					className={ClassNames('piece-countdown-panel__timecode', 'dashboard__panel--font-scaled', {
 						overtime: Math.floor(this.state.displayTimecode / 1000) > 0,
 					})}
-					style={{ fontSize: isDashboardLayout ? 'var(--dashboard-panel-scaled-font-size)' : undefined }}
 				>
 					{RundownUtils.formatDiffToTimecode(
 						this.state.displayTimecode || 0,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix (UI)


* **What is the current behavior?** (You can also link to an open issue here)
Setting a Scale other than 1 on some dashboard panels (NextInfoPanel and PieceCountdownPanel) affects their position change. Cause: changing fontSize on an element positioned using `em`.


* **What is the new behavior (if this is a feature change)?**
Positioning on these panels is fixed to work exactly as other panels.

* **Other information**:
The additional variable (`--dashboard-panel-scale`) is not used by these panels, but used by TV 2's keyboard map. Can it stay there?

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
