### PR TITLE
doc: package manager powershell note

### DIFF
--- a/packages/documentation/docs/user-guide/installation/installing-package-manager.md
+++ b/packages/documentation/docs/user-guide/installation/installing-package-manager.md
@@ -30,7 +30,14 @@ Package Manager is a suite of standalone applications, separate from _Sofie&nbsp
 git clone https://github.com/nrkno/sofie-package-manager.git
 cd tv-automation-package-manager
 yarn install
-yarn start:single-app -- -- --basePath "C:\Your\Path\To\CasparCG&nbsp;Server\media-folder (i.e. sofie-demo-media)"
+yarn build
+yarn start:single-app -- -- --basePath "C:\your\path\to\casparcg-server\media-folder (i.e. sofie-demo-media)"
+```
+
+Note: if Powershell throws `Unknown argument: basePath` error, add one more pair of dashes (`--`) before the basePath argument:
+
+```bash
+yarn start:single-app -- -- -- --basePath "C:\your\path\to\casparcg-server\media-folder (i.e. sofie-demo-media)"
 ```
 
 On first startup, Package Manager will exit with the following message:


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs update


* **What is the current behavior?** (You can also link to an open issue here)
Some Powershell users won't be able to start package-manager successfully - they need to add an extra pair of dashes.


* **What is the new behavior (if this is a feature change)?**
The note is added so that all Powershell users who encounter the issue will know how to fix it.