### PR TITLE
fix: infinites capped by virtuals

### DIFF
--- a/meteor/client/ui/TestTools/Timeline.tsx
+++ b/meteor/client/ui/TestTools/Timeline.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Translated, translateWithTracker, withTracker } from '../../lib/ReactMeteorData/react-meteor-data'
 import * as _ from 'underscore'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
-import { deserializeTimelineBlob } from '../../../lib/collections/Timeline'
+import { deserializeTimelineBlob, RoutedTimeline } from '../../../lib/collections/Timeline'
 import { Time, applyToArray, clone } from '../../../lib/lib'
 import { PubSub } from '../../../lib/api/pubsub'
 import { TimelineState, Resolver, ResolvedStates } from 'superfly-timeline'
@@ -12,7 +12,6 @@ import { makeTableOfObject } from '../../lib/utilComponents'
 import { StudioSelect } from './StudioSelect'
 import { StudioId } from '../../../lib/collections/Studios'
 import { Mongo } from 'meteor/mongo'
-import { RoutedTimeline } from '../../../lib/collections/Timeline'
 
 const StudioTimeline = new Mongo.Collection<RoutedTimeline>('studioTimeline')
 

--- a/meteor/client/ui/TestTools/Timeline.tsx
+++ b/meteor/client/ui/TestTools/Timeline.tsx
@@ -217,7 +217,7 @@ export const ComponentTimelineSimulate = withTracker<
 								type="text"
 								value={this.state.layerFilterText}
 								onChange={this.changeLayerFilter}
-								placeholder="Text or RegEx"
+								placeholder="Text or /RegEx/"
 							/>
 						</div>
 					</div>

--- a/meteor/lib/rundown/__tests__/infinites.test.ts
+++ b/meteor/lib/rundown/__tests__/infinites.test.ts
@@ -398,6 +398,27 @@ describe('Infinites', () => {
 				},
 			])
 		})
