### PR TITLE
fix: ensure timelinediv is an HtmlElement before trying to calculate …

### DIFF
--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -294,7 +294,7 @@ export const SegmentTimelineContainer = withResolvedSegment(
 				currentNextPart &&
 				(nextPartIdOrOffsetHasChanged || isBecomingNextSegment)
 			) {
-				const timelineWidth = getElementWidth(this.timelineDiv)
+				const timelineWidth = this.timelineDiv instanceof HTMLElement ? getElementWidth(this.timelineDiv) : 0 // unsure if this is a good default/substitute
 				// If part is not within viewport scroll to its start
 				if (
 					this.state.scrollLeft > partOffset ||
@@ -488,7 +488,7 @@ export const SegmentTimelineContainer = withResolvedSegment(
 				let scrollLeft = state.scrollLeft
 
 				if (zoomInToFit) {
-					const timelineWidth = getElementWidth(this.timelineDiv)
+					const timelineWidth = this.timelineDiv instanceof HTMLElement ? getElementWidth(this.timelineDiv) : 0 // unsure if this is good default/substitute
 					newScale =
 						(Math.max(0, timelineWidth - TIMELINE_RIGHT_PADDING * 2) / 3 || 1) /
 						(SegmentTimelinePartClass.getPartDisplayDuration(part, this.context?.durations) || 1)
@@ -608,8 +608,13 @@ export const SegmentTimelineContainer = withResolvedSegment(
 		}
 
 		getShowAllTimeScale = () => {
+			let calculatedTimelineDivWidth = 1
+			if (this.timelineDiv instanceof HTMLElement) {
+				calculatedTimelineDivWidth = getElementWidth(this.timelineDiv) - TIMELINE_RIGHT_PADDING || 1
+			}
+
 			let newScale =
-				(getElementWidth(this.timelineDiv) - TIMELINE_RIGHT_PADDING || 1) /
+				calculatedTimelineDivWidth /
 				((computeSegmentDisplayDuration(this.context.durations, this.props.parts) || 1) -
 					(this.state.isLiveSegment ? this.state.livePosition : 0))
 			newScale = Math.min(MINIMUM_ZOOM_FACTOR, newScale)


### PR DESCRIPTION
…its width

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
We have occurrences in the logs of `Error in Kibana: 'getComputedStyle': parameter 1 is not of type 'Element'` which is believed to originate from this component.


* **What is the new behavior (if this is a feature change)?**
This fix ensures that the timeline div actually is an HTMLElement before trying to calculate its width.


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
