### PR TITLE
fix: show adLibs from different show-styles as disabled

### DIFF
--- a/meteor/client/styles/contextMenu.scss
+++ b/meteor/client/styles/contextMenu.scss
@@ -25,6 +25,10 @@ nav.react-contextmenu {
 		background: none;
 		width: 100%;
 		text-align: left;
+		text-overflow: ellipsis;
+		overflow: hidden;
+		white-space: nowrap;
+		max-width: 350px;
 	}
 
 	.react-contextmenu-label {

--- a/meteor/client/styles/shelf/adLibPanel.scss
+++ b/meteor/client/styles/shelf/adLibPanel.scss
@@ -354,6 +354,20 @@ $adlib-item-selected-color: var(--adlib-item-selected-color);
 						}
 					}
 
+					&.disabled {
+						// opacity: 0.5;
+
+						.adlib-panel__list-view__list__table__cell--icon {
+							background: $ui-dark-color;
+						}
+					}
+
+					&.disabled.selected {
+						&::after {
+							border: 1px solid $ui-dark-color-brighter;
+						}
+					}
+
 					@include invalid-overlay();
 					@include floated-overlay();
 				}

--- a/meteor/client/ui/Shelf/AdLibListItem.tsx
+++ b/meteor/client/ui/Shelf/AdLibListItem.tsx
@@ -31,6 +31,7 @@ interface IListViewItemProps {
 	studio: Studio
 	layer: ISourceLayer | undefined
 	selected: boolean
+	disabled?: boolean
 	onSelectAdLib: (aSLine: IAdLibListItem) => void
 	onToggleAdLib: (aSLine: IAdLibListItem, queue: boolean, context: any, mode?: IBlueprintActionTriggerMode) => void
 	playlist: RundownPlaylist
@@ -53,12 +54,13 @@ export const AdLibListItem = withMediaObjectStatus<IListViewItemProps, {}>()(
 							selected: this.props.selected,
 							invalid: this.props.piece.invalid,
 							floated: this.props.piece.floated,
+							disabled: this.props.disabled,
 						}),
 						//@ts-ignore React.HTMLAttributes does not list data attributes, but that's fine
 						'data-obj-id': this.props.piece._id,
 						onClick: () => this.props.onSelectAdLib(this.props.piece),
 						onContextMenu: () => this.props.onSelectAdLib(this.props.piece),
-						onDoubleClick: (e) => this.props.onToggleAdLib(this.props.piece, e.shiftKey, e),
+						onDoubleClick: (e) => !this.props.disabled && this.props.onToggleAdLib(this.props.piece, e.shiftKey, e),
 					}}
 					collect={() =>
 						setShelfContextMenuContext({

--- a/meteor/client/ui/Shelf/AdLibListItem.tsx
+++ b/meteor/client/ui/Shelf/AdLibListItem.tsx
@@ -67,7 +67,8 @@ export const AdLibListItem = withMediaObjectStatus<IListViewItemProps, {}>()(
 							type: MenuContextType.ADLIB,
 							details: {
 								adLib: this.props.piece,
-								onToggle: this.props.onToggleAdLib,
+								onToggle: !this.props.disabled ? this.props.onToggleAdLib : undefined,
+								disabled: this.props.disabled,
 							},
 						})
 					}

--- a/meteor/client/ui/Shelf/AdLibPanel.tsx
+++ b/meteor/client/ui/Shelf/AdLibPanel.tsx
@@ -487,7 +487,14 @@ type SourceLayerLookup = Record<string, ISourceLayer>
 
 type MinimalRundown = Pick<
 	Rundown,
-	'_id' | 'name' | '_rank' | 'playlistId' | 'timing' | 'showStyleBaseId' | 'endOfRundownIsShowBreak'
+	| '_id'
+	| 'name'
+	| '_rank'
+	| 'playlistId'
+	| 'timing'
+	| 'showStyleBaseId'
+	| 'showStyleVariantId'
+	| 'endOfRundownIsShowBreak'
 >
 
 export interface AdLibFetchAndFilterProps {
@@ -611,8 +618,8 @@ export function fetchAndFilter(props: Translated<IAdLibPanelProps>): AdLibFetchA
 					isLive: false,
 					isNext: false,
 					isCompatibleShowStyle: currentPartInstance?.rundownId
-						? rundowns[unprotectString(currentPartInstance.rundownId)].showStyleBaseId ===
-						  rundowns[unprotectString(segment.rundownId)].showStyleBaseId
+						? rundowns[unprotectString(currentPartInstance.rundownId)].showStyleVariantId ===
+						  rundowns[unprotectString(segment.rundownId)].showStyleVariantId
 						: true,
 				})
 
