### PR TITLE
feat: reduce number of loaded PartInstances

### DIFF
--- a/packages/corelib/src/lib.ts
+++ b/packages/corelib/src/lib.ts
@@ -44,6 +44,14 @@ export function max<T>(vals: T[], iterator: _.ListIterator<T, any>): T | undefin
 	}
 }
 
+export function min<T>(vals: T[], iterator: _.ListIterator<T, any>): T | undefined {
+	if (vals.length <= 1) {
+		return vals[0]
+	} else {
+		return _.min(vals, iterator) as T
+	}
+}
+
 export function assertNever(_never: never): void {
 	// Do nothing. This is a type guard
 }

--- a/packages/corelib/src/mongo.ts
+++ b/packages/corelib/src/mongo.ts
@@ -91,6 +91,19 @@ export function mongoWhere<T>(o: Record<string, any>, selector: MongoQuery<T>): 
 				} else {
 					throw new Error('An $or filter must be an array')
 				}
+			} else if (key === '$and') {
+				if (Array.isArray(s) && s.length >= 1) {
+					let ok2 = true
+					for (const innerSelector of s) {
+						ok2 = ok2 && mongoWhere(o, innerSelector)
+						if (!ok2) break
+					}
+					ok = ok2
+				} else {
+					throw new Error('An $and filter must be an array')
+				}
+			} else if (key.startsWith('$')) {
+				throw new Error(`Operand "${key}" is not implemented`)
 			} else {
 				const oAttr = o[key]
 

--- a/packages/job-worker/src/playout/adlib.ts
+++ b/packages/job-worker/src/playout/adlib.ts
@@ -32,7 +32,7 @@ import {
 	getResolvedPieces,
 	setupPieceInstanceInfiniteProperties,
 } from './pieces'
-import { updatePartInstanceRanks } from '../rundown'
+import { updatePartInstanceRanksAfterAdlib } from '../rundown'
 import {
 	fetchPiecesThatMayBeActiveForPart,
 	getPieceInstancesForPart,
@@ -548,7 +548,7 @@ export async function innerStartQueuedAdLib(
 		cache.PieceInstances.insert(pieceInstance)
 	})
 
-	updatePartInstanceRanks(cache, [{ segmentId: newPartInstance.part.segmentId, oldPartIdsAndRanks: null }])
+	updatePartInstanceRanksAfterAdlib(cache, newPartInstance.part.segmentId)
 
 	// Find and insert any rundown defined infinites that we should inherit
 	newPartInstance = cache.PartInstances.findOne(newPartInstance._id) as DBPartInstance

--- a/packages/job-worker/src/playout/lib.ts
+++ b/packages/job-worker/src/playout/lib.ts
@@ -23,7 +23,7 @@ import {
 	getPieceInstancesForPart,
 	syncPlayheadInfinitesForNextPartInstance,
 } from './infinites'
-import { protectString, unprotectString } from '@sofie-automation/corelib/dist/protectedString'
+import { protectString } from '@sofie-automation/corelib/dist/protectedString'
 import { PRESERVE_UNSYNCED_PLAYING_SEGMENT_CONTENTS } from '@sofie-automation/corelib/dist/constants'
 import { logger } from '../logging'
 import { getCurrentTime } from '../lib'
@@ -40,18 +40,7 @@ export async function resetRundownPlaylist(context: JobContext, cache: CacheForP
 	// Remove all dunamically inserted pieces (adlibs etc)
 	// const rundownIds = new Set(getRundownIDsFromCache(cache))
 
-	const partInstancesToRemove = cache.PartInstances.remove((p) => p.rehearsal)
-	if (partInstancesToRemove.length) {
-		const cachedRemovedPieceInstances = cache.PieceInstances.remove({
-			partInstanceId: { $in: partInstancesToRemove },
-		})
-		cache.deferAfterSave(async () => {
-			await context.directCollections.PieceInstances.remove({
-				partInstanceId: { $in: partInstancesToRemove },
-				_id: { $nin: cachedRemovedPieceInstances },
-			})
-		})
-	}
+	removePartInstancesWithPieceInstances(context, cache, { rehearsal: true })
 	resetPartInstancesWithPieceInstances(context, cache)
 
 	cache.Playlist.update({
@@ -430,20 +419,9 @@ export async function setNextPart(
 			}
 
 			if (resetPartInstanceIds.size > 0) {
-				cache.PartInstances.update(
-					(p) => resetPartInstanceIds.has(p._id),
-					(p) => {
-						p.reset = true
-						return p
-					}
-				)
-				cache.PieceInstances.update(
-					(p) => resetPartInstanceIds.has(p.partInstanceId),
-					(p) => {
-						p.reset = true
-						return p
-					}
-				)
+				resetPartInstancesWithPieceInstances(context, cache, {
+					_id: { $in: Array.from(resetPartInstanceIds) },
+				})
 			}
 		}
 	}
@@ -483,27 +461,22 @@ export function setNextSegment(context: JobContext, cache: CacheForPlayout, next
  */
 async function cleanupOrphanedItems(context: JobContext, cache: CacheForPlayout) {
 	const playlist = cache.Playlist.doc
-	const selectedPartInstanceIds = _.compact([playlist.currentPartInstanceId, playlist.nextPartInstanceId])
 
-	const removePartInstanceIds: PartInstanceId[] = []
+	const selectedPartInstancesSegmentIds = new Set<SegmentId>()
+	const selectedPartInstances = getSelectedPartInstancesFromCache(cache)
+	if (selectedPartInstances.currentPartInstance)
+		selectedPartInstancesSegmentIds.add(selectedPartInstances.currentPartInstance.segmentId)
+	if (selectedPartInstances.nextPartInstance)
+		selectedPartInstancesSegmentIds.add(selectedPartInstances.nextPartInstance.segmentId)
 
 	// Cleanup any orphaned segments once they are no longer being played. This also cleans up any adlib-parts, that have been marked as deleted as a deferred cleanup operation
 	const segments = cache.Segments.findFetch((s) => !!s.orphaned)
 	const orphanedSegmentIds = new Set(segments.map((s) => s._id))
-	const groupedPartInstances = _.groupBy(
-		cache.PartInstances.findFetch((p) => orphanedSegmentIds.has(p.segmentId)),
-		(p) => unprotectString(p.segmentId)
-	)
+
 	const alterSegmentsFromRundowns = new Map<RundownId, { deleted: SegmentId[]; hidden: SegmentId[] }>()
 	for (const segment of segments) {
-		const partInstances = groupedPartInstances[unprotectString(segment._id)] || []
-		const partInstanceIds = new Set(partInstances.map((p) => p._id))
-
-		// Not in current or next. Previous can be reset as it will still be in the db, but not shown in the ui
-		if (
-			(!playlist.currentPartInstanceId || !partInstanceIds.has(playlist.currentPartInstanceId)) &&
-			(!playlist.nextPartInstanceId || !partInstanceIds.has(playlist.nextPartInstanceId))
-		) {
+		// If the segment is orphaned and not the segment for the next or current partinstance
+		if (!selectedPartInstancesSegmentIds.has(segment._id)) {
 			let rundownSegments = alterSegmentsFromRundowns.get(segment.rundownId)
 			if (!rundownSegments) {
 				rundownSegments = { deleted: [], hidden: [] }
@@ -539,6 +512,7 @@ async function cleanupOrphanedItems(context: JobContext, cache: CacheForPlayout)
 		}
 	}
 
+	const removePartInstanceIds: PartInstanceId[] = []
 	// Cleanup any orphaned partinstances once they are no longer being played (and the segment isnt orphaned)
 	const orphanedInstances = cache.PartInstances.findFetch((p) => p.orphaned === 'deleted' && !p.reset)
 	for (const partInstance of orphanedInstances) {
@@ -547,16 +521,68 @@ async function cleanupOrphanedItems(context: JobContext, cache: CacheForPlayout)
 			continue
 		}
 
-		if (!selectedPartInstanceIds.includes(partInstance._id)) {
+		if (partInstance._id !== playlist.currentPartInstanceId && partInstance._id !== playlist.nextPartInstanceId) {
 			removePartInstanceIds.push(partInstance._id)
 		}
 	}
 
 	// Cleanup any instances from above
 	if (removePartInstanceIds.length > 0) {
-		cache.PartInstances.update({ _id: { $in: removePartInstanceIds } }, { $set: { reset: true } })
-		cache.PieceInstances.update({ partInstanceId: { $in: removePartInstanceIds } }, { $set: { reset: true } })
+		resetPartInstancesWithPieceInstances(context, cache, { _id: { $in: removePartInstanceIds } })
 	}
+}
+
+/**
+ * Remove selected partInstances with their pieceInstances
+ */
+function removePartInstancesWithPieceInstances(
+	context: JobContext,
+	cache: CacheForPlayout,
+	selector: MongoQuery<DBPartInstance>
+): void {
+	const partInstancesToRemove = cache.PartInstances.remove(selector)
+
+	// Reset any in the cache now
+	if (partInstancesToRemove.length) {
+		cache.PieceInstances.remove({
+			partInstanceId: { $in: partInstancesToRemove },
+		})
+	}
+
+	// Defer ones which arent loaded
+	cache.deferAfterSave(async (cache) => {
+		// We need to keep any for PartInstances which are still existent in the cache (as they werent removed)
+		const partInstanceIdsInCache = cache.PartInstances.findFetch({}).map((p) => p._id)
+
+		// Find all the partInstances which are not loaded, but should be removed
+		const removeFromDb = await context.directCollections.PartInstances.findFetch(
+			{
+				$and: [
+					selector,
+					{
+						// Not any which are in the cache, as they have already been done if needed
+						_id: { $nin: partInstanceIdsInCache },
+					},
+				],
+			},
+			{ projection: { _id: 1 } }
+		).then((ps) => ps.map((p) => p._id))
+
+		// Do the remove
+		const allToRemove = [...removeFromDb, ...partInstancesToRemove]
+		await Promise.all([
+			removeFromDb.length > 0
+				? context.directCollections.PartInstances.remove({
+						_id: { $in: removeFromDb },
+				  })
+				: undefined,
+			allToRemove.length > 0
+				? context.directCollections.PieceInstances.remove({
+						partInstanceId: { $in: allToRemove },
+				  })
+				: undefined,
+		])
+	})
 }
 
 /**
@@ -582,8 +608,10 @@ function resetPartInstancesWithPieceInstances(
 			},
 		}
 	)
+
+	// Reset any in the cache now
 	if (partInstancesToReset.length) {
-		const cachedResetPieceInstances = cache.PieceInstances.update(
+		cache.PieceInstances.update(
 			{
 				partInstanceId: { $in: partInstancesToReset },
 				reset: { $ne: true },
@@ -594,21 +622,58 @@ function resetPartInstancesWithPieceInstances(
 				},
 			}
 		)
-		cache.deferAfterSave(async () => {
-			await context.directCollections.PieceInstances.update(
-				{
-					partInstanceId: { $in: partInstancesToReset },
-					reset: { $ne: true },
-					_id: { $nin: cachedResetPieceInstances },
-				},
-				{
-					$set: {
-						reset: true,
-					},
-				}
-			)
-		})
 	}
+
+	// Defer ones which arent loaded
+	cache.deferAfterSave(async (cache) => {
+		const partInstanceIdsInCache = cache.PartInstances.findFetch({}).map((p) => p._id)
+
+		// Find all the partInstances which are not loaded, but should be reset
+		const resetInDb = await context.directCollections.PartInstances.findFetch(
+			{
+				$and: [
+					selector ?? {},
+					{
+						// Not any which are in the cache, as they have already been done if needed
+						_id: { $nin: partInstanceIdsInCache },
+						reset: { $ne: true },
+					},
+				],
+			},
+			{ projection: { _id: 1 } }
+		).then((ps) => ps.map((p) => p._id))
+
+		// Do the reset
+		const allToReset = [...resetInDb, ...partInstancesToReset]
+		await Promise.all([
+			resetInDb.length
+				? context.directCollections.PartInstances.update(
+						{
+							_id: { $in: resetInDb },
+							reset: { $ne: true },
+						},
+						{
+							$set: {
+								reset: true,
+							},
+						}
+				  )
+				: undefined,
+			allToReset.length
+				? context.directCollections.PieceInstances.update(
+						{
+							partInstanceId: { $in: allToReset },
+							reset: { $ne: true },
+						},
+						{
+							$set: {
+								reset: true,
+							},
+						}
+				  )
+				: undefined,
+		])
+	})
 }
 
 export function onPartHasStoppedPlaying(

--- a/packages/job-worker/src/playout/pieces.ts
+++ b/packages/job-worker/src/playout/pieces.ts
@@ -274,17 +274,6 @@ export function getResolvedPiecesFromFullTimeline(
 
 	if (currentPartInstance && currentPartInstance.part.autoNext && playlist.nextPartInstanceId) {
 		pieceInstances.push(...cache.PieceInstances.findFetch((p) => p.partInstanceId === playlist.nextPartInstanceId))
-
-		// If a segment is queued and we're about to consume it, remove nextSegmentId from playlist
-		if (playlist.nextSegmentId) {
-			const consumedPartsInstancesInNextSegment = cache.PartInstances.findFetch({
-				_id: { $in: pieceInstances.map((p) => p.partInstanceId) },
-				segmentId: playlist.nextSegmentId,
-			})
-			if (consumedPartsInstancesInNextSegment.length) {
-				cache.Playlist.update({ $unset: { nextSegmentId: true } })
-			}
-		}
 	}
 
 	const transformedObjs = transformTimeline(objs)

--- a/packages/job-worker/src/rundown.ts
+++ b/packages/job-worker/src/rundown.ts
@@ -3,10 +3,13 @@ import { DBPart } from '@sofie-automation/corelib/dist/dataModel/Part'
 import { DBPartInstance } from '@sofie-automation/corelib/dist/dataModel/PartInstance'
 import { DBRundown } from '@sofie-automation/corelib/dist/dataModel/Rundown'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
-import { normalizeArrayToMap } from '@sofie-automation/corelib/dist/lib'
+import { normalizeArrayToMap, min } from '@sofie-automation/corelib/dist/lib'
 import { unprotectString } from '@sofie-automation/corelib/dist/protectedString'
+import { AnyBulkWriteOperation } from 'mongodb'
 import { ReadonlyDeep } from 'type-fest'
 import _ = require('underscore')
+import { CacheForIngest } from './ingest/cache'
+import { BeforePartMap } from './ingest/commit'
 import { JobContext } from './jobs'
 import { logger } from './logging'
 import { CacheForPlayout } from './playout/cache'
@@ -37,158 +40,259 @@ export async function allowedToMoveRundownOutOfPlaylist(
 	return selectedPartInstancesInRundown.length === 0
 }
 
-export type ChangedSegmentsRankInfo = Array<{
-	segmentId: SegmentId
-	oldPartIdsAndRanks: Array<{ id: PartId; rank: number }> | null // Null if the Parts havent changed, and so can be loaded locally
-}>
-
 /**
  * Update the ranks of all PartInstances in the given segments.
  * Syncs the ranks from matching Parts to PartInstances.
  * Orphaned PartInstances get ranks interpolated based on what they were ranked between before the ingest update
  */
-export function updatePartInstanceRanks(cache: CacheForPlayout, changedSegments: ChangedSegmentsRankInfo): void {
+export async function updatePartInstanceRanks(
+	context: JobContext,
+	cache: CacheForIngest,
+	changedSegmentIds: ReadonlyDeep<SegmentId[]>,
+	beforePartMap: BeforePartMap
+): Promise<void> {
 	const groupedPartInstances = _.groupBy(
-		cache.PartInstances.findFetch({
+		await context.directCollections.PartInstances.findFetch({
 			reset: { $ne: true },
-			segmentId: { $in: changedSegments.map((s) => s.segmentId) },
+			segmentId: { $in: changedSegmentIds as SegmentId[] },
 		}),
 		(p) => unprotectString(p.segmentId)
 	)
 	const groupedNewParts = _.groupBy(
 		cache.Parts.findFetch({
-			segmentId: { $in: changedSegments.map((s) => s.segmentId) },
+			segmentId: { $in: changedSegmentIds as SegmentId[] },
 		}),
 		(p) => unprotectString(p.segmentId)
 	)
 
-	let updatedParts = 0
-	for (const { segmentId, oldPartIdsAndRanks: oldPartIdsAndRanks0 } of changedSegments) {
+	const writeOps: AnyBulkWriteOperation<DBPartInstance>[] = []
+
+	for (const segmentId of changedSegmentIds) {
+		const oldPartIdsAndRanks = beforePartMap.get(segmentId) ?? []
+
 		const newParts = groupedNewParts[unprotectString(segmentId)] || []
 		const segmentPartInstances = _.sortBy(
 			groupedPartInstances[unprotectString(segmentId)] || [],
 			(p) => p.part._rank
 		)
 
-		// Ensure the PartInstance ranks are synced with their Parts
-		const newPartsMap = normalizeArrayToMap(newParts, '_id')
-		for (const partInstance of segmentPartInstances) {
-			const part = newPartsMap.get(partInstance.part._id)
-			if (part) {
-				// We have a part and instance, so make sure the part isn't orphaned and sync the rank
-				cache.PartInstances.update(partInstance._id, {
-					$set: {
-						'part._rank': part._rank,
-					},
-					$unset: {
-						orphaned: 1,
-					},
-				})
-
-				// Update local copy
-				delete partInstance.orphaned
-				partInstance.part._rank = part._rank
-			} else if (!partInstance.orphaned) {
-				cache.PartInstances.update(partInstance._id, {
-					$set: {
-						orphaned: 'deleted',
+		const newRanks = calculateNewRanksForParts(segmentId, oldPartIdsAndRanks, newParts, segmentPartInstances)
+		for (const [instanceId, info] of newRanks.entries()) {
+			if (info.deleted) {
+				writeOps.push({
+					updateOne: {
+						filter: { _id: instanceId },
+						update: {
+							$set: {
+								orphaned: 'deleted',
+								'part._rank': info.rank,
+							},
+						},
 					},
 				})
-				partInstance.orphaned = 'deleted'
+			} else if (info.deleted === undefined) {
+				writeOps.push({
+					updateOne: {
+						filter: { _id: instanceId },
+						update: {
+							$set: {
+								'part._rank': info.rank,
+							},
+						},
+					},
+				})
+			} else {
+				writeOps.push({
+					updateOne: {
+						filter: { _id: instanceId },
+						update: {
+							$set: {
+								'part._rank': info.rank,
+							},
+							$unset: {
+								orphaned: 1,
+							},
+						},
+					},
+				})
 			}
 		}
+	}
 
-		const orphanedPartInstances = segmentPartInstances
-			.map((p) => ({ rank: p.part._rank, orphaned: p.orphaned, instanceId: p._id, id: p.part._id }))
-			.filter((p) => p.orphaned)
+	if (writeOps.length > 0) {
+		await context.directCollections.PartInstances.bulkWrite(writeOps)
+	}
+	logger.debug(`updatePartRanks: ${writeOps.length} PartInstances updated`)
+}
 
-		if (orphanedPartInstances.length === 0) {
-			// No orphans to position
-			continue
+/**
+ * Update the ranks of all PartInstances in the given segments.
+ * Syncs the ranks from matching Parts to PartInstances.
+ */
+export function updatePartInstanceRanksAfterAdlib(cache: CacheForPlayout, segmentId: SegmentId): void {
+	const newParts = cache.Parts.findFetch((p) => p.segmentId === segmentId)
+	const segmentPartInstances = _.sortBy(
+		cache.PartInstances.findFetch((p) => p.segmentId === segmentId),
+		(p) => p.part._rank
+	)
+
+	const newRanks = calculateNewRanksForParts(segmentId, null, newParts, segmentPartInstances)
+	for (const [instanceId, info] of newRanks.entries()) {
+		if (info.deleted) {
+			cache.PartInstances.update(instanceId, {
+				$set: {
+					orphaned: 'deleted',
+					'part._rank': info.rank,
+				},
+			})
+		} else if (info.deleted === undefined) {
+			cache.PartInstances.update(instanceId, {
+				$set: {
+					'part._rank': info.rank,
+				},
+			})
+		} else {
+			cache.PartInstances.update(instanceId, {
+				$set: {
+					'part._rank': info.rank,
+				},
+				$unset: {
+					orphaned: 1,
+				},
+			})
+		}
+	}
+
+	logger.debug(`updatePartRanks: ${newRanks.size} PartInstances updated`)
+}
+
+function calculateNewRanksForParts(
+	segmentId: SegmentId,
+	oldPartIdsAndRanks0: Array<{ id: PartId; rank: number }> | null, // Null if the Parts havent changed, and so can be loaded locally
+	newParts: DBPart[],
+	segmentPartInstances: DBPartInstance[]
+): Map<PartInstanceId, { deleted: boolean | undefined; rank: number }> {
+	const changedRanks = new Map<PartInstanceId, { deleted: boolean | undefined; rank: number }>()
+
+	// Ensure the PartInstance ranks are synced with their Parts
+	const newPartsMap = normalizeArrayToMap(newParts, '_id')
+	for (const partInstance of segmentPartInstances) {
+		const part = newPartsMap.get(partInstance.part._id)
+		if (part) {
+			// We have a part and instance, so make sure the part isn't orphaned and sync the rank
+			changedRanks.set(partInstance._id, {
+				rank: part._rank,
+				deleted: false,
+			})
+
+			// Update local copy
+			delete partInstance.orphaned
+			partInstance.part._rank = part._rank
+		} else if (!partInstance.orphaned) {
+			partInstance.orphaned = 'deleted'
+			changedRanks.set(partInstance._id, {
+				rank: partInstance.part._rank,
+				deleted: true,
+			})
+		}
+	}
+
+	const orphanedPartInstances = segmentPartInstances
+		.map((p) => ({ rank: p.part._rank, orphaned: p.orphaned, instanceId: p._id, id: p.part._id }))
+		.filter((p) => p.orphaned)
+
+	if (orphanedPartInstances.length === 0) {
+		// No orphans to position
+		return changedRanks
+	}
+
+	logger.debug(
+		`updatePartInstanceRanks: ${segmentPartInstances.length} partInstances with ${orphanedPartInstances.length} orphans in segment "${segmentId}"`
+	)
+
+	// If we have no instances, or no parts to base it on, then we can't do anything
+	if (newParts.length === 0) {
+		// position them all 0..n
+		let i = 0
+		for (const partInfo of orphanedPartInstances) {
+			changedRanks.set(partInfo.instanceId, { rank: i++, deleted: true })
 		}
 
-		logger.debug(
-			`updatePartInstanceRanks: ${segmentPartInstances.length} partInstances with ${orphanedPartInstances.length} orphans in segment "${segmentId}"`
+		return changedRanks
+	}
+
+	const oldPartIdsAndRanks = oldPartIdsAndRanks0 ?? newParts.map((p) => ({ id: p._id, rank: p._rank }))
+
+	const preservedPreviousParts = oldPartIdsAndRanks.filter((p) => newPartsMap.has(p.id))
+
+	if (preservedPreviousParts.length === 0) {
+		// position them all before the first
+
+		const firstPartRank = min(newParts, (p) => p._rank)?._rank ?? 0
+		let i = firstPartRank - orphanedPartInstances.length
+		for (const partInfo of orphanedPartInstances) {
+			changedRanks.set(partInfo.instanceId, {
+				rank: i++,
+				deleted: changedRanks.get(partInfo.instanceId)?.deleted,
+			})
+		}
+	} else {
+		// they need interleaving
+
+		// compile the old order, and get a list of the ones that still remain in the new state
+		const allParts = new Map<PartId, { rank: number; id: PartId; instanceId?: PartInstanceId }>()
+		for (const oldPart of oldPartIdsAndRanks) allParts.set(oldPart.id, oldPart)
+		for (const orphanedPart of orphanedPartInstances) allParts.set(orphanedPart.id, orphanedPart)
+
+		// Now go through and update their ranks
+		const remainingPreviousParts = _.sortBy(Array.from(allParts.values()), (p) => p.rank).filter(
+			(p) => p.instanceId || newPartsMap.has(p.id)
 		)
 
-		// If we have no instances, or no parts to base it on, then we can't do anything
-		if (newParts.length === 0) {
-			// position them all 0..n
-			let i = 0
-			for (const partInfo of orphanedPartInstances) {
-				cache.PartInstances.update(partInfo.instanceId, { $set: { 'part._rank': i++ } })
+		for (let i = -1; i < remainingPreviousParts.length - 1; ) {
+			// Find the range to process this iteration
+			const beforePartIndex = i
+			const afterPartIndex = remainingPreviousParts.findIndex((p, o) => o > i && !p.instanceId)
+
+			if (afterPartIndex === beforePartIndex + 1) {
+				// no dynamic parts in between
+				i++
+				continue
+			} else if (afterPartIndex === -1) {
+				// We will reach the end, so make sure we stop
+				i = remainingPreviousParts.length
+			} else {
+				// next iteration should look from the next fixed point
+				i = afterPartIndex
 			}
-			continue
-		}
 
-		const oldPartIdsAndRanks = oldPartIdsAndRanks0 ?? newParts.map((p) => ({ id: p._id, rank: p._rank }))
+			const firstDynamicIndex = beforePartIndex + 1
+			const lastDynamicIndex = afterPartIndex === -1 ? remainingPreviousParts.length - 1 : afterPartIndex - 1
 
-		const preservedPreviousParts = oldPartIdsAndRanks.filter((p) => newPartsMap.has(p.id))
+			// Calculate the rank change per part
+			const dynamicPartCount = lastDynamicIndex - firstDynamicIndex + 1
+			const basePartRank =
+				beforePartIndex === -1 ? -1 : newPartsMap.get(remainingPreviousParts[beforePartIndex].id)!._rank // eslint-disable-line @typescript-eslint/no-non-null-assertion
+			const afterPartRank =
+				afterPartIndex === -1
+					? basePartRank + 1
+					: newPartsMap.get(remainingPreviousParts[afterPartIndex].id)!._rank // eslint-disable-line @typescript-eslint/no-non-null-assertion
+			const delta = (afterPartRank - basePartRank) / (dynamicPartCount + 1)
 
-		if (preservedPreviousParts.length === 0) {
-			// position them all before the first
-			const firstPartRank = newParts.length > 0 ? (_.min(newParts, (p) => p._rank) as DBPart)._rank : 0
-			let i = firstPartRank - orphanedPartInstances.length
-			for (const partInfo of orphanedPartInstances) {
-				cache.PartInstances.update(partInfo.instanceId, { $set: { 'part._rank': i++ } })
-			}
-		} else {
-			// they need interleaving
+			let prevRank = basePartRank
+			for (let o = firstDynamicIndex; o <= lastDynamicIndex; o++) {
+				const newRank = (prevRank = prevRank + delta)
 
-			// compile the old order, and get a list of the ones that still remain in the new state
-			const allParts = new Map<PartId, { rank: number; id: PartId; instanceId?: PartInstanceId }>()
-			for (const oldPart of oldPartIdsAndRanks) allParts.set(oldPart.id, oldPart)
-			for (const orphanedPart of orphanedPartInstances) allParts.set(orphanedPart.id, orphanedPart)
-
-			// Now go through and update their ranks
-			const remainingPreviousParts = _.sortBy(Array.from(allParts.values()), (p) => p.rank).filter(
-				(p) => p.instanceId || newPartsMap.has(p.id)
-			)
-
-			for (let i = -1; i < remainingPreviousParts.length - 1; ) {
-				// Find the range to process this iteration
-				const beforePartIndex = i
-				const afterPartIndex = remainingPreviousParts.findIndex((p, o) => o > i && !p.instanceId)
-
-				if (afterPartIndex === beforePartIndex + 1) {
-					// no dynamic parts in between
-					i++
-					continue
-				} else if (afterPartIndex === -1) {
-					// We will reach the end, so make sure we stop
-					i = remainingPreviousParts.length
-				} else {
-					// next iteration should look from the next fixed point
-					i = afterPartIndex
-				}
-
-				const firstDynamicIndex = beforePartIndex + 1
-				const lastDynamicIndex = afterPartIndex === -1 ? remainingPreviousParts.length - 1 : afterPartIndex - 1
-
-				// Calculate the rank change per part
-				const dynamicPartCount = lastDynamicIndex - firstDynamicIndex + 1
-				const basePartRank =
-					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-					beforePartIndex === -1 ? -1 : newPartsMap.get(remainingPreviousParts[beforePartIndex].id)?._rank! // eslint-disable-line @typescript-eslint/no-non-null-asserted-optional-chain
-				const afterPartRank =
-					afterPartIndex === -1
-						? basePartRank + 1
-						: // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-						  newPartsMap.get(remainingPreviousParts[afterPartIndex].id)?._rank! // eslint-disable-line @typescript-eslint/no-non-null-asserted-optional-chain
-				const delta = (afterPartRank - basePartRank) / (dynamicPartCount + 1)
-
-				let prevRank = basePartRank
-				for (let o = firstDynamicIndex; o <= lastDynamicIndex; o++) {
-					const newRank = (prevRank = prevRank + delta)
-
-					const orphanedPart = remainingPreviousParts[o]
-					if (orphanedPart.instanceId && orphanedPart.rank !== newRank) {
-						cache.PartInstances.update(orphanedPart.instanceId, { $set: { 'part._rank': newRank } })
-						updatedParts++
-					}
+				const orphanedPart = remainingPreviousParts[o]
+				if (orphanedPart.instanceId && orphanedPart.rank !== newRank) {
+					changedRanks.set(orphanedPart.instanceId, {
+						rank: newRank,
+						deleted: changedRanks.get(orphanedPart.instanceId)?.deleted,
+					})
 				}
 			}
 		}
 	}
-	logger.debug(`updatePartRanks: ${updatedParts} PartInstances updated`)
+
+	return changedRanks
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature/fix

Rebase of https://github.com/nrkno/sofie-core/pull/696 for r41

* **What is the current behavior?** (You can also link to an open issue here)

Over time, the number of PartInstances loaded into the Cache increases. It only gets reduced when parts/segments are reset, which does not happen automatically (by design)

* **What is the new behavior (if this is a feature change)?**

To avoid the amount of data continually growing, we can limit the PartInstances to be the Segments containing the previous, current and next PartInstances. It might be possible to reduce this further, but this much is a good starting point.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK