### PR TITLE
Feat/migration context expose get triggered actionsid

### DIFF
--- a/meteor/client/ui/Settings/components/triggeredActions/TriggeredActionsEditor.tsx
+++ b/meteor/client/ui/Settings/components/triggeredActions/TriggeredActionsEditor.tsx
@@ -304,8 +304,8 @@ export const TriggeredActionsEditor: React.FC<IProps> = function TriggeredAction
 			.catch(console.error)
 	}, [props.showStyleBaseId])
 
-	const onRemoveTriggeredAction = useCallback((triggeredActionsId: TriggeredActionId) => {
-		MeteorCall.triggeredActions.removeTriggeredActions(triggeredActionsId).catch(console.error)
+	const onRemoveTriggeredAction = useCallback((triggeredActionId: TriggeredActionId) => {
+		MeteorCall.triggeredActions.removeTriggeredActions(triggeredActionId).catch(console.error)
 	}, [])
 
 	const onDuplicateEntry = useCallback(

--- a/meteor/server/api/blueprints/migrationContext.ts
+++ b/meteor/server/api/blueprints/migrationContext.ts
@@ -122,7 +122,7 @@ class AbstractMigrationContextWithTriggeredActions {
 		if (currentTriggeredAction) {
 			TriggeredActions.remove({
 				_id: currentTriggeredAction._id,
-				showStyleBaseId: null,
+				showStyleBaseId: this.showStyleBaseId,
 			})
 		}
 	}

--- a/meteor/server/api/blueprints/migrationContext.ts
+++ b/meteor/server/api/blueprints/migrationContext.ts
@@ -48,37 +48,37 @@ import { TriggeredActionId, TriggeredActions, TriggeredActionsObj } from '../../
 
 class AbstractMigrationContextWithTriggeredActions {
 	protected showStyleBaseId: ShowStyleBaseId | null = null
-	getTriggeredActionsId(triggeredActionId: string): string {
+	getTriggeredActionId(triggeredActionId: string): string {
 		return getHash((this.showStyleBaseId ?? 'core') + '_' + triggeredActionId)
 	}
-	private getProtectedTriggeredActionsId(triggeredActionId: string): TriggeredActionId {
-		return protectString<TriggeredActionId>(this.getTriggeredActionsId(triggeredActionId))
+	private getProtectedTriggeredActionId(triggeredActionId: string): TriggeredActionId {
+		return protectString<TriggeredActionId>(this.getTriggeredActionId(triggeredActionId))
 	}
 	getAllTriggeredActions(): IBlueprintTriggeredActions[] {
 		return TriggeredActions.find({
 			showStyleBaseId: this.showStyleBaseId,
 		}).map((triggeredActions) => unprotectObject(triggeredActions))
 	}
-	private getTriggeredActionFromDb(triggeredActionsId: string): TriggeredActionsObj | undefined {
+	private getTriggeredActionFromDb(triggeredActionId: string): TriggeredActionsObj | undefined {
 		const triggeredAction = TriggeredActions.findOne({
 			showStyleBaseId: this.showStyleBaseId,
-			_id: this.getProtectedTriggeredActionsId(triggeredActionsId),
+			_id: this.getProtectedTriggeredActionId(triggeredActionId),
 		})
 		if (triggeredAction) return triggeredAction
 
 		// Assume we were given the full id
 		return TriggeredActions.findOne({
 			showStyleBaseId: this.showStyleBaseId,
-			_id: protectString(triggeredActionsId),
+			_id: protectString(triggeredActionId),
 		})
 	}
-	getTriggeredAction(triggeredActionsId: string): IBlueprintTriggeredActions | undefined {
-		check(triggeredActionsId, String)
-		if (!triggeredActionsId) {
-			throw new Meteor.Error(500, `Triggered actions Id "${triggeredActionsId}" is invalid`)
+	getTriggeredAction(triggeredActionId: string): IBlueprintTriggeredActions | undefined {
+		check(triggeredActionId, String)
+		if (!triggeredActionId) {
+			throw new Meteor.Error(500, `Triggered actions Id "${triggeredActionId}" is invalid`)
 		}
 
-		return unprotectObject(this.getTriggeredActionFromDb(triggeredActionsId))
+		return unprotectObject(this.getTriggeredActionFromDb(triggeredActionId))
 	}
 	setTriggeredAction(triggeredActions: IBlueprintTriggeredActions) {
 		check(triggeredActions, Object)
@@ -97,7 +97,7 @@ class AbstractMigrationContextWithTriggeredActions {
 				...triggeredActions,
 				_rundownVersionHash: '',
 				showStyleBaseId: this.showStyleBaseId,
-				_id: this.getProtectedTriggeredActionsId(triggeredActions._id),
+				_id: this.getProtectedTriggeredActionId(triggeredActions._id),
 			})
 		} else {
 			TriggeredActions.update(
@@ -112,13 +112,13 @@ class AbstractMigrationContextWithTriggeredActions {
 			)
 		}
 	}
-	removeTriggeredAction(triggeredActionsId: string) {
-		check(triggeredActionsId, String)
-		if (!triggeredActionsId) {
-			throw new Meteor.Error(500, `Triggered actions Id "${triggeredActionsId}" is invalid`)
+	removeTriggeredAction(triggeredActionId: string) {
+		check(triggeredActionId, String)
+		if (!triggeredActionId) {
+			throw new Meteor.Error(500, `Triggered actions Id "${triggeredActionId}" is invalid`)
 		}
 
-		const currentTriggeredAction = this.getTriggeredActionFromDb(triggeredActionsId)
+		const currentTriggeredAction = this.getTriggeredActionFromDb(triggeredActionId)
 		if (currentTriggeredAction) {
 			TriggeredActions.remove({
 				_id: currentTriggeredAction._id,

--- a/meteor/server/api/triggeredActions.ts
+++ b/meteor/server/api/triggeredActions.ts
@@ -172,8 +172,8 @@ class ServerTriggeredActionsAPI extends MethodContextAPI implements NewTriggered
 	) {
 		return makePromise(() => apiCreateTriggeredActions(this, showStyleBaseId, base))
 	}
-	async removeTriggeredActions(triggeredActionsId: TriggeredActionId) {
-		return makePromise(() => apiRemoveTriggeredActions(this, triggeredActionsId))
+	async removeTriggeredActions(triggeredActionId: TriggeredActionId) {
+		return makePromise(() => apiRemoveTriggeredActions(this, triggeredActionId))
 	}
 }
 registerClassToMeteorMethods(

--- a/packages/blueprints-integration/src/migrations.ts
+++ b/packages/blueprints-integration/src/migrations.ts
@@ -79,6 +79,7 @@ export interface ShowStyleVariantPart {
 interface MigrationContextWithTriggeredActions {
 	getAllTriggeredActions: () => IBlueprintTriggeredActions[]
 	getTriggeredAction: (triggeredActionsId: string) => IBlueprintTriggeredActions | undefined
+	getTriggeredActionsId: (triggeredActionId: string) => string
 	setTriggeredAction: (triggeredActions: IBlueprintTriggeredActions) => void
 	removeTriggeredAction: (triggeredActionsId: string) => void
 }

--- a/packages/blueprints-integration/src/migrations.ts
+++ b/packages/blueprints-integration/src/migrations.ts
@@ -78,10 +78,10 @@ export interface ShowStyleVariantPart {
 
 interface MigrationContextWithTriggeredActions {
 	getAllTriggeredActions: () => IBlueprintTriggeredActions[]
-	getTriggeredAction: (triggeredActionsId: string) => IBlueprintTriggeredActions | undefined
-	getTriggeredActionsId: (triggeredActionId: string) => string
+	getTriggeredAction: (triggeredActionId: string) => IBlueprintTriggeredActions | undefined
+	getTriggeredActionId: (triggeredActionId: string) => string
 	setTriggeredAction: (triggeredActions: IBlueprintTriggeredActions) => void
-	removeTriggeredAction: (triggeredActionsId: string) => void
+	removeTriggeredAction: (triggeredActionId: string) => void
 }
 
 export interface MigrationContextShowStyle extends MigrationContextWithTriggeredActions {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** Feature, adds a new method to `MigrationContextWithTriggeredActions`



* **What is the current behavior?** (You can also link to an open issue here)
Blueprints aren't able to generate a hashed triggeredActionId, which is needed for Migrations i Blueprints to perform any comparisons between existing and potential new actionTriggers



* **What is the new behavior (if this is a feature change)?**
API change exposing `getTriggeredActionsId` in the migration context of Blueprints Integration.


* **Other information**:
It also fixes a bug in `removeTriggeredAction` where the db selector was missing a default value, and all comparisons failed resulting in failed attempts to remove any triggeredActions.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
