### PR TITLE
feat(Timeline+Storyboard): Invalid Parts show hover inspector with invalidReason

### DIFF
--- a/meteor/client/styles/_itemTypeColors.scss
+++ b/meteor/client/styles/_itemTypeColors.scss
@@ -401,6 +401,7 @@ $layer-types: join($layer-types-solid, $layer-types-gradient);
 }
 
 :root {
+	--segment-layer-border-unknown: #{$segment-layer-border-unknown};
 	--segment-layer-background-unknown: #{$segment-layer-background-unknown};
 	--segment-layer-background-unknown--second: #{$segment-layer-background-unknown};
 	--segment-layer-background-camera: #{$segment-layer-background-camera};

--- a/meteor/client/styles/_itemTypeColors.scss
+++ b/meteor/client/styles/_itemTypeColors.scss
@@ -1,5 +1,6 @@
 $segment-timeline-background-color: #1f1f1f;
 
+$segment-layer-border-unknown: darken(#4b4b4b, 10%);
 $segment-layer-background-unknown: #4b4b4b;
 $segment-layer-background-camera: #18791c;
 $segment-layer-background-camera--second: darken($segment-layer-background-camera, 10%);

--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -1422,7 +1422,7 @@ svg.icon {
 				bottom: 0;
 				right: 1px;
 				z-index: 10;
-				pointer-events: none;
+				pointer-events: all;
 				background-image: repeating-linear-gradient(
 						45deg,
 						var(--invalid-reason-color-transparent) 0%,

--- a/meteor/client/ui/FloatingInspectors/InvalidFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/InvalidFloatingInspector.tsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { FloatingInspector } from '../FloatingInspector'
+import { DBPart } from '../../../lib/collections/Parts'
+import { NoteSeverity } from '@sofie-automation/blueprints-integration'
+import { CriticalIconSmall, WarningIconSmall } from '../../lib/ui/icons/notifications'
+import { translateMessage } from '@sofie-automation/corelib/dist/TranslatableMessage'
+
+interface IProps {
+	itemElement: HTMLDivElement | null
+	showMiniInspector: boolean
+	floatingInspectorStyle: React.CSSProperties
+	part: DBPart
+
+	displayOn?: 'document' | 'viewport'
+}
+
+function renderReason(noticeLevel: NoteSeverity, noticeMessage: string | null): JSX.Element {
+	return (
+		<>
+			<div className="segment-timeline__mini-inspector__notice-header">
+				{noticeLevel === NoteSeverity.ERROR ? (
+					<CriticalIconSmall />
+				) : noticeLevel === NoteSeverity.WARNING ? (
+					<WarningIconSmall />
+				) : null}
+			</div>
+			<div className="segment-timeline__mini-inspector__notice">{noticeMessage}</div>
+		</>
+	)
+}
+
+export const InvalidFloatingInspector: React.FunctionComponent<IProps> = (props: IProps) => {
+	const { t } = useTranslation()
+
+	if (!props.part.invalidReason) {
+		return null
+	}
+
+	const noteSeverity = props.part.invalidReason.severity || NoteSeverity.INFO
+
+	return (
+		<FloatingInspector shown={props.showMiniInspector && props.itemElement !== undefined} displayOn={props.displayOn}>
+			<div
+				className={
+					'segment-timeline__mini-inspector ' +
+					'unknown' +
+					' ' +
+					(noteSeverity === NoteSeverity.ERROR
+						? 'segment-timeline__mini-inspector--notice notice-critical'
+						: noteSeverity === NoteSeverity.WARNING
+						? 'segment-timeline__mini-inspector--notice notice-warning'
+						: '')
+				}
+				style={props.floatingInspectorStyle}
+			>
+				{renderReason(noteSeverity, translateMessage(props.part.invalidReason.message, t))}
+			</div>
+		</FloatingInspector>
+	)
+}

--- a/meteor/client/ui/SegmentStoryboard/SegmentStoryboard.scss
+++ b/meteor/client/ui/SegmentStoryboard/SegmentStoryboard.scss
@@ -371,7 +371,7 @@ $part-right-padding: 5px;
 		bottom: 0;
 		right: 1px;
 		z-index: 1;
-		pointer-events: none;
+		pointer-events: all;
 		background-image: repeating-linear-gradient(
 				45deg,
 				var(--invalid-reason-color-transparent) 0%,

--- a/meteor/client/ui/SegmentStoryboard/StoryboardPart.tsx
+++ b/meteor/client/ui/SegmentStoryboard/StoryboardPart.tsx
@@ -17,6 +17,7 @@ import RundownViewEventBus, { HighlightEvent, RundownViewEvents } from '../Rundo
 import { Meteor } from 'meteor/meteor'
 import { StoryboardPartTransitions } from './StoryboardPartTransitions'
 import { PartDisplayDuration } from '../RundownView/RundownTiming/PartDuration'
+import { InvalidPartCover } from '../SegmentTimeline/Parts/InvalidPartCover'
 
 interface IProps {
 	className?: string
@@ -147,7 +148,9 @@ export function StoryboardPart({
 					</div>
 				</>
 			)}
-			{isInvalid ? <div className="segment-storyboard__part__invalid-cover"></div> : null}
+			{isInvalid ? (
+				<InvalidPartCover className="segment-storyboard__part__invalid-cover" part={part.instance.part} />
+			) : null}
 			{isFloated ? <div className="segment-storyboard__part__floated-cover"></div> : null}
 			<div className="segment-storyboard__part__title">{part.instance.part.title}</div>
 			<div

--- a/meteor/client/ui/SegmentTimeline/Parts/InvalidPartCover.tsx
+++ b/meteor/client/ui/SegmentTimeline/Parts/InvalidPartCover.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react'
+import { DBPart } from '../../../../lib/collections/Parts'
+import { InvalidFloatingInspector } from '../../FloatingInspectors/InvalidFloatingInspector'
+
+interface IProps {
+	className?: string
+	part: DBPart
+}
+
+export function InvalidPartCover({ className, part }: IProps) {
+	const element = React.createRef<HTMLDivElement>()
+	const [hover, setHover] = useState(false)
+	const [position, setPosition] = useState({ left: 0, top: 0, width: 0 })
+
+	function onMouseEnter() {
+		if (!element.current) {
+			return
+		}
+
+		setHover(true)
+		const rect = element.current.getBoundingClientRect()
+		setPosition({
+			top: rect.top + window.scrollY,
+			left: rect.left + window.scrollX,
+			width: rect.width,
+		})
+	}
+
+	function onMouseLeave() {
+		setHover(false)
+	}
+
+	return (
+		<div className={className} ref={element} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+			<InvalidFloatingInspector
+				part={part}
+				showMiniInspector={hover}
+				itemElement={element.current}
+				floatingInspectorStyle={{
+					top: `${position.top}px`,
+					left: `${position.left + position.width / 2}px`,
+				}}
+			/>
+		</div>
+	)
+}

--- a/meteor/client/ui/SegmentTimeline/Parts/SegmentTimelinePart.tsx
+++ b/meteor/client/ui/SegmentTimeline/Parts/SegmentTimelinePart.tsx
@@ -26,6 +26,7 @@ import { getShowHiddenSourceLayers } from '../../../lib/localStorage'
 import { Part } from '../../../../lib/collections/Parts'
 import { RundownTimingContext } from '../../../lib/rundownTiming'
 import { OutputGroup } from './OutputGroup'
+import { InvalidPartCover } from './InvalidPartCover'
 
 export const SegmentTimelineLineElementId = 'rundown__segment__line__'
 export const SegmentTimelinePartElementId = 'rundown__segment__part__'
@@ -595,7 +596,9 @@ export class SegmentTimelinePartClass extends React.Component<Translated<WithTim
 						</div>
 					)}
 					{this.renderTimelineOutputGroups(this.props.part)}
-					{innerPart.invalid ? <div className="segment-timeline__part__invalid-cover"></div> : null}
+					{innerPart.invalid ? (
+						<InvalidPartCover className="segment-timeline__part__invalid-cover" part={innerPart} />
+					) : null}
 					{innerPart.floated ? <div className="segment-timeline__part__floated-cover"></div> : null}
 					{this.props.playlist.nextTimeOffset &&
 						this.state.isNext && ( // This is the off-set line


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

After `invalidReason` stopped being promoted to a notification, there was no way of identifying the reason for an invalid Part.

* **What is the new behavior (if this is a feature change)?**

When hovering over an invalid Part, a floating inspector is shown with a notification about the reason for the invalid state, provided by the Blueprints.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
