### PR TITLE
fix: expose versionExtended (git hash) in package.json on CI build

### DIFF
--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -125,6 +125,10 @@ jobs:
         if: ${{ steps.image-tags.outputs.images }}
         run: |
           yarn build:packages
+      - name: Persist Built Version information
+        if: ${{ steps.image-tags.outputs.images }}
+          cd meteor
+          yarn inject-git-hash
       - name: Meteor Build
         if: ${{ steps.image-tags.outputs.images }}
         run: |

--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -127,6 +127,7 @@ jobs:
           yarn build:packages
       - name: Persist Built Version information
         if: ${{ steps.image-tags.outputs.images }}
+        run: |
           cd meteor
           yarn inject-git-hash
       - name: Meteor Build

--- a/meteor/Dockerfile
+++ b/meteor/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /opt/core/meteor
 RUN meteor --version --allow-superuser
 RUN meteor npm install -g yarn
 RUN meteor yarn install
+RUN meteor yarn run inject-git-hash
 # Restore the NODE_ENV variable:
 ENV NODE_ENV $NODE_ENV_TMP
 RUN --mount=type=cache,target=/opt/core/meteor/.meteor/local NODE_OPTIONS="--max-old-space-size=4096" METEOR_DEBUG_BUILD=1 meteor build --allow-superuser --directory /opt/

--- a/meteor/client/styles/rundownListFooter.scss
+++ b/meteor/client/styles/rundownListFooter.scss
@@ -1,0 +1,6 @@
+.version-info {
+	abbr {
+		text-decoration: none;
+		border-bottom: none;
+	}
+}

--- a/meteor/client/styles/rundownListFooter.scss
+++ b/meteor/client/styles/rundownListFooter.scss
@@ -1,6 +1,0 @@
-.version-info {
-	abbr {
-		text-decoration: none;
-		border-bottom: none;
-	}
-}

