### PR TITLE
Feat/userlog deep links

### DIFF
--- a/meteor/client/lib/datePicker.tsx
+++ b/meteor/client/lib/datePicker.tsx
@@ -27,6 +27,12 @@ export const DatePickerFromTo = withTranslation()(
 				dateTo: props.to ? new Date(props.to) : moment().startOf('day').toDate(),
 			}
 		}
+		static getDerivedStateFromProps(props: IProps): IState {
+			return {
+				dateFrom: props.from ? new Date(props.from) : moment().subtract(1, 'days').startOf('day').toDate(),
+				dateTo: props.to ? new Date(props.to) : moment().startOf('day').toDate(),
+			}
+		}
 		triggerOnchange = (state: IState) => {
 			this.props.onChange(state.dateFrom.valueOf(), state.dateTo.valueOf())
 		}

--- a/meteor/client/ui/Status/UserActivity.tsx
+++ b/meteor/client/ui/Status/UserActivity.tsx
@@ -7,6 +7,7 @@ import moment from 'moment'
 import { PubSub } from '../../../lib/api/pubsub'
 import { useTranslation } from 'react-i18next'
 import { parse as queryStringParse } from 'query-string'
+import { Link } from 'react-router-dom'
 
 const PARAM_DATE_FORMAT = 'YYYY-MM-DD'
 const PARAM_NAME_FROM_DATE = 'fromDate'
