### PR TITLE
tsconfig issue with SonarCloud

### DIFF
--- a/packages/blueprints-integration/tsconfig.build.json
+++ b/packages/blueprints-integration/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
-	"extends": "@sofie-automation/code-standard-preset/ts/tsconfig.lib",
+	"extends": "@sofie-automation/code-standard-preset/ts/tsconfig.lib.json",
 	"include": ["src/**/*.ts"],
 	"exclude": ["node_modules/**", "src/**/*spec.ts", "src/**/__tests__/*", "src/**/__mocks__/*"],
 	"compilerOptions": {

--- a/packages/corelib/tsconfig.build.json
+++ b/packages/corelib/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
-	"extends": "@sofie-automation/code-standard-preset/ts/tsconfig.lib",
+	"extends": "@sofie-automation/code-standard-preset/ts/tsconfig.lib.json",
 	"include": ["src/**/*.ts"],
 	"exclude": ["node_modules/**", "src/**/*spec.ts", "src/**/__tests__/*", "src/**/__mocks__/*"],
 	"compilerOptions": {

--- a/packages/job-worker/tsconfig.build.json
+++ b/packages/job-worker/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
-	"extends": "@sofie-automation/code-standard-preset/ts/tsconfig.lib",
+	"extends": "@sofie-automation/code-standard-preset/ts/tsconfig.lib.json",
 	"include": ["src/**/*.ts"],
 	"exclude": ["node_modules/**", "src/**/*spec.ts", "src/**/__tests__/*", "src/**/__mocks__/*"],
 	"compilerOptions": {

--- a/packages/playout-gateway/tsconfig.build.json
+++ b/packages/playout-gateway/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
-	"extends": "@sofie-automation/code-standard-preset/ts/tsconfig.bin",
+	"extends": "@sofie-automation/code-standard-preset/ts/tsconfig.bin.json",
 	"include": ["src/**/*.ts"],
 	"exclude": ["node_modules/**", "src/**/*spec.ts", "src/**/__tests__/*", "src/**/__mocks__/*"],
 	"compilerOptions": {


### PR DESCRIPTION
don't omit the file extension when extending a tsconfig, as this results in errors in the SonarCloud scan.