--- a/meteor/client/ui/RundownList/RundownListFooter.tsx
+++ b/meteor/client/ui/RundownList/RundownListFooter.tsx
@@ -19,8 +19,8 @@ export function RundownListFooter({ systemStatus }: IProps) {
 
 	return (
 		<div className="mtl gutter version-info">
-			<p data-version-extended={versionExtended}>
-				{t('Sofie Automation')} {t('version')}: {version}
+			<p>
+				{t('Sofie Automation')} {t('version')}: <abbr title={versionExtended}>{version}</abbr>
 			</p>
 			<div className="mod">
 				{systemStatus ? (

--- a/meteor/client/ui/RundownList/RundownListFooter.tsx
+++ b/meteor/client/ui/RundownList/RundownListFooter.tsx
@@ -2,62 +2,54 @@ import React from 'react'
 import Tooltip from 'rc-tooltip'
 import { getHelpMode } from '../../lib/localStorage'
 import { StatusResponse } from '../../../lib/api/systemStatus'
-import { withTranslation } from 'react-i18next'
-import { Translated } from '../../lib/ReactMeteorData/ReactMeteorData'
 import { TOOLTIP_DEFAULT_DELAY } from '../../lib/lib'
+import { useTranslation } from 'react-i18next'
 
-const PackageInfo = require('../../../package.json')
+const PackageInfo = require('../../../package.json') as Record<string, any>
 
-interface IRundownListFooterProps {
+interface IProps {
 	systemStatus: StatusResponse
 }
 
-export const RundownListFooter = withTranslation()(
-	class RundownListFooter extends React.Component<Translated<IRundownListFooterProps>> {
-		constructor(props: Translated<IRundownListFooterProps>) {
-			super(props)
-		}
+export function RundownListFooter({ systemStatus }: IProps) {
+	const { t } = useTranslation()
 
-		render() {
-			const { systemStatus, t } = this.props
+	const version = PackageInfo.version || 'UNSTABLE'
+	const versionExtended = PackageInfo.versionExtended || version
 
-			return (
-				<div className="mtl gutter version-info">
-					<p>
-						{t('Sofie Automation')} {t('version')}: {PackageInfo.versionExtended || PackageInfo.version || 'UNSTABLE'}
-					</p>
-					<div className="mod">
-						{systemStatus ? (
-							<React.Fragment>
-								<div>
-									{t('System Status')}:&nbsp;
-									<Tooltip
-										overlay={t('System has issues which need to be resolved')}
-										mouseEnterDelay={TOOLTIP_DEFAULT_DELAY}
-										visible={systemStatus.status === 'FAIL' && getHelpMode()}
-										placement="top"
-									>
-										<span>{systemStatus.status}</span>
-									</Tooltip>
-									&nbsp;/&nbsp;{systemStatus._internal.statusCodeString}
-								</div>
-								<div>
-									{systemStatus._internal.messages.length ? (
-										<div>
-											{t('Status Messages:')}
-											<ul>
-												{systemStatus._internal.messages.map((message, i) => {
-													return <li key={i}>{message}</li>
-												})}
-											</ul>
-										</div>
-									) : null}
-								</div>
-							</React.Fragment>
+	return (
+		<div className="mtl gutter version-info">
+			<p data-version-extended={versionExtended}>
+				{t('Sofie Automation')} {t('version')}: {version}
+			</p>
+			<div className="mod">
+				{systemStatus ? (
+					<>
+						<div>
+							{t('System Status')}:&nbsp;
+							<Tooltip
+								overlay={t('System has issues which need to be resolved')}
+								mouseEnterDelay={TOOLTIP_DEFAULT_DELAY}
+								visible={systemStatus.status === 'FAIL' && getHelpMode()}
+								placement="top"
+							>
+								<span>{systemStatus.status}</span>
+							</Tooltip>
+							&nbsp;/&nbsp;{systemStatus._internal.statusCodeString}
+						</div>
+						{systemStatus._internal.messages.length ? (
+							<div>
+								{t('Status Messages:')}
+								<ul>
+									{systemStatus._internal.messages.map((message, i) => {
+										return <li key={i}>{message}</li>
+									})}
+								</ul>
+							</div>
 						) : null}
-					</div>
-				</div>
-			)
-		}
-	}
-)
+					</>
+				) : null}
+			</div>
+		</div>
+	)
+}

--- a/meteor/client/ui/RundownList/RundownListFooter.tsx
+++ b/meteor/client/ui/RundownList/RundownListFooter.tsx
@@ -20,7 +20,10 @@ export function RundownListFooter({ systemStatus }: IProps) {
 	return (
 		<div className="mtl gutter version-info">
 			<p>
-				{t('Sofie Automation')} {t('version')}: <abbr title={versionExtended}>{version}</abbr>
+				{t('Sofie Automation')} {t('version')}:&nbsp;
+				<Tooltip overlay={versionExtended} placement="top" mouseEnterDelay={1}>
+					<span>{version}</span>
+				</Tooltip>
 			</p>
 			<div className="mod">
 				{systemStatus ? (

--- a/meteor/package.json
+++ b/meteor/package.json
@@ -12,6 +12,7 @@
 		"libs:syncVersionsAndChangelogs": "cd ../packages && yarn sync-version-and-changelog",
 		"postinstall": "meteor yarn prepareForTest",
 		"prepareForTest": "node ../scripts/fixTestFibers.js",
+		"inject-git-hash": "node ./scripts/generate-version-file.js",
 		"unit": "jest",
 		"unitci": "jest --maxWorkers 2 --coverage",
 		"unitcov": "jest --coverage",

--- a/meteor/scripts/generate-version-file.js
+++ b/meteor/scripts/generate-version-file.js
@@ -11,14 +11,15 @@ const pkg = JSON.parse(fs.readFileSync(pkgPath))
 ;(async () => {
 	const commitTime = await simpleGit.raw(['log', '-1', '--pretty=format:%ct', 'HEAD'])
 	const dateStr = moment(parseInt(commitTime, 10) * 1000).format('YYYYMMDD-HHmm')
+	const commitHash = await simpleGit.revparse(['--short', 'HEAD'])
+	const branch = (await simpleGit.raw(['rev-parse', '--abbrev-ref', 'HEAD'])).trim()
+
+	const isRelease = branch === 'main' || branch === 'master' // Support "main" for future-compat
 
 	if (isRelease) {
-		const commitHash = await simpleGit.revparse(['--short', 'HEAD'])
 		pkg.versionExtended = `${pkg.version}+g${commitHash}-${dateStr}`
 	} else {
-		const versionStr = await simpleGit.raw(['describe', '--always'])
-		const branch = await simpleGit.raw(['rev-parse', '--abbrev-ref', 'HEAD'])
-		pkg.versionExtended = `${pkg.version}+${branch.trim()}-${versionStr.trim()}-${dateStr}`
+		pkg.versionExtended = `${pkg.version}+${branch.trim()}-g${commitHash}-${dateStr}`
 	}
 
 	console.log('Version:', pkg.versionExtended)

--- a/meteor/server/api/snapshot.ts
+++ b/meteor/server/api/snapshot.ts
@@ -97,6 +97,8 @@ import {
 import { PackageInfoDB, PackageInfos } from '../../lib/collections/PackageInfos'
 import { checkStudioExists } from '../../lib/collections/optimizations'
 
+const PackageInfo = require('../../package.json') as Record<string, any>
+
 interface DeprecatedRundownSnapshot {
 	// Old, from the times before rundownPlaylists
 	version: string
@@ -118,6 +120,7 @@ interface DeprecatedRundownSnapshot {
 
 interface RundownPlaylistSnapshot {
 	version: string
+	versionExtended?: string
 	playlistId: RundownPlaylistId
 	snapshot: SnapshotRundownPlaylist
 	playlist: DBRundownPlaylist
@@ -145,6 +148,7 @@ interface RundownPlaylistSnapshot {
 }
 interface SystemSnapshot {
 	version: string
+	versionExtended?: string
 	studioId: StudioId | null
 	snapshot: SnapshotSystem
 	studios: Array<Studio>
@@ -159,6 +163,7 @@ interface SystemSnapshot {
 }
 interface DebugSnapshot {
 	version: string
+	versionExtended?: string
 	studioId?: StudioId
 	snapshot: SnapshotDebug
 	system: SystemSnapshot
@@ -261,6 +266,7 @@ async function createRundownPlaylistSnapshot(
 	logger.info(`Snapshot generation done`)
 	return {
 		version: CURRENT_SYSTEM_VERSION,
+		versionExtended: PackageInfo.versionExtended || PackageInfo.version || 'UNKNOWN',
 		playlistId,
 		snapshot: {
 			_id: snapshotId,
@@ -378,6 +384,7 @@ async function createSystemSnapshot(
 	logger.info(`Snapshot generation done`)
 	return {
 		version: CURRENT_SYSTEM_VERSION,
+		versionExtended: PackageInfo.versionExtended || PackageInfo.version || 'UNKNOWN',
 		studioId: studioId,
 		snapshot: {
 			_id: snapshotId,
@@ -456,6 +463,7 @@ async function createDebugSnapshot(studioId: StudioId, organizationId: Organizat
 	logger.info(`Snapshot generation done`)
 	return {
 		version: CURRENT_SYSTEM_VERSION,
+		versionExtended: PackageInfo.versionExtended || PackageInfo.version || 'UNKNOWN',
 		studioId: studioId,
 		snapshot: {
 			_id: snapshotId,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix: Brings back a broken pipeline feature where the githash would be included in the `package.json` file under `versionExtended` key.

* **What is the current behavior?** (You can also link to an open issue here)

There is no `versionExtended` key in `package.json`

* **What is the new behavior (if this is a feature change)?**

There is a `versionExtended` key in `package.json`. Also, the extended version string (with git hash) is presented in the User Interface, if you hover over the version number.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
