### PR TITLE
fix: avoid regenerating segments when only the rank changes

### DIFF
--- a/meteor/server/api/ingest/mosDevice/diff.ts
+++ b/meteor/server/api/ingest/mosDevice/diff.ts
@@ -67,10 +67,19 @@ export async function diffAndApplyChanges(
 	// Updated segments that has had their segment.externalId changed:
 	const renamedSegments = applyExternalIdDiff(cache, segmentDiff)
 
+	// Figure out which segments need to be regenerated
+	const segmentsToRegenerate = Object.values(segmentDiff.added)
+	for (const changedSegment of Object.values(segmentDiff.changed)) {
+		// Rank changes are handled above
+		if (!segmentDiff.onlyRankChanged[changedSegment.externalId]) {
+			segmentsToRegenerate.push(changedSegment)
+		}
+	}
+
 	// Create/Update segments
 	const segmentChanges = await calculateSegmentsFromIngestData(
 		cache,
-		_.sortBy([...Object.values(segmentDiff.added), ...Object.values(segmentDiff.changed)], (se) => se.rank),
+		_.sortBy(segmentsToRegenerate, (se) => se.rank),
 		null
 	)
 


### PR DESCRIPTION
* ** (Bug fix, feature, docs update, ...)

Fix

* **What is the current behavior?** (You can also link to an open issue here)

When receiving a sendROMoveStories or some other mos operations, we will regenerate all the segments following the change

* **What is the new behavior (if this is a feature change)?**

For most of those segments, only the rank has changed, which we have a shortcut for. Avoid re-running blueprints for these segments to speed up the ingest operations

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