@@ -695,6 +702,7 @@ export function fetchAndFilter(props: Translated<IAdLibPanelProps>): AdLibFetchA
 			if (segment) {
 				segment.pieces.push({
 					...piece,
+					disabled: !segment.isCompatibleShowStyle,
 					sourceLayer: sourceLayerLookup[piece.sourceLayerId],
 					outputLayer: outputLayerLookup[piece.outputLayerId],
 				})
@@ -733,6 +741,7 @@ export function fetchAndFilter(props: Translated<IAdLibPanelProps>): AdLibFetchA
 	adlibActions.forEach((action) => {
 		const segment = uiPartSegmentMap.get(action.partId)
 		if (segment) {
+			action.piece.disabled = !segment.isCompatibleShowStyle
 			segment.pieces.push(action.piece)
 		}
 	})
@@ -741,10 +750,7 @@ export function fetchAndFilter(props: Translated<IAdLibPanelProps>): AdLibFetchA
 		// Sort the pieces:
 		segment.pieces = sortAdlibs(
 			segment.pieces.map((piece) => ({
-				adlib: {
-					...piece,
-					disabled: !segment.isCompatibleShowStyle,
-				},
+				adlib: piece,
 				label: piece.adlibAction?.display?.label ?? piece.name,
 				adlibRank: piece._rank,
 				adlibId: piece._id,

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -503,7 +503,8 @@ export class DashboardPanelInner extends MeteorReactComponent<
 												type: ContextType.ADLIB,
 												details: {
 													adLib: adLibPiece,
-													onToggle: this.onToggleAdLib,
+													onToggle: !adLibPiece.disabled ? this.onToggleAdLib : undefined,
+													disabled: adLibPiece.disabled,
 												},
 											})
 										}

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -532,6 +532,7 @@ export class DashboardPanelInner extends MeteorReactComponent<
 											showThumbnailsInList={filter.showThumbnailsInList}
 											toggleOnSingleClick={filter.toggleOnSingleClick || this.state.singleClickMode}
 											isSelected={this.state.selectedAdLib && adLibPiece._id === this.state.selectedAdLib._id}
+											disabled={adLibPiece.disabled}
 										>
 											{adLibPiece.name}
 										</DashboardPieceButton>

--- a/meteor/client/ui/Shelf/ShelfContextMenu.tsx
+++ b/meteor/client/ui/Shelf/ShelfContextMenu.tsx
@@ -37,7 +37,8 @@ export interface ShelfContextMenuContextBucketAdLib extends ShelfContextMenuCont
 		bucket: Bucket
 		adLib: BucketAdLibItem
 		canQueue?: boolean
-		onToggle: (aSLine: BucketAdLibItem, queue: boolean, context: any, mode?: IBlueprintActionTriggerMode) => void
+		disabled?: boolean
+		onToggle?: (aSLine: BucketAdLibItem, queue: boolean, context: any, mode?: IBlueprintActionTriggerMode) => void
 	}
 }
 