@@ -54,7 +55,9 @@ export function UserActionsList(props: IUserActionsListProps) {
 				{props.logItems.map((msg) => {
 					const formattedTimestamp = moment(msg.timestamp).format('YYYY/MM/DD HH:mm:ss.SSS')
 					const anchorId = `t${msg.timestamp}`
-					const selfLink = `${location.pathname}?${PARAM_NAME_FROM_DATE}=${props.startDate}#${anchorId}`
+					const selfLink = `${location.pathname}?${PARAM_NAME_FROM_DATE}=${moment(props.startDate).format(
+						PARAM_DATE_FORMAT
+					)}#${anchorId}`
 					return (
 						<tr
 							className={props.onItemClick ? 'clickable' : undefined}
@@ -62,36 +65,38 @@ export function UserActionsList(props: IUserActionsListProps) {
 							onClick={() => props.onItemClick && props.onItemClick(msg)}
 						>
 							<td className="user-action-log__timestamp">
-								<a id={anchorId} href={selfLink}>
+								<Link id={anchorId} to={selfLink}>
 									{formattedTimestamp}
-								</a>
+								</Link>
 							</td>
 							<td className="user-action-log__executionTime">
 								<table>
-									{msg.executionTime ? (
-										<tr>
-											<td>{t('Core')}:</td>
-											<td>{msg.executionTime} ms</td>
-										</tr>
-									) : null}
-									{msg.workerTime ? (
-										<tr>
-											<td>{t('Worker')}:</td>
-											<td>{msg.workerTime} ms</td>
-										</tr>
-									) : null}
-									{msg.gatewayDuration ? (
-										<tr>
-											<td>{t('Gateway')}:</td>
-											<td>{msg.gatewayDuration.join(', ')} ms</td>
-										</tr>
-									) : null}
-									{msg.timelineResolveDuration ? (
-										<tr>
-											<td>{t('TSR')}:</td>
-											<td>{msg.timelineResolveDuration.join(', ')} ms</td>
-										</tr>
-									) : null}
+									<tbody>
+										{msg.executionTime ? (
+											<tr>
+												<td>{t('Core')}:</td>
+												<td>{msg.executionTime} ms</td>
+											</tr>
+										) : null}
+										{msg.workerTime ? (
+											<tr>
+												<td>{t('Worker')}:</td>
+												<td>{msg.workerTime} ms</td>
+											</tr>
+										) : null}
+										{msg.gatewayDuration ? (
+											<tr>
+												<td>{t('Gateway')}:</td>
+												<td>{msg.gatewayDuration.join(', ')} ms</td>
+											</tr>
+										) : null}
+										{msg.timelineResolveDuration ? (
+											<tr>
+												<td>{t('TSR')}:</td>
+												<td>{msg.timelineResolveDuration.join(', ')} ms</td>
+											</tr>
+										) : null}
+									</tbody>
 								</table>
 							</td>
 							<td className="user-action-log__userId">{msg.userId}</td>
@@ -179,7 +184,7 @@ function UserActivity() {
 			targetElement.scrollIntoView()
 			setFound(true)
 		}
-	}, [!found])
+	}, [found, logItems.length])
 
 	return (
 		<div className="mhl gutter external-message-status">

--- a/meteor/client/ui/Status/UserActivity.tsx
+++ b/meteor/client/ui/Status/UserActivity.tsx
@@ -1,14 +1,11 @@
-import { Meteor } from 'meteor/meteor'
-import * as React from 'react'
-import { Translated, translateWithTracker } from '../../lib/ReactMeteorData/react-meteor-data'
+import React, { useEffect, useState, useLayoutEffect } from 'react'
+import { useSubscription, useTracker } from '../../lib/ReactMeteorData/react-meteor-data'
 import { Time, unprotectString } from '../../../lib/lib'
-import * as _ from 'underscore'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { UserActionsLog, UserActionsLogItem } from '../../../lib/collections/UserActionsLog'
 import { DatePickerFromTo } from '../../lib/datePicker'
 import moment from 'moment'
-import { PubSub, meteorSubscribe } from '../../../lib/api/pubsub'
-import { withTranslation } from 'react-i18next'
+import { PubSub } from '../../../lib/api/pubsub'
+import { useTranslation } from 'react-i18next'
 import { parse as queryStringParse } from 'query-string'
 
 const PARAM_DATE_FORMAT = 'YYYY-MM-DD'
@@ -29,110 +26,107 @@ function prettyPrintJsonString(str: string): string {
 	}
 }
 
-export const UserActionsList = withTranslation()(
-	class UserActionsList extends React.Component<Translated<IUserActionsListProps>> {
-		renderMessageHead() {
-			const { t } = this.props
-			return (
-				<thead>
-					<tr>
-						<th className="c3 user-action-log__timestamp">{t('Timestamp')}</th>
-						<th className="c3 user-action-log__executionTime">{t('Execution times')}</th>
-						<th className="c1 user-action-log__userId">{t('User ID')}</th>
-						<th className="c2 user-action-log__clientAddress">{t('Client IP')}</th>
-						<th className="c3 user-action-log__context">{t('Action')}</th>
-						<th className="c3 user-action-log__method">{t('Method')}</th>
-						<th className="c1 user-action-log__status">{t('Status')}</th>
-						<th className="c1 user-action-log__args">{t('Parameters')}</th>
-						{this.props.renderButtons ? <th className="c1 user-action-log__buttons"></th> : null}
-					</tr>
-				</thead>
-			)
-		}
+export function UserActionsList(props: IUserActionsListProps) {
+	const { t } = useTranslation()
 
-		render() {
-			const { t } = this.props
-			return (
-				<table className="table user-action-log">
-					{this.renderMessageHead()}
-					<tbody>
-						{_.map(this.props.logItems, (msg) => {
-							const formattedTimestamp = moment(msg.timestamp).format('YYYY/MM/DD HH:mm:ss.SSS')
-							const anchorId = `t${msg.timestamp}`
-							const selfLink = `${location.pathname}?${PARAM_NAME_FROM_DATE}=${this.props.startDate}#${anchorId}`
-							return (
-								<tr
-									className={this.props.onItemClick ? 'clickable' : undefined}
-									key={unprotectString(msg._id)}
-									onClick={() => this.props.onItemClick && this.props.onItemClick(msg)}
-								>
-									<td className="user-action-log__timestamp">
-										<a id={anchorId} href={selfLink}>
-											{formattedTimestamp}
-										</a>
-									</td>
-									<td className="user-action-log__executionTime">
-										<table>
-											{msg.executionTime ? (
-												<tr>
-													<td>{t('Core')}:</td>
-													<td>{msg.executionTime} ms</td>
-												</tr>
-											) : null}
-											{msg.workerTime ? (
-												<tr>
-													<td>{t('Worker')}:</td>
-													<td>{msg.workerTime} ms</td>
-												</tr>
-											) : null}
-											{msg.gatewayDuration ? (
-												<tr>
-													<td>{t('Gateway')}:</td>
-													<td>{msg.gatewayDuration.join(', ')} ms</td>
-												</tr>
-											) : null}
-											{msg.timelineResolveDuration ? (
-												<tr>
-													<td>{t('TSR')}:</td>
-													<td>{msg.timelineResolveDuration.join(', ')} ms</td>
-												</tr>
-											) : null}
-										</table>
-									</td>
-									<td className="user-action-log__userId">{msg.userId}</td>
-									<td className="user-action-log__clientAddress">{msg.clientAddress}</td>
-									<td className="user-action-log__context">{msg.context}</td>
-									<td className="user-action-log__method">{msg.method}</td>
-									<td className="user-action-log__status">
-										{msg.success ? 'Success' : msg.success === false ? 'Error: ' + msg.errorMessage : null}
-									</td>
-									<td className="user-action-log__args">{prettyPrintJsonString(msg.args)}</td>
-									{this.props.renderButtons ? (
-										<td className="user-action-log__buttons">{this.props.renderButtons(msg)}</td>
-									) : null}
-								</tr>
-							)
-						})}
-					</tbody>
-				</table>
-			)
-		}
+	function renderMessageHead() {
+		return (
+			<thead>
+				<tr>
+					<th className="c3 user-action-log__timestamp">{t('Timestamp')}</th>
+					<th className="c3 user-action-log__executionTime">{t('Execution times')}</th>
+					<th className="c1 user-action-log__userId">{t('User ID')}</th>
+					<th className="c2 user-action-log__clientAddress">{t('Client IP')}</th>
+					<th className="c3 user-action-log__context">{t('Action')}</th>
+					<th className="c3 user-action-log__method">{t('Method')}</th>
+					<th className="c1 user-action-log__status">{t('Status')}</th>
+					<th className="c1 user-action-log__args">{t('Parameters')}</th>
+					{props.renderButtons ? <th className="c1 user-action-log__buttons"></th> : null}
+				</tr>
+			</thead>
+		)
 	}
-)
 
-interface IUserActivityProps {}
-interface IUserActivityState {
-	dateFrom: Time
-	dateTo: Time
-}
-interface IUserActivityTrackedProps {
-	log: UserActionsLogItem[]
+	return (
+		<table className="table user-action-log">
+			{renderMessageHead()}
+			<tbody>
+				{props.logItems.map((msg) => {
+					const formattedTimestamp = moment(msg.timestamp).format('YYYY/MM/DD HH:mm:ss.SSS')
+					const anchorId = `t${msg.timestamp}`
+					const selfLink = `${location.pathname}?${PARAM_NAME_FROM_DATE}=${props.startDate}#${anchorId}`
+					return (
+						<tr
+							className={props.onItemClick ? 'clickable' : undefined}
+							key={unprotectString(msg._id)}
+							onClick={() => props.onItemClick && props.onItemClick(msg)}
+						>
+							<td className="user-action-log__timestamp">
+								<a id={anchorId} href={selfLink}>
+									{formattedTimestamp}
+								</a>
+							</td>
+							<td className="user-action-log__executionTime">
+								<table>
+									{msg.executionTime ? (
+										<tr>
+											<td>{t('Core')}:</td>
+											<td>{msg.executionTime} ms</td>
+										</tr>
+									) : null}
+									{msg.workerTime ? (
+										<tr>
+											<td>{t('Worker')}:</td>
+											<td>{msg.workerTime} ms</td>
+										</tr>
+									) : null}
+									{msg.gatewayDuration ? (
+										<tr>
+											<td>{t('Gateway')}:</td>
+											<td>{msg.gatewayDuration.join(', ')} ms</td>
+										</tr>
+									) : null}
+									{msg.timelineResolveDuration ? (
+										<tr>
+											<td>{t('TSR')}:</td>
+											<td>{msg.timelineResolveDuration.join(', ')} ms</td>
+										</tr>
+									) : null}
+								</table>
+							</td>
+							<td className="user-action-log__userId">{msg.userId}</td>
+							<td className="user-action-log__clientAddress">{msg.clientAddress}</td>
+							<td className="user-action-log__context">{msg.context}</td>
+							<td className="user-action-log__method">{msg.method}</td>
+							<td className="user-action-log__status">
+								{msg.success ? 'Success' : msg.success === false ? 'Error: ' + msg.errorMessage : null}
+							</td>
+							<td className="user-action-log__args">{prettyPrintJsonString(msg.args)}</td>
+							{props.renderButtons ? <td className="user-action-log__buttons">{props.renderButtons(msg)}</td> : null}
+						</tr>
+					)
+				})}
+			</tbody>
+		</table>
+	)
 }
 
-const UserActivity = translateWithTracker<IUserActivityProps, IUserActivityState, IUserActivityTrackedProps>(
-	(_props: IUserActivityProps) => {
-		return {
-			log: UserActionsLog.find(
+function UserActivity() {
+	const { t } = useTranslation()
+
+	const [dateFrom, setDateFrom] = useState<Time>(moment().startOf('day').valueOf())
+	const [dateTo, setDateTo] = useState<Time>(moment().add(1, 'days').startOf('day').valueOf())
+
+	useSubscription(PubSub.userActionsLog, {
+		timestamp: {
+			$gte: dateFrom,
+			$lt: dateTo,
+		},
+	})
+
+	const log = useTracker(
+		() =>
+			UserActionsLog.find(
 				{},
 				{
 					sort: {
@@ -140,98 +134,61 @@ const UserActivity = translateWithTracker<IUserActivityProps, IUserActivityState
 					},
 				}
 			).fetch(),
+		[],
+		[]
+	)
+
+	useEffect(() => {
+		const queryParams = queryStringParse(location.search, {
+			arrayFormat: 'comma',
+		})
+
+		const qsStartDate = moment(queryParams[PARAM_NAME_FROM_DATE], PARAM_DATE_FORMAT, true)
+
+		if (qsStartDate.isValid()) {
+			setDateFrom(qsStartDate.startOf('day').valueOf())
+			setDateTo(qsStartDate.add(1, 'days').startOf('day').valueOf())
 		}
+	}, [])
+
+	function onDateChange(from: Time, to: Time) {
+		setDateFrom(from)
+		setDateTo(to)
 	}
-)(
-	class UserActivity extends MeteorReactComponent<
-		Translated<IUserActivityProps & IUserActivityTrackedProps>,
-		IUserActivityState
-	> {
-		private _currentsub: string = ''
-		private _sub?: Meteor.SubscriptionHandle
-		constructor(props) {
-			super(props)
 
-			// use from and to from querystring if given
-			const queryParams = queryStringParse(location.search, {
-				arrayFormat: 'comma',
-			})
+	const logItems = log.filter(({ timestamp }) => timestamp >= dateFrom && timestamp < dateTo)
 
-			const qsStartDate = moment(queryParams[PARAM_NAME_FROM_DATE], PARAM_DATE_FORMAT, true)
-
-			if (qsStartDate.isValid()) {
-				this.state = {
-					dateFrom: qsStartDate.startOf('day').valueOf(),
-					dateTo: qsStartDate.add(1, 'days').startOf('day').valueOf(),
-				}
-			} else {
-				this.state = {
-					dateFrom: moment().startOf('day').valueOf(),
-					dateTo: moment().add(1, 'days').startOf('day').valueOf(),
-				}
-			}
-		}
-		componentDidMount() {
-			// Subscribe to data:
-			this.updateSubscription()
-		}
-		componentDidUpdate() {
-			this.updateSubscription()
-		}
-		updateSubscription() {
-			const h = this.state.dateFrom + '_' + this.state.dateTo
-			if (h !== this._currentsub) {
-				this._currentsub = h
-				if (this._sub) {
-					this._sub.stop()
-				}
-				this._sub = meteorSubscribe(PubSub.userActionsLog, {
-					timestamp: {
-						$gte: this.state.dateFrom,
-						$lt: this.state.dateTo,
-					},
-				})
-			}
-		}
-		componentWillUnmount() {
-			if (this._sub) {
-				this._sub.stop()
-			}
-			this._cleanUp()
-		}
-
-		handleChangeDate = (from: Time, to: Time) => {
-			this.setState({
-				dateFrom: from,
-				dateTo: to,
-			})
-		}
-
-		renderUserActivity() {
-			const { dateFrom, dateTo } = this.state
-			const logItems = this.props.log.filter(({ timestamp }) => timestamp >= dateFrom && timestamp < dateTo)
-
-			return (
-				<div>
-					<div className="paging">
-						<DatePickerFromTo from={dateFrom} to={dateTo} onChange={this.handleChangeDate} />
-					</div>
-					<UserActionsList logItems={logItems} startDate={dateFrom} />
+	function renderUserActivity() {
+		return (
+			<div>
+				<div className="paging">
+					<DatePickerFromTo from={dateFrom} to={dateTo} onChange={onDateChange} />
 				</div>
-			)
-		}
-
-		render() {
-			const { t } = this.props
-			return (
-				<div className="mhl gutter external-message-status">
-					<header className="mbs">
-						<h1>{t('User Activity Log')}</h1>
-					</header>
-					<div className="mod mvl">{this.renderUserActivity()}</div>
-				</div>
-			)
-		}
+				<UserActionsList logItems={logItems} startDate={dateFrom} />
+			</div>
+		)
 	}
-)
+
+	const [found, setFound] = useState(false)
+
+	useLayoutEffect(() => {
+		if (!found && logItems.length && location.hash) {
+			const targetId = location.hash.substring(1)
+			const targetElement = document.getElementById(targetId)
+			if (!targetElement) return
+			targetElement.scrollIntoView()
+			setFound(true)
+		}
+	}, [!found])
+
+	return (
+		<div className="mhl gutter external-message-status">
+			<header className="mbs">
+				<h1>{t('User Activity Log')}</h1>
+			</header>
+			<div className="mod mvl">{renderUserActivity()}</div>
+		</div>
+	)
+}
+
 export { UserActivity }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This change introduces direct deep links to individual user log lines, for easy referencing of specific log lines when reporting issues.

* **What is the new behavior (if this is a feature change)?**
All log lines will have self-links wrapping the log line timestamps. These links are generated as deep links, so that they can be shared/referenced in tasks.

To facilitate this it is now also possible to preset the start (from) date as a querystring parameter named `fromDate` (formatted as `YYYY-MM-DD`) rather than using the paging control on the page.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
