### PR TITLE
fix(Prompter): If collection changes are slow, Prompter may receive incomplete updates, and render some Script missing

### DIFF
--- a/meteor/client/ui/Prompter/PrompterView.tsx
+++ b/meteor/client/ui/Prompter/PrompterView.tsx
@@ -26,6 +26,10 @@ import { StudioScreenSaver } from '../StudioScreenSaver/StudioScreenSaver'
 import { RundownTimingProvider } from '../RundownView/RundownTiming/RundownTimingProvider'
 import { OverUnderTimer } from './OverUnderTimer'
 import { Rundown, Rundowns } from '../../../lib/collections/Rundowns'
+import { PieceId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+
+const DEFAULT_UPDATE_THROTTLE = 250 //ms
+const PIECE_MISSING_UPDATE_THROTTLE = 2000 //ms
 
 interface PrompterConfig {
 	mirror?: boolean
@@ -696,9 +700,45 @@ export const Prompter = translateWithTracker<IPrompterProps, {}, IPrompterTracke
 			}
 		}
 
-		shouldComponentUpdate(_nextProps, _nextState): boolean {
+		shouldComponentUpdate(nextProps: Translated<IPrompterProps & IPrompterTrackedProps>): boolean {
+			const { prompterData } = this.props
+			const { prompterData: nextPrompterData } = nextProps
+
+			const currentPrompterPieces = _.flatten(
+				prompterData?.segments.map((segment) =>
+					segment.parts.map((part) =>
+						// collect all the PieceId's of all the non-empty pieces of script
+						_.compact(part.pieces.map((dataPiece) => (dataPiece.text !== '' ? dataPiece.id : null)))
+					)
+				) ?? []
+			) as PieceId[]
+			const nextPrompterPieces = _.flatten(
+				nextPrompterData?.segments.map((segment) =>
+					segment.parts.map((part) =>
+						// collect all the PieceId's of all the non-empty pieces of script
+						_.compact(part.pieces.map((dataPiece) => (dataPiece.text !== '' ? dataPiece.id : null)))
+					)
+				) ?? []
+			) as PieceId[]
+
+			// Flag for marking that a Piece is going missing during the update (was present in prompterData)
+			// no longer present in nextPrompterData
+			let missingPiece = false
+			for (const pieceId of currentPrompterPieces) {
+				if (!nextPrompterPieces.includes(pieceId)) {
+					missingPiece = true
+					break
+				}
+			}
+
+			// Default delay for updating the prompter (for providing stability/batching the updates)
+			let delay = DEFAULT_UPDATE_THROTTLE
+			// If a Piece has gone missing, delay the update by up to 3 seconds, so that it has a chance to stream in.
+			// When the Piece streams in, shouldComponentUpdate will run again, and then, if the piece is available
+			// we will use the shorter value and update sooner
+			if (missingPiece) delay = PIECE_MISSING_UPDATE_THROTTLE
 			clearTimeout(this._debounceUpdate)
-			this._debounceUpdate = setTimeout(() => this.forceUpdate(), 250)
+			this._debounceUpdate = setTimeout(() => this.forceUpdate(), delay)
 			return false
 		}
 

--- a/meteor/client/ui/Prompter/PrompterView.tsx
+++ b/meteor/client/ui/Prompter/PrompterView.tsx
@@ -721,8 +721,8 @@ export const Prompter = translateWithTracker<IPrompterProps, {}, IPrompterTracke
 				) ?? []
 			) as PieceId[]
 
-			// Flag for marking that a Piece is going missing during the update (was present in prompterData)
-			// no longer present in nextPrompterData
+			// Flag for marking that a Piece is going missing during the update (was present in prompterData
+			// no longer present in nextPrompterData)
 			let missingPiece = false
 			for (const pieceId of currentPrompterPieces) {
 				if (!nextPrompterPieces.includes(pieceId)) {
@@ -733,7 +733,7 @@ export const Prompter = translateWithTracker<IPrompterProps, {}, IPrompterTracke
 
 			// Default delay for updating the prompter (for providing stability/batching the updates)
 			let delay = DEFAULT_UPDATE_THROTTLE
-			// If a Piece has gone missing, delay the update by up to 3 seconds, so that it has a chance to stream in.
+			// If a Piece has gone missing, delay the update by up to 2 seconds, so that it has a chance to stream in.
 			// When the Piece streams in, shouldComponentUpdate will run again, and then, if the piece is available
 			// we will use the shorter value and update sooner
 			if (missingPiece) delay = PIECE_MISSING_UPDATE_THROTTLE

--- a/meteor/lib/api/prompter.ts
+++ b/meteor/lib/api/prompter.ts
@@ -3,7 +3,7 @@ import { check } from '../../lib/check'
 import * as _ from 'underscore'
 import { ISourceLayer, ScriptContent, SourceLayerType } from '@sofie-automation/blueprints-integration'
 import { RundownPlaylists, RundownPlaylistId, RundownPlaylistCollectionUtil } from '../collections/RundownPlaylists'
-import { getRandomId, normalizeArray, normalizeArrayToMap } from '../lib'
+import { normalizeArray, normalizeArrayToMap, protectString } from '../lib'
 import { SegmentId } from '../collections/Segments'
 import { Piece, PieceId, Pieces } from '../collections/Pieces'
 import { getPieceInstancesForPartInstance, getSegmentsWithPartInstances } from '../Rundown'
@@ -231,7 +231,7 @@ export namespace PrompterAPI {
 				if (partData.pieces.length === 0) {
 					// insert an empty line
 					partData.pieces.push({
-						id: getRandomId(),
+						id: protectString(`part_${partData.id}_empty`),
 						text: '',
 					})
 				}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

In non-ideal network situations, it's possible that the Piece/PieceInstance collection updates will not stream at once into the Prompter. If that takes more than 250 ms, then the prompter will update once (without a Piece of script) and then once again (with a Piece of Script shown again).

* **What is the new behavior (if this is a feature change)?**

This change introduces an alternative timer that, if a Script Piece is not present in an update, a 2s delay will wait for that Script Piece to re-appear, before rendering it gone. This in turn, should prevent the Prompter scroll position locking to lock to a new Piece, because the old Piece was gone for a second.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