@@ -46,7 +47,8 @@ export interface ShelfContextMenuContextAdLib extends ShelfContextMenuContextBas
 	details: {
 		adLib: IAdLibListItem
 		canQueue?: boolean
-		onToggle: (aSLine: IAdLibListItem, queue: boolean, context: any, mode?: IBlueprintActionTriggerMode) => void
+		disabled?: boolean
+		onToggle?: (aSLine: IAdLibListItem, queue: boolean, context: any, mode?: IBlueprintActionTriggerMode) => void
 	}
 }
 
@@ -78,7 +80,8 @@ export default function ShelfContextMenu() {
 
 	const renderStartExecuteAdLib = function renderStartExecuteAdLib<T extends IAdLibListItem | BucketAdLibItem>(item: {
 		adLib: T
-		onToggle: (adLib: T, queue: boolean, e: any, mode?: IBlueprintActionTriggerMode) => void
+		onToggle?: (adLib: T, queue: boolean, e: any, mode?: IBlueprintActionTriggerMode) => void
+		disabled?: boolean
 	}) {
 		if (isActionItem(item.adLib)) {
 			const adLibAction = getActionItem(item.adLib)
@@ -93,8 +96,9 @@ export default function ShelfContextMenu() {
 						key={mode.data}
 						onClick={(e) => {
 							e.persist()
-							item.onToggle(item.adLib, false, e, mode)
+							item.onToggle && item.onToggle(item.adLib, false, e, mode)
 						}}
+						disabled={item.disabled}
 					>
 						{translateMessage(mode.display.label, t)}
 					</MenuItem>
@@ -104,8 +108,9 @@ export default function ShelfContextMenu() {
 					<MenuItem
 						onClick={(e) => {
 							e.persist()
-							item.onToggle(item.adLib, false, e)
+							item.onToggle && item.onToggle(item.adLib, false, e)
 						}}
+						disabled={item.disabled}
 					>
 						{(adLibAction?.display.triggerLabel && translateMessage(adLibAction?.display.triggerLabel, t)) ??
 							t('Execute')}
@@ -118,8 +123,9 @@ export default function ShelfContextMenu() {
 					<MenuItem
 						onClick={(e) => {
 							e.persist()
-							item.onToggle(item.adLib, false, e)
+							item.onToggle && item.onToggle(item.adLib, false, e)
 						}}
+						disabled={item.disabled}
 					>
 						{t('Start this AdLib')}
 					</MenuItem>
@@ -127,8 +133,9 @@ export default function ShelfContextMenu() {
 						<MenuItem
 							onClick={(e) => {
 								e.persist()
-								item.onToggle(item.adLib, true, e)
+								item.onToggle && item.onToggle(item.adLib, true, e)
 							}}
+							disabled={item.disabled}
 						>
 							{t('Queue this AdLib')}
 						</MenuItem>

--- a/meteor/lib/collections/RundownPlaylists.ts
+++ b/meteor/lib/collections/RundownPlaylists.ts
@@ -97,7 +97,14 @@ export class RundownPlaylistCollectionUtil {
 	): Array<{
 		rundown: Pick<
 			Rundown,
-			'_id' | 'name' | '_rank' | 'playlistId' | 'timing' | 'showStyleBaseId' | 'endOfRundownIsShowBreak'
+			| '_id'
+			| 'name'
+			| '_rank'
+			| 'playlistId'
+			| 'timing'
+			| 'showStyleBaseId'
+			| 'showStyleVariantId'
+			| 'endOfRundownIsShowBreak'
 		>
 		segments: Segment[]
 	}> {
@@ -108,6 +115,7 @@ export class RundownPlaylistCollectionUtil {
 				playlistId: 1,
 				timing: 1,
 				showStyleBaseId: 1,
+				showStyleVariantId: 1,
 				endOfRundownIsShowBreak: 1,
 			},
 		})


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

AdLibs of different showStyle-bases are presented as compatible, even though it's not technically possible to mix AdLibs from one ShowStyle in another.

* **What is the new behavior (if this is a feature change)?**

These AdLibs are now shown as disabled (grayed out) and will not be triggered when double-clicking.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