+		testInFiber('stop onRundownEnd continuation when start=0 and onSegmentEnd is present', () => {
+			const pieceInstances = [
+				createPieceInstance('one', { start: 0 }, 'one', PieceLifespan.OutOnRundownEnd, false, {
+					fromPreviousPart: true,
+					infiniteInstanceId: protectString('one_a'),
+					infinitePieceId: protectString('one_b'),
+				}),
+				createPieceInstance('two', { start: 0 }, 'one', PieceLifespan.OutOnSegmentEnd, false, {
+					fromPreviousPart: false,
+					infiniteInstanceId: protectString('two_a'),
+					infinitePieceId: protectString('two_b'),
+				}),
+			]
+
+			pieceInstances[1].piece.virtual = true
+
+			const resolvedInstances = runAndTidyResult(pieceInstances, 500)
+
+			// don't expect virtual Pieces in the results, but 'one' should be pruned too
+			expect(resolvedInstances).toEqual([])
+		})
 	})
 	describe('getPlayheadTrackingInfinitesForPart', () => {
 		function runAndTidyResult(

--- a/meteor/lib/rundown/infinites.ts
+++ b/meteor/lib/rundown/infinites.ts
@@ -546,14 +546,13 @@ export function processAndPrunePieceInstanceTimings(
 				activePiece.resolvedEndCap = offsetFromStart(start, newPiece)
 			}
 			// track the new piece
-			console.log(key, newPiece._id)
 			activePieces[key] = newPiece
 
 			// We don't want to include virtual pieces in the output (most of the time)
 			// TODO - do we want to always output virtual pieces from the 'other' group?
 			if (
-				(!isClear(newPiece) || key === 'other' || includeVirtual) &&
-				!isCappedByAVirtual(activePieces, key, newPiece)
+				includeVirtual ||
+				((!isClear(newPiece) || key === 'other') && !isCappedByAVirtual(activePieces, key, newPiece))
 			) {
 				// add the piece to results
 				result.push(newPiece)

--- a/meteor/lib/rundown/infinites.ts
+++ b/meteor/lib/rundown/infinites.ts
@@ -495,6 +495,30 @@ function offsetFromStart(start: number | 'now', newPiece: PieceInstance): number
 	return typeof start === 'number' ? start + offset : `#${getPieceGroupId(newPiece)}.start + ${offset}`
 }
 
+function isClear(piece?: PieceInstance): boolean {
+	return !!piece?.piece.virtual
+}
+
+function isCappedByAVirtual(
+	activePieces: PieceInstanceOnInfiniteLayers,
+	key: keyof PieceInstanceOnInfiniteLayers,
+	newPiece: PieceInstance
+): boolean {
+	if (
+		(key === 'onRundownEnd' || key === 'onShowStyleEnd') &&
+		activePieces.onSegmentEnd &&
+		isCandidateMoreImportant(newPiece, activePieces.onSegmentEnd)
+	)
+		return true
+	if (
+		key === 'onShowStyleEnd' &&
+		activePieces.onRundownEnd &&
+		isCandidateMoreImportant(newPiece, activePieces.onRundownEnd)
+	)
+		return true
+	return false
+}
+
 /**
  * Process the infinite pieces to determine the start time and a maximum end time for each.
  * Any pieces which have no chance of being shown (duplicate start times) are pruned
@@ -509,8 +533,6 @@ export function processAndPrunePieceInstanceTimings(
 ): PieceInstanceWithTimings[] {
 	const result: PieceInstanceWithTimings[] = []
 
-	const isClear = (piece?: PieceInstance): boolean => !!piece?.piece.virtual
-
 	const updateWithNewPieces = (
 		activePieces: PieceInstanceOnInfiniteLayers,
 		newPieces: PieceInstanceOnInfiniteLayers,
@@ -523,12 +545,17 @@ export function processAndPrunePieceInstanceTimings(
 			if (activePiece) {
 				activePiece.resolvedEndCap = offsetFromStart(start, newPiece)
 			}
+			// track the new piece
+			console.log(key, newPiece._id)
+			activePieces[key] = newPiece
 
 			// We don't want to include virtual pieces in the output (most of the time)
 			// TODO - do we want to always output virtual pieces from the 'other' group?
-			if (!isClear(newPiece) || key === 'other' || includeVirtual) {
-				// track the new piece
-				activePieces[key] = newPiece
+			if (
+				(!isClear(newPiece) || key === 'other' || includeVirtual) &&
+				!isCappedByAVirtual(activePieces, key, newPiece)
+			) {
+				// add the piece to results
 				result.push(newPiece)
 
 				if (
@@ -546,9 +573,6 @@ export function processAndPrunePieceInstanceTimings(
 						activePieces.other = undefined
 					}
 				}
-			} else {
-				// the piece has stopped with no replacement, so clear the tracking state
-				activePieces[key] = undefined
 			}
 		}
 	}
@@ -597,7 +621,7 @@ export function processAndPrunePieceInstanceTimings(
 	return result.filter((p) => p.resolvedEndCap === undefined || p.resolvedEndCap !== p.piece.enable.start)
 }
 
-function isCandidateBetterToBeContinued(best: PieceInstance, candidate: PieceInstance): boolean {
+function isCandidateMoreImportant(best: PieceInstance, candidate: PieceInstance): boolean | undefined {
 	// Prioritise the one from this part over previous part
 	if (best.infinite?.fromPreviousPart && !candidate.infinite?.fromPreviousPart) {
 		// Prefer the candidate as it is not from previous
@@ -632,9 +656,13 @@ function isCandidateBetterToBeContinued(best: PieceInstance, candidate: PieceIns
 		return true
 	}
 
+	return undefined
+}
+
+function isCandidateBetterToBeContinued(best: PieceInstance, candidate: PieceInstance): boolean {
 	// Fallback to id, as we dont have any other criteria and this will be stable.
 	// Note: we shouldnt even get here, as it shouldnt be possible for multiple to start at the same time, but it is possible
-	return best.piece._id < candidate.piece._id
+	return isCandidateMoreImportant(best, candidate) ?? best.piece._id < candidate.piece._id
 }
 
 interface PieceInstanceOnInfiniteLayers {

--- a/meteor/package-lock.json
+++ b/meteor/package-lock.json
@@ -4711,7 +4711,7 @@
 		},
 		"chalk": {
 			"version": "1.1.3",
-			"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 			"requires": {
 				"ansi-styles": "^2.2.1",
@@ -11238,7 +11238,7 @@
 			"dependencies": {
 				"asn1.js": {
 					"version": "5.4.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
 					"integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
 					"requires": {
 						"bn.js": "^4.0.0",
@@ -11249,7 +11249,7 @@
 					"dependencies": {
 						"bn.js": {
 							"version": "4.12.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
 							"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
 						}
 					}
@@ -11267,22 +11267,22 @@
 				},
 				"base64-js": {
 					"version": "1.5.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
 					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				},
 				"bn.js": {
 					"version": "5.2.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
 					"integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
 				},
 				"brorand": {
 					"version": "1.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
 					"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
 				},
 				"browserify-aes": {
 					"version": "1.2.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
 					"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
 					"requires": {
 						"buffer-xor": "^1.0.3",
@@ -11295,7 +11295,7 @@
 				},
 				"browserify-cipher": {
 					"version": "1.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
 					"integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
 					"requires": {
 						"browserify-aes": "^1.0.4",
@@ -11305,7 +11305,7 @@
 				},
 				"browserify-des": {
 					"version": "1.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
 					"integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
 					"requires": {
 						"cipher-base": "^1.0.1",
@@ -11316,7 +11316,7 @@
 				},
 				"browserify-rsa": {
 					"version": "4.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
 					"integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
 					"requires": {
 						"bn.js": "^5.0.0",
@@ -11325,7 +11325,7 @@
 				},
 				"browserify-sign": {
 					"version": "4.2.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
 					"integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
 					"requires": {
 						"bn.js": "^5.1.1",
@@ -11341,7 +11341,7 @@
 				},
 				"browserify-zlib": {
 					"version": "0.2.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
 					"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
 					"requires": {
 						"pako": "~1.0.5"
@@ -11358,12 +11358,12 @@
 				},
 				"buffer-xor": {
 					"version": "1.0.3",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
 					"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
 				},
 				"builtin-status-codes": {
 					"version": "3.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
 					"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
 				},
 				"call-bind": {
@@ -11377,7 +11377,7 @@
 				},
 				"cipher-base": {
 					"version": "1.0.4",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
 					"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
 					"requires": {
 						"inherits": "^2.0.1",
@@ -11386,17 +11386,17 @@
 				},
 				"console-browserify": {
 					"version": "1.2.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
 					"integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="
 				},
 				"constants-browserify": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
 					"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
 				},
 				"create-ecdh": {
 					"version": "4.0.4",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
 					"integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
 					"requires": {
 						"bn.js": "^4.1.0",
@@ -11405,14 +11405,14 @@
 					"dependencies": {
 						"bn.js": {
 							"version": "4.12.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
 							"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
 						}
 					}
 				},
 				"create-hash": {
 					"version": "1.2.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
 					"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
 					"requires": {
 						"cipher-base": "^1.0.1",
@@ -11424,7 +11424,7 @@
 				},
 				"create-hmac": {
 					"version": "1.1.7",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
 					"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
 					"requires": {
 						"cipher-base": "^1.0.3",
@@ -11437,7 +11437,7 @@
 				},
 				"crypto-browserify": {
 					"version": "3.12.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
 					"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
 					"requires": {
 						"browserify-cipher": "^1.0.0",
@@ -11463,7 +11463,7 @@
 				},
 				"des.js": {
 					"version": "1.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
 					"integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
 					"requires": {
 						"inherits": "^2.0.1",
@@ -11472,7 +11472,7 @@
 				},
 				"diffie-hellman": {
 					"version": "5.0.3",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
 					"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
 					"requires": {
 						"bn.js": "^4.1.0",
@@ -11482,14 +11482,14 @@
 					"dependencies": {
 						"bn.js": {
 							"version": "4.12.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
 							"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
 						}
 					}
 				},
 				"elliptic": {
 					"version": "6.5.4",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
 					"integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
 					"requires": {
 						"bn.js": "^4.11.9",
@@ -11503,7 +11503,7 @@
 					"dependencies": {
 						"bn.js": {
 							"version": "4.12.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
 							"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
 						}
 					}
@@ -11525,12 +11525,12 @@
 				},
 				"events": {
 					"version": "3.3.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
 					"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
 				},
 				"evp_bytestokey": {
 					"version": "1.0.3",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
 					"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
 					"requires": {
 						"md5.js": "^1.3.4",
@@ -11577,7 +11577,7 @@
 				},
 				"hash-base": {
 					"version": "3.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
 					"integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
 					"requires": {
 						"inherits": "^2.0.4",
@@ -11587,7 +11587,7 @@
 				},
 				"hash.js": {
 					"version": "1.1.7",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
 					"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
 					"requires": {
 						"inherits": "^2.0.3",
@@ -11596,7 +11596,7 @@
 				},
 				"hmac-drbg": {
 					"version": "1.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
 					"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
 					"requires": {
 						"hash.js": "^1.0.3",
@@ -11606,12 +11606,12 @@
 				},
 				"https-browserify": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
 					"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
 				},
 				"ieee754": {
 					"version": "1.2.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
 					"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
 				},
 				"inherits": {
@@ -11652,7 +11652,7 @@
 				},
 				"md5.js": {
 					"version": "1.3.5",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
 					"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
 					"requires": {
 						"hash-base": "^3.0.0",
@@ -11662,7 +11662,7 @@
 				},
 				"miller-rabin": {
 					"version": "4.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
 					"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
 					"requires": {
 						"bn.js": "^4.0.0",
@@ -11671,19 +11671,19 @@
 					"dependencies": {
 						"bn.js": {
 							"version": "4.12.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
 							"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
 						}
 					}
 				},
 				"minimalistic-assert": {
 					"version": "1.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
 					"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
 				},
 				"minimalistic-crypto-utils": {
 					"version": "1.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
 					"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
 				},
 				"object-inspect": {
@@ -11718,17 +11718,17 @@
 				},
 				"os-browserify": {
 					"version": "0.3.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
 					"integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
 				},
 				"pako": {
 					"version": "1.0.11",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
 					"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
 				},
 				"parse-asn1": {
 					"version": "5.1.6",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
 					"integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
 					"requires": {
 						"asn1.js": "^5.2.0",
@@ -11740,7 +11740,7 @@
 				},
 				"path-browserify": {
 					"version": "1.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
 					"integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
 				},
 				"pbkdf2": {
@@ -11757,12 +11757,12 @@
 				},
 				"process": {
 					"version": "0.11.10",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
 					"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
 				},
 				"public-encrypt": {
 					"version": "4.0.3",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
 					"integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
 					"requires": {
 						"bn.js": "^4.1.0",
@@ -11775,29 +11775,29 @@
 					"dependencies": {
 						"bn.js": {
 							"version": "4.12.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
 							"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
 						}
 					}
 				},
 				"punycode": {
 					"version": "2.1.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
 				},
 				"querystring": {
 					"version": "0.2.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
 					"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
 				},
 				"querystring-es3": {
 					"version": "0.2.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
 					"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
 				},
 				"randombytes": {
 					"version": "2.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
 					"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
 					"requires": {
 						"safe-buffer": "^5.1.0"
@@ -11805,7 +11805,7 @@
 				},
 				"randomfill": {
 					"version": "1.0.4",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
 					"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
 					"requires": {
 						"randombytes": "^2.0.5",
@@ -11814,7 +11814,7 @@
 				},
 				"readable-stream": {
 					"version": "3.6.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
 					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 					"requires": {
 						"inherits": "^2.0.3",
@@ -11824,7 +11824,7 @@
 				},
 				"ripemd160": {
 					"version": "2.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
 					"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
 					"requires": {
 						"hash-base": "^3.0.0",
@@ -11833,22 +11833,22 @@
 				},
 				"safe-buffer": {
 					"version": "5.2.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
 					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 				},
 				"setimmediate": {
 					"version": "1.0.5",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
 					"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 				},
 				"sha.js": {
 					"version": "2.4.11",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
 					"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
 					"requires": {
 						"inherits": "^2.0.1",
@@ -11895,7 +11895,7 @@
 				},
 				"string_decoder": {
 					"version": "1.3.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
 					"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
 					"requires": {
 						"safe-buffer": "~5.2.0"
@@ -11903,7 +11903,7 @@
 				},
 				"timers-browserify": {
 					"version": "2.0.12",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
 					"integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
 					"requires": {
 						"setimmediate": "^1.0.4"
@@ -11911,7 +11911,7 @@
 				},
 				"tty-browserify": {
 					"version": "0.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
 					"integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw=="
 				},
 				"unbox-primitive": {
@@ -11927,7 +11927,7 @@
 				},
 				"url": {
 					"version": "0.11.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
 					"integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
 					"requires": {
 						"punycode": "1.3.2",
@@ -11936,7 +11936,7 @@
 					"dependencies": {
 						"punycode": {
 							"version": "1.3.2",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
 							"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
 						}
 					}
@@ -11956,12 +11956,12 @@
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 				},
 				"vm-browserify": {
 					"version": "1.1.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
 					"integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
 				},
 				"which-boxed-primitive": {
@@ -11978,7 +11978,7 @@
 				},
 				"xtend": {
 					"version": "4.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
 					"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
 				}
 			}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

When a Virtual Piece (generally, an infinite-capping "clear" Piece) is placed in the current Part, if it is on a different PieceLifeSpan than the one it's supposed to stop, the Virtual Piece will not be included in the result from `processAndPrunePieceInstanceTimings`, unless `includeVirtual` is enabled. Because of that, it will never actually stop the infinite Piece at the resolution stage and effectively result in the infinite Piece continuing.

* **What is the new behavior (if this is a feature change)?**

Before adding a Piece to the result set of `processAndPrunePieceInstanceTimings`, the Piece is evaluated against the `activePieces` object, so that it's verified that there are no activePieces on a higher layer that are more important (using an algorithm borrowed from `isCandidateBetterToBeContinued`).

Also adds a small facility to the Test Tools Timeline view that allows filtering layers either using a simple subset check or a Regular Expression - the contents of the field are treated as a regular expression if contained in `chars` (`/<RegExp>/`).

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
