### PR TITLE
Fix: log errors

### DIFF
--- a/meteor/__mocks__/meteor.ts
+++ b/meteor/__mocks__/meteor.ts
@@ -363,8 +363,7 @@ export async function runInFiber<T>(fcn: () => T | Promise<T>): Promise<T> {
 				}
 			} catch (e: any) {
 				// Note: we cannot use
-				console.log('Error: ' + stringifyError(e))
-				if ((e instanceof Error || e instanceof MeteorMock.Error) && e.stack) console.log(e.stack)
+				console.log(`Error: ${stringifyError(e)}`)
 				reject(e)
 			}
 		}).run()

--- a/meteor/client/lib/clientAPI.ts
+++ b/meteor/client/lib/clientAPI.ts
@@ -2,6 +2,7 @@ import * as _ from 'underscore'
 import { logger } from '../../lib/logging'
 import { PeripheralDevice, PeripheralDeviceId } from '../../lib/collections/PeripheralDevices'
 import { MeteorCall } from '../../lib/api/methods'
+import { stringifyError } from '../../lib/lib'
 
 export async function callPeripheralDeviceFunction(
 	e: any,
@@ -52,8 +53,7 @@ export function eventContextForLog(e: any): string {
 		str = e.type
 	}
 	if (!str) {
-		logger.error('Unknown event', e)
-		console.error(e)
+		logger.error(`Unknown event: ${stringifyError(e)}`)
 		str = 'N/A'
 	}
 

--- a/meteor/client/lib/triggers/TriggersHandler.tsx
+++ b/meteor/client/lib/triggers/TriggersHandler.tsx
@@ -22,7 +22,7 @@ import {
 } from '../../../lib/api/triggers/actionFactory'
 import { Tracker } from 'meteor/tracker'
 import { PartId } from '../../../lib/collections/Parts'
-import { flatten, ProtectedString, protectString } from '../../../lib/lib'
+import { flatten, ProtectedString, protectString, stringifyError } from '../../../lib/lib'
 import { IWrappedAdLib } from '../../../lib/api/triggers/actionFilterChainCompilers'
 import { Mongo } from 'meteor/mongo'
 import { AdLibActionId } from '../../../lib/collections/AdLibActions'
@@ -440,7 +440,7 @@ export const TriggersHandler: React.FC<IProps> = function TriggersHandler(
 					try {
 						previewAdLibs = action.preview()
 					} catch (e) {
-						console.error('Exception thrown while previewing action', e)
+						console.error(`Exception thrown while previewing action: ${stringifyError(e)}`)
 					}
 
 					previewAdLibs.forEach((adLib) => {

--- a/meteor/client/lib/uncaughtErrorHandler.ts
+++ b/meteor/client/lib/uncaughtErrorHandler.ts
@@ -40,10 +40,18 @@ function uncaughtErrorHandler(errorObj: any) {
 	if (!errorObj) return // Nothing to report..
 
 	// To get the textual content of Error('my Error')
-	let stringContent: string = `${errorObj}`
+	let stringContent: string
 	if (Array.isArray(errorObj)) {
 		stringContent = errorObj.map((err) => stringifyError(err)).join(',')
+	} else {
+		stringContent = stringifyError(errorObj)
 	}
+
+	const caughtErrorStack = new Error('')
+	if (caughtErrorStack.stack) {
+		stringContent += `\nCaught stack: ${caughtErrorStack.stack}`
+	}
+
 	const errorLog: LoggedError = {
 		location: window.location.href,
 		content: errorObj,

--- a/meteor/client/lib/uncaughtErrorHandler.ts
+++ b/meteor/client/lib/uncaughtErrorHandler.ts
@@ -1,7 +1,7 @@
 import { Meteor } from 'meteor/meteor'
 import { Tracker } from 'meteor/tracker'
 import { Time } from '@sofie-automation/blueprints-integration'
-import { getCurrentTime } from '../../lib/lib'
+import { getCurrentTime, stringifyError } from '../../lib/lib'
 import { MeteorCall } from '../../lib/api/methods'
 
 interface LoggedError {
@@ -42,7 +42,7 @@ function uncaughtErrorHandler(errorObj: any) {
 	// To get the textual content of Error('my Error')
 	let stringContent: string = `${errorObj}`
 	if (Array.isArray(errorObj)) {
-		stringContent = errorObj.map((err) => `${err?.stack ? err.stack : err}`).join(',')
+		stringContent = errorObj.map((err) => stringifyError(err)).join(',')
 	}
 	const errorLog: LoggedError = {
 		location: window.location.href,

--- a/meteor/client/ui/Account/NotLoggedIn/SignupPage.tsx
+++ b/meteor/client/ui/Account/NotLoggedIn/SignupPage.tsx
@@ -99,7 +99,7 @@ export const SignupPage = translateWithTracker((props: ISignupPageProps) => {
 					broadcastMediums: this.state.broadcastMediums,
 				},
 			}).catch((error) => {
-				console.error('Error creating new User', error)
+				console.error(`Error creating new User: ${stringifyError(error)}`)
 				this.handleError(`Error creating new user: ${error.reason || error.toString()}`)
 			})
 		}

--- a/meteor/client/ui/Prompter/controller/midi-pedal-device.ts
+++ b/meteor/client/ui/Prompter/controller/midi-pedal-device.ts
@@ -3,6 +3,7 @@ import { PrompterViewInner, PrompterConfigMode } from '../PrompterView'
 import Spline from 'cubic-spline'
 
 import webmidi, { Input, InputEventControlchange } from 'webmidi'
+import { stringifyError } from '../../../../lib/lib'
 
 /**
  * This class handles control of the prompter using
@@ -93,7 +94,7 @@ export class MidiPedalController extends ControllerAbstract {
 
 	private setupMidiListeners(err: Error | undefined) {
 		if (err) {
-			console.error('Error enabling WebMIDI', err)
+			console.error(`Error enabling WebMIDI: ${stringifyError(err)}`)
 			return
 		}
 

--- a/meteor/client/ui/SegmentTimeline/Renderers/MicSourceRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/MicSourceRenderer.tsx
@@ -8,7 +8,7 @@ import * as _ from 'underscore'
 import { getElementWidth } from '../../../utils/dimensions'
 import { MicFloatingInspector } from '../../FloatingInspectors/MicFloatingInspector'
 import { calculatePartInstanceExpectedDurationWithPreroll } from '@sofie-automation/corelib/dist/playout/timings'
-import { unprotectString } from '../../../../lib/lib'
+import { stringifyError, unprotectString } from '../../../../lib/lib'
 
 type IProps = ICustomLayerItemProps
 interface IState {}
@@ -149,7 +149,7 @@ export const MicSourceRenderer = withTranslation()(
 					try {
 						this.lineItem.remove()
 					} catch (err) {
-						console.error('Error in MicSourceRenderer.componentDidUpdate', err)
+						console.error(`Error in MicSourceRenderer.componentDidUpdate: ${stringifyError(err)}`)
 					}
 				}
 				this.itemElement = this.props.itemElement
@@ -178,7 +178,7 @@ export const MicSourceRenderer = withTranslation()(
 				// Remove the line element
 				this.lineItem?.remove()
 			} catch (err) {
-				console.error('Error in MicSourceRenderer.componentWillUnmount', err)
+				console.error(`Error in MicSourceRenderer.componentWillUnmount: ${stringifyError(err)}`)
 			}
 		}
 

--- a/meteor/client/ui/SegmentTimeline/Renderers/VTSourceRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/VTSourceRenderer.tsx
@@ -18,7 +18,7 @@ import { PieceStatusIcon } from '../../../lib/ui/PieceStatusIcon'
 import { NoticeLevel, getNoticeLevelForPieceStatus } from '../../../lib/notifications/notifications'
 import { VTFloatingInspector } from '../../FloatingInspectors/VTFloatingInspector'
 import { ScanInfoForPackages } from '../../../../lib/mediaObjects'
-import { clone } from '../../../../lib/lib'
+import { clone, stringifyError } from '../../../../lib/lib'
 import { RundownUtils } from '../../../lib/rundown'
 import { FreezeFrameIcon } from '../../../lib/ui/icons/freezeFrame'
 import StudioContext from '../../RundownView/StudioContext'
@@ -112,7 +112,7 @@ export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithT
 					try {
 						this.rightLabelContainer?.remove()
 					} catch (err) {
-						console.error('Error in VTSourceRendererBase.mountRightLabelContainer 1', err)
+						console.error(`Error in VTSourceRendererBase.mountRightLabelContainer 1: ${stringifyError(err)}`)
 					}
 					itemElement.appendChild(this.rightLabelContainer)
 					newState.rightLabelIsAppendage = false
@@ -126,7 +126,7 @@ export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithT
 					try {
 						this.rightLabelContainer?.remove()
 					} catch (err) {
-						console.error('Error in VTSourceRendererBase.mountRightLabelContainer 2', err)
+						console.error(`Error in VTSourceRendererBase.mountRightLabelContainer 2: ${stringifyError(err)}`)
 					}
 					itemElement.appendChild(this.rightLabelContainer)
 					newState.rightLabelIsAppendage = false
@@ -167,7 +167,7 @@ export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithT
 			try {
 				this.countdownContainer.remove()
 			} catch (err) {
-				console.error('Error in VTSourceRendererBase.mountSourceEndedCountdownContainer 1', err)
+				console.error(`Error in VTSourceRendererBase.mountSourceEndedCountdownContainer 1: ${stringifyError(err)}`)
 			}
 			newState.sourceEndCountdownAppendage = false
 		}
@@ -286,7 +286,7 @@ export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithT
 			try {
 				this.rightLabelContainer.remove()
 			} catch (err) {
-				console.error('Error in VTSourceRendererBase.componentWillUnmount 1', err)
+				console.error(`Error in VTSourceRendererBase.componentWillUnmount 1: ${stringifyError(err)}`)
 			}
 			this.rightLabelContainer = null
 		}
@@ -295,7 +295,7 @@ export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithT
 			try {
 				this.countdownContainer.remove()
 			} catch (err) {
-				console.error('Error in VTSourceRendererBase.componentWillUnmount 2', err)
+				console.error(`Error in VTSourceRendererBase.componentWillUnmount 2: ${stringifyError(err)}`)
 			}
 			this.countdownContainer = null
 		}

--- a/meteor/client/ui/Settings/BlueprintSettings.tsx
+++ b/meteor/client/ui/Settings/BlueprintSettings.tsx
@@ -151,7 +151,7 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 															)
 														})
 														.catch((err: string) => {
-															// console.error('Blueprint restore failure: ', err)
+															// console.error(`Blueprint restore failure: ${stringifyError(err)}`)
 															NotificationCenter.push(
 																new Notification(
 																	undefined,
@@ -170,7 +170,7 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 											},
 										})
 									} else {
-										// console.error('Blueprint restore failure: ', err)
+										// console.error(`Blueprint restore failure: ${stringifyError(err)}`)
 										NotificationCenter.push(
 											new Notification(
 												undefined,

--- a/meteor/client/ui/Settings/SnapshotsView.tsx
+++ b/meteor/client/ui/Settings/SnapshotsView.tsx
@@ -102,7 +102,7 @@ export default translateWithTracker<IProps, IState, ITrackedProps>(() => {
 								)
 							})
 							.catch((err) => {
-								// console.error('Snapshot restore failure: ', err)
+								// console.error(`Snapshot restore failure: ${err}`)
 								NotificationCenter.push(
 									new Notification(
 										undefined,

--- a/meteor/client/ui/Settings/StudioSettings.tsx
+++ b/meteor/client/ui/Settings/StudioSettings.tsx
@@ -46,7 +46,7 @@ import { ConfigManifestSettings } from './ConfigManifestSettings'
 import { Blueprints, BlueprintId } from '../../../lib/collections/Blueprints'
 import { getHelpMode } from '../../lib/localStorage'
 import { SettingsNavigation } from '../../lib/SettingsNavigation'
-import { unprotectString, protectString } from '../../../lib/lib'
+import { unprotectString, protectString, stringifyError } from '../../../lib/lib'
 import { MeteorCall } from '../../../lib/api/methods'
 import { TransformedCollection } from '../../../lib/typings/meteor'
 import { doUserAction, UserAction } from '../../lib/userAction'
@@ -2155,7 +2155,7 @@ class StudioBaselineStatus extends MeteorReactComponent<
 				if (this.updateInterval) this.setState({ needsUpdate: !!result })
 			})
 			.catch((err) => {
-				console.error('Failed to update studio baseline status', err)
+				console.error(`Failed to update studio baseline status: ${stringifyError(err)}`)
 				if (this.updateInterval) this.setState({ needsUpdate: false })
 			})
 	}
@@ -2167,7 +2167,7 @@ class StudioBaselineStatus extends MeteorReactComponent<
 				if (this.updateInterval) this.setState({ needsUpdate: !!result })
 			})
 			.catch((err) => {
-				console.error('Failed to update studio baseline', err)
+				console.error(`Failed to update studio baseline: ${stringifyError(err)}`)
 				if (this.updateInterval) this.setState({ needsUpdate: false })
 			})
 	}

--- a/meteor/client/ui/Settings/components/ConfigManifestOAuthFlow.tsx
+++ b/meteor/client/ui/Settings/components/ConfigManifestOAuthFlow.tsx
@@ -87,7 +87,7 @@ export const ConfigManifestOAuthFlowComponent = withTranslation()(
 				// 			}).then(res => {
 				// 				console.log('Blueprint restore success')
 				// 			}).catch(err => {
-				// 				console.error('Blueprint restore failure: ', err)
+				// 				console.error(`Blueprint restore failure: ${stringifyError(err)}`)
 				// 			})
 				// 		}
 				// 	},

--- a/meteor/client/ui/i18n.ts
+++ b/meteor/client/ui/i18n.ts
@@ -15,6 +15,7 @@ import { I18NextData } from '@sofie-automation/blueprints-integration'
 import { MeteorCall } from '../../lib/api/methods'
 import { ClientAPI } from '../../lib/api/client'
 import { interpollateTranslation } from '@sofie-automation/corelib/dist/TranslatableMessage'
+import { stringifyError } from '../../lib/lib'
 
 const i18nOptions = {
 	fallbackLng: {
@@ -89,7 +90,7 @@ class I18nContainer extends WithManagedTracker {
 				document.documentElement.lang = i18n.language
 			})
 			.catch((err: Error) => {
-				console.error('Error initializing i18Next:', err)
+				console.error(`Error initializing i18Next: ${stringifyError(err)}`)
 			})
 
 		this.subscribe(PubSub.translationsBundles, {})
@@ -128,11 +129,13 @@ class I18nContainer extends WithManagedTracker {
 							)
 						})
 						.catch((reason) => {
-							console.error(`Failed to fetch translations bundle "${bundleMetadata._id}": `, reason)
+							console.error(
+								`Failed to fetch translations bundle "${bundleMetadata._id}": ${stringifyError(reason)}`
+							)
 						})
 				)
 			).catch((reason) => {
-				console.error(`One of the translation bundles failed to load: `, reason)
+				console.error(`One of the translation bundles failed to load: ${stringifyError(reason)}`)
 			})
 		})
 	}

--- a/meteor/lib/logging.ts
+++ b/meteor/lib/logging.ts
@@ -1,5 +1,6 @@
 import { Meteor } from 'meteor/meteor'
 import * as _ from 'underscore'
+import { stringifyError } from './lib'
 
 export interface LoggerInstanceFixed {
 	error: LeveledLogMethodFixed
@@ -30,20 +31,7 @@ let logger: LoggerInstanceFixed
 if (Meteor.isServer) {
 	const getLogMethod = (type) => {
 		return (...args) => {
-			args = _.map(args, (arg) => {
-				if (_.isObject(arg)) {
-					if (arg.toString) {
-						return arg.toString() + ' ' + arg.stack
-					}
-					try {
-						return JSON.stringify(arg)
-					} catch (e) {
-						return `[object: cant stringify: ${e}]`
-					}
-				} else {
-					return '' + arg
-				}
-			})
+			args = _.map(args, (arg) => stringifyError(arg))
 			return Meteor.call('logger', type, ...args)
 		}
 	}

--- a/meteor/server/api/blueprints/cache.ts
+++ b/meteor/server/api/blueprints/cache.ts
@@ -4,7 +4,6 @@ import { logger } from '../../logging'
 import { Blueprint } from '../../../lib/collections/Blueprints'
 import { SomeBlueprintManifest } from '@sofie-automation/blueprints-integration'
 import { stringifyError } from '@sofie-automation/corelib/dist/lib'
-import { Meteor } from 'meteor/meteor'
 
 export function evalBlueprint(blueprint: Blueprint): SomeBlueprintManifest {
 	const vm = new VM({
@@ -22,9 +21,7 @@ export function evalBlueprint(blueprint: Blueprint): SomeBlueprintManifest {
 				try {
 					return value(...args)
 				} catch (e) {
-					let msg = `Error in Blueprint "${blueprint._id}".${key}: "${stringifyError(e)}"`
-					if ((e instanceof Error || e instanceof Meteor.Error) && e.stack) msg += '\n' + e.stack
-					logger.error(msg)
+					logger.error(`Error in Blueprint "${blueprint._id}".${key}: "${stringifyError(e)}"`)
 					throw e
 				}
 			}

--- a/meteor/server/api/client.ts
+++ b/meteor/server/api/client.ts
@@ -15,7 +15,6 @@ import { isInTestWrite, triggerWriteAccessBecauseNoCheckNecessary } from '../sec
 import { PeripheralDeviceContentWriteAccess } from '../security/peripheralDevice'
 import { endTrace, sendTrace, startTrace } from './integration/influx'
 import { interpollateTranslation, translateMessage } from '@sofie-automation/corelib/dist/TranslatableMessage'
-import { Meteor } from 'meteor/meteor'
 import { UserError, UserErrorMessage } from '@sofie-automation/corelib/dist/error'
 import { StudioJobFunc } from '@sofie-automation/corelib/dist/worker/studio'
 import { StudioId } from '../../lib/collections/Studios'
@@ -240,9 +239,6 @@ export namespace ServerClientAPI {
 					const errorTime = Date.now()
 
 					logger.error(`Error in ${methodName}: ${stringifyError(e)}`)
-					if ((e instanceof Error || e instanceof Meteor.Error) && e.stack) {
-						logger.error(e.stack)
-					}
 
 					const wrappedError = rewrapError(methodName, e)
 					const wrappedErrorStr = `ClientResponseError: ${translateMessage(

--- a/meteor/server/api/integration/rabbitMQ.ts
+++ b/meteor/server/api/integration/rabbitMQ.ts
@@ -88,7 +88,7 @@ class ConnectionManager extends Manager<AMQP.Connection> {
 			})
 
 			connection.on('error', (err) => {
-				logger.error('AMQP connection error', err)
+				logger.error(`AMQP connection error: ${stringifyError(err)}`)
 				this.errorCount++
 			})
 			connection.on('close', () => {
@@ -97,7 +97,7 @@ class ConnectionManager extends Manager<AMQP.Connection> {
 			})
 			connection.on('blocked', (reason) => {
 				this.blocked = true
-				logger.error('AMQP connection blocked', reason)
+				logger.error(`AMQP connection blocked: ${stringifyError(reason)}`)
 			})
 			connection.on('unblocked', () => {
 				this.blocked = false
@@ -151,7 +151,7 @@ class ChannelManager extends Manager<AMQP.ConfirmChannel> {
 
 			channel.on('error', (err) => {
 				this.errorCount++
-				logger.error('AMQP channel error', err)
+				logger.error(`AMQP channel error: ${stringifyError(err)}`)
 			})
 			channel.on('close', () => {
 				this.open = false
@@ -159,7 +159,7 @@ class ChannelManager extends Manager<AMQP.ConfirmChannel> {
 			})
 			channel.on('blocked', (reason) => {
 				this.blocked = true
-				logger.error('AMQP channel blocked', reason)
+				logger.error(`AMQP channel blocked: ${stringifyError(reason)}`)
 			})
 			channel.on('unblocked', () => {
 				this.blocked = false
@@ -167,7 +167,7 @@ class ChannelManager extends Manager<AMQP.ConfirmChannel> {
 			})
 			// When a "mandatory" message cannot be delivered, it's returned here:
 			// channel.on('return', message => {
-			// 	logger.error('AMQP channel return', message)
+			// 	logger.error(`AMQP channel return: ${stringifyError(message)}')
 			// })
 			channel.on('drain', () => {
 				logger.error('AMQP channel drain')

--- a/meteor/server/api/serviceMessages/postHandler.ts
+++ b/meteor/server/api/serviceMessages/postHandler.ts
@@ -74,7 +74,7 @@ function postHandler(params, req: BodyParsingIncomingMessage, res: ServerRespons
 		res.setHeader('Content-Type', 'application/json; charset-utf8')
 		res.end(JSON.stringify(serviceMessage))
 	} catch (error) {
-		logger.error(`Unable to store message`, { serviceMessage, error })
+		logger.error(`Unable to store message: ${error}`, { serviceMessage })
 		res.statusCode = 500
 		res.end('System error, unable to store message')
 	}

--- a/meteor/server/api/user.ts
+++ b/meteor/server/api/user.ts
@@ -1,7 +1,7 @@
 import { Meteor } from 'meteor/meteor'
 import * as _ from 'underscore'
 import { Accounts } from 'meteor/accounts-base'
-import { makePromise, unprotectString, waitForPromise, protectString, waitTime } from '../../lib/lib'
+import { makePromise, unprotectString, waitForPromise, protectString, waitTime, stringifyError } from '../../lib/lib'
 import { MethodContextAPI, MethodContext } from '../../lib/api/methods'
 import { NewUserAPI, UserAPIMethods, createUser } from '../../lib/api/user'
 import { registerClassToMeteorMethods } from '../methods'
@@ -25,7 +25,7 @@ export function enrollUser(email: string, name: string): UserId {
 	try {
 		Accounts.sendEnrollmentEmail(unprotectString(id), email)
 	} catch (error) {
-		console.error('ERROR sending email enrollment', error)
+		console.error(`ERROR sending email enrollment: ${stringifyError(error)}`)
 	}
 
 	return id
@@ -66,7 +66,7 @@ function sendVerificationEmail(userId: UserId) {
 			}
 		})
 	} catch (error) {
-		console.error('ERROR sending email verification', error)
+		console.error(`ERROR sending email verification: ${stringifyError(error)}`)
 	}
 }
 

--- a/meteor/server/migration/databaseMigration.ts
+++ b/meteor/server/migration/databaseMigration.ts
@@ -649,9 +649,6 @@ export function runMigration(
 			}
 		} catch (e) {
 			logger.error(`Error in Migration step ${step.id}: ${stringifyError(e)}`)
-			if ((e instanceof Error || e instanceof Meteor.Error) && e.stack) {
-				logger.error(e.stack)
-			}
 			warningMessages.push(`Internal server error in step ${step.id}`)
 		}
 	})

--- a/packages/job-worker/src/blueprints/events.ts
+++ b/packages/job-worker/src/blueprints/events.ts
@@ -10,6 +10,7 @@ import { PartInstanceId, RundownPlaylistId } from '@sofie-automation/corelib/dis
 import { logger } from '../logging'
 import * as debounceFn from 'debounce-fn'
 import { EventsJobs } from '@sofie-automation/corelib/dist/worker/events'
+import { stringifyError } from '@sofie-automation/corelib/dist/lib'
 
 const EVENT_WAIT_TIME = 500
 
@@ -37,9 +38,9 @@ function handlePartInstanceTimingEvent(
 						partInstanceId,
 					})
 					.catch((e) => {
-						let msg = `Failed to queue job in handlePartInstanceTimingEvent "${funcId}": "${e.toString()}"`
-						if (e.stack) msg += '\n' + e.stack
-						logger.error(msg)
+						logger.error(
+							`Failed to queue job in handlePartInstanceTimingEvent "${funcId}": "${stringifyError(e)}"`
+						)
 					})
 			},
 			{

--- a/packages/job-worker/src/cache/CacheBase.ts
+++ b/packages/job-worker/src/cache/CacheBase.ts
@@ -6,7 +6,7 @@ import { isDbCacheWritable } from './lib'
 import { anythingChanged, sumChanges } from '../db/changes'
 import { IS_PRODUCTION } from '../environment'
 import { logger } from '../logging'
-import { sleep } from '@sofie-automation/corelib/dist/lib'
+import { sleep, stringifyError } from '@sofie-automation/corelib/dist/lib'
 import { JobContext } from '../jobs'
 
 type DeferredFunction<Cache> = (cache: Cache) => void | Promise<void>
@@ -136,8 +136,7 @@ export abstract class ReadOnlyCacheBase<T extends ReadOnlyCacheBase<never>> {
 			if (!IS_PRODUCTION) {
 				throw error
 			} else {
-				logger.error(error.toString())
-				if (error.stack) logger.error(error.stack)
+				logger.error(stringifyError(error))
 			}
 		}
 

--- a/packages/job-worker/src/events/handle.ts
+++ b/packages/job-worker/src/events/handle.ts
@@ -306,7 +306,7 @@ async function notifyCurrentPlayingPartMOS(
 					MOS.IMOSObjectStatus.PLAY
 				)
 			} catch (error) {
-				logger.error('Error in setStoryStatus PLAY', error)
+				logger.error(`Error in setStoryStatus PLAY: ${stringifyError(error)}`)
 			}
 		}
 
@@ -320,7 +320,7 @@ async function notifyCurrentPlayingPartMOS(
 					MOS.IMOSObjectStatus.STOP
 				)
 			} catch (error) {
-				logger.error('Error in setStoryStatus STOP', error)
+				logger.error(`Error in setStoryStatus STOP: ${stringifyError(error)}`)
 			}
 		}
 	}

--- a/packages/job-worker/src/playout/timeline.ts
+++ b/packages/job-worker/src/playout/timeline.ts
@@ -441,7 +441,7 @@ function processTimelineObjects(context: JobContext, timelineObjs: Array<Timelin
 					objectType: o.objectType,
 					inGroup: o.id,
 				}
-				if (!childFixed.id) logger.error(`TimelineObj missing id attribute (child of ${o.id})`, childFixed)
+				if (!childFixed.id) logger.error(`TimelineObj missing id attribute (child of ${o.id})`, { childFixed })
 				timelineObjs.push(childFixed)
 
 				fixObjectChildren(childFixed)


### PR DESCRIPTION
This PR contains various fixes to the error logging.

* fix: use `stringifyError` in log functions. This is to ensure that errors are logged properly (error message, stack etc..).
* Removed unnesessary uses of `.stack` (since this is already handled in stringifyError)
* fix: improve `stringifyError` slightly. Refactor to clarify, and do JSON.stringify as last resort for objects.
* fix: improve client-side uncaughtErrorHandler (adding another stack trace).
