### PR TITLE
fix: RundownView now uses TriggersHandler with detached Shelfs.

### DIFF
--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1156,7 +1156,6 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 	let currentPartInstance: PartInstance | undefined
 	let nextPartInstance: PartInstance | undefined
 	let currentRundown: Rundown | undefined = undefined
-
 	if (playlist) {
 		studio = Studios.findOne({ _id: playlist.studioId })
 		rundowns = memoizedIsolatedAutorun(
@@ -2951,6 +2950,25 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 							shelfDisplayOptions={this.props.shelfDisplayOptions}
 							bucketDisplayFilter={this.props.bucketDisplayFilter}
 						/>
+					</ErrorBoundary>
+					<ErrorBoundary>
+						<SorensenContext.Consumer>
+							{(sorensen) =>
+								sorensen && (
+									<TriggersHandler
+										rundownPlaylistId={this.props.rundownPlaylistId}
+										showStyleBaseId={this.props.showStyleBase!._id}
+										currentRundownId={this.props.currentRundown?._id || null}
+										currentPartId={this.props.currentPartInstance?.part._id || null}
+										nextPartId={this.props.nextPartInstance?.part._id || null}
+										currentSegmentPartIds={this.props.currentSegmentPartIds}
+										nextSegmentPartIds={this.props.nextSegmentPartIds}
+										sorensen={sorensen}
+										global={this.isHotkeyAllowed}
+									/>
+								)
+							}
+						</SorensenContext.Consumer>
 					</ErrorBoundary>
 				</RundownTimingProvider>
 			)

--- a/meteor/client/ui/Shelf/Shelf.tsx
+++ b/meteor/client/ui/Shelf/Shelf.tsx
@@ -24,6 +24,7 @@ import { ContextMenuTrigger } from '@jstarpl/react-contextmenu'
 import { ShelfInspector } from './Inspector/ShelfInspector'
 import { Studio } from '../../../lib/collections/Studios'
 import RundownViewEventBus, {
+	IEventContext,
 	RundownViewEvents,
 	SelectPieceEvent,
 	ShelfStateEvent,
@@ -123,6 +124,10 @@ export class ShelfBase extends React.Component<Translated<IShelfProps>, IState> 
 		}
 	}
 
+	onTake = (e: IEventContext) => {
+		this.take(e.context)
+	}
+
 	take = (e: any) => {
 		const { t } = this.props
 		if (this.props.studioMode) {
@@ -138,12 +143,20 @@ export class ShelfBase extends React.Component<Translated<IShelfProps>, IState> 
 		RundownViewEventBus.on(RundownViewEvents.SWITCH_SHELF_TAB, this.onSwitchShelfTab)
 		RundownViewEventBus.on(RundownViewEvents.SELECT_PIECE, this.onSelectPiece)
 		RundownViewEventBus.on(RundownViewEvents.SHELF_STATE, this.onShelfStateChange)
+
+		if (this.props.fullViewport) {
+			RundownViewEventBus.on(RundownViewEvents.TAKE, this.onTake)
+		}
 	}
 
 	componentWillUnmount() {
 		RundownViewEventBus.off(RundownViewEvents.SWITCH_SHELF_TAB, this.onSwitchShelfTab)
 		RundownViewEventBus.off(RundownViewEvents.SELECT_PIECE, this.onSelectPiece)
 		RundownViewEventBus.off(RundownViewEvents.SHELF_STATE, this.onShelfStateChange)
+
+		if (this.props.fullViewport) {
+			RundownViewEventBus.off(RundownViewEvents.TAKE, this.onTake)
+		}
 	}
 
 	componentDidUpdate(prevProps: IShelfProps, prevState: IState) {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Prior to action triggers, shortcuts could be triggered with `onlyShelf`, but with action triggers shortcuts aren't triggered in, the equivalent, detached shelfs, since there are no TriggersHandler being instantiated for this case.


* **What is the new behavior (if this is a feature change)?**
Shortcuts are triggered in detached shelfs, due to an instantiated TriggersHandler.
Currently the only soft action that the detached shelf listens for is soft take.


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
