### PR TITLE
Chore: code standard preset update

### DIFF
--- a/meteor/client/ui/Settings/ConfigManifestSettings.tsx
+++ b/meteor/client/ui/Settings/ConfigManifestSettings.tsx
@@ -106,7 +106,6 @@ function getEditAttribute<DBInterface extends { _id: ProtectedString<any> }>(
 					}
 				/>
 			)
-		case ConfigManifestEntryType.NUMBER:
 		case ConfigManifestEntryType.INT:
 			return (
 				<EditAttribute
@@ -412,7 +411,6 @@ export class ConfigManifestTable<
 						} else {
 							return (a as string).localeCompare(b as string)
 						}
-					case ConfigManifestEntryType.NUMBER:
 					case ConfigManifestEntryType.INT:
 					case ConfigManifestEntryType.FLOAT:
 						return (a as number) - (b as number)
@@ -438,7 +436,6 @@ export class ConfigManifestTable<
 										<th key={col.id}>
 											<span title={col.description}>{col.name} </span>
 											{(col.type === ConfigManifestEntryType.STRING ||
-												col.type === ConfigManifestEntryType.NUMBER ||
 												col.type === ConfigManifestEntryType.INT ||
 												col.type === ConfigManifestEntryType.FLOAT) && (
 												<button
@@ -682,7 +679,6 @@ export class ConfigManifestSettings<
 				) : (
 					value.toString()
 				)
-			case ConfigManifestEntryType.NUMBER:
 			case ConfigManifestEntryType.INT:
 				return _.isNumber(value) && item.zeroBased ? (value + 1).toString() : value.toString()
 			default:

--- a/meteor/package.json
+++ b/meteor/package.json
@@ -113,7 +113,7 @@
 	"devDependencies": {
 		"@babel/core": "^7.17.12",
 		"@babel/plugin-transform-modules-commonjs": "^7.17.12",
-		"@sofie-automation/code-standard-preset": "~2.0.1",
+		"@sofie-automation/code-standard-preset": "~2.0.2",
 		"@types/app-root-path": "^1.2.4",
 		"@types/body-parser": "^1.19.2",
 		"@types/classnames": "^2.3.1",

--- a/meteor/yarn.lock
+++ b/meteor/yarn.lock
@@ -1147,13 +1147,13 @@
   version "0.0.0"
   uid ""
 
-"@sofie-automation/code-standard-preset@~2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@sofie-automation/code-standard-preset/-/code-standard-preset-2.0.1.tgz#0b0a4e05fb24ddd44303505cf184876ae7e941be"
-  integrity sha512-VasJgINuSyJ5nGl+P2FxNDpZalW17urgdFprWlag2Xxl9KDR9RrkHe53xeiCE2+ZClSBNSeMCg1xtsFUkYA9gg==
+"@sofie-automation/code-standard-preset@~2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@sofie-automation/code-standard-preset/-/code-standard-preset-2.0.2.tgz#e2bff6e75bd7cd8638fc624a40aea087fddb3a7b"
+  integrity sha512-ksQ8feMBxDVjZACMQhP5Irebjwde6OaS9mAASicS2MNs9VEaltl4sgwlbYIL5jkxISrdzvLiYk2PtdWm4rJHew==
   dependencies:
-    "@typescript-eslint/eslint-plugin" "^5.12.0"
-    "@typescript-eslint/parser" "^5.12.0"
+    "@typescript-eslint/eslint-plugin" "^5.24.0"
+    "@typescript-eslint/parser" "^5.24.0"
     eslint "^8.9.0"
     eslint-config-prettier "^8.3.0"
     eslint-plugin-jest "^26.1.1"
@@ -1517,7 +1517,7 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^5.12.0":
+"@typescript-eslint/eslint-plugin@^5.24.0":
   version "5.25.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.25.0.tgz#e8ce050990e4d36cc200f2de71ca0d3eb5e77a31"
   integrity sha512-icYrFnUzvm+LhW0QeJNKkezBu6tJs9p/53dpPLFH8zoM9w1tfaKzVurkPotEpAqQ8Vf8uaFyL5jHd0Vs6Z0ZQg==
@@ -1532,7 +1532,7 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/parser@^5.12.0":
+"@typescript-eslint/parser@^5.24.0":
   version "5.25.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.25.0.tgz#fb533487147b4b9efd999a4d2da0b6c263b64f7f"
   integrity sha512-r3hwrOWYbNKP1nTcIw/aZoH+8bBnh/Lh1iDHoFpyG4DnCpvEdctrSl6LOo19fZbzypjQMHdajolxs6VpYoChgA==

--- a/packages/blueprints-integration/src/config.ts
+++ b/packages/blueprints-integration/src/config.ts
@@ -5,8 +5,6 @@ import { SourceLayerType } from './content'
 export enum ConfigManifestEntryType {
 	STRING = 'string',
 	MULTILINE_STRING = 'multiline_string',
-	/** @deprecated use INT/FLOAT instead */
-	NUMBER = 'number',
 	INT = 'int',
 	FLOAT = 'float',
 	BOOLEAN = 'boolean',
@@ -21,7 +19,6 @@ export enum ConfigManifestEntryType {
 export type BasicConfigManifestEntry =
 	| ConfigManifestEntryString
 	| ConfigManifestEntryMultilineString
-	| ConfigManifestEntryNumber
 	| ConfigManifestEntryInt
 	| ConfigManifestEntryFloat
 	| ConfigManifestEntryBoolean
@@ -54,15 +51,6 @@ export interface ConfigManifestEntryString extends ConfigManifestEntryBase {
 export interface ConfigManifestEntryMultilineString extends ConfigManifestEntryBase {
 	type: ConfigManifestEntryType.MULTILINE_STRING
 	defaultVal: string[]
-}
-/** @deprecated use INT/FLOAT instead */
-export interface ConfigManifestEntryNumber extends ConfigManifestEntryBase {
-	type: ConfigManifestEntryType.NUMBER
-	defaultVal: number
-	/** Zero-based values will be stored in the database (and reported to blueprints) as values starting from 0, however,
-	 * 	when rendered in settings pages they will appear as value + 1
-	 */
-	zeroBased?: boolean
 }
 export interface ConfigManifestEntryInt extends ConfigManifestEntryBase {
 	type: ConfigManifestEntryType.INT

--- a/packages/corelib/src/deviceConfig.ts
+++ b/packages/corelib/src/deviceConfig.ts
@@ -42,8 +42,6 @@ export enum ConfigManifestEntryType {
 	STRING = 'string',
 	MULTILINE_STRING = 'multiline_string',
 	BOOLEAN = 'boolean',
-	/** @deprecated use INT/FLOAT instead */
-	NUMBER = 'float',
 	FLOAT = 'float',
 	INT = 'int',
 	TABLE = 'table',

--- a/packages/package.json
+++ b/packages/package.json
@@ -37,7 +37,7 @@
 	"devDependencies": {
 		"@babel/core": "^7.17.12",
 		"@babel/plugin-transform-modules-commonjs": "^7.17.12",
-		"@sofie-automation/code-standard-preset": "~2.0.1",
+		"@sofie-automation/code-standard-preset": "~2.0.2",
 		"@types/amqplib": "^0.5.17",
 		"@types/debug": "^4.1.7",
 		"@types/ejson": "^2.2.0",

--- a/packages/playout-gateway/src/configManifest.ts
+++ b/packages/playout-gateway/src/configManifest.ts
@@ -156,7 +156,7 @@ const PLAYOUT_SUBDEVICE_CONFIG: ImplementedSubDeviceConfig = {
 		{
 			id: 'options.faderThreshold',
 			name: 'Fader cutoff value',
-			type: ConfigManifestEntryType.NUMBER,
+			type: ConfigManifestEntryType.INT,
 			placeholder: '-60',
 		},
 	],
@@ -202,7 +202,7 @@ const PLAYOUT_SUBDEVICE_CONFIG: ImplementedSubDeviceConfig = {
 					{
 						id: 'temporalPriority',
 						name: 'Temporal Priority',
-						type: ConfigManifestEntryType.NUMBER,
+						type: ConfigManifestEntryType.INT,
 					},
 					{
 						id: 'queueId',
@@ -242,7 +242,7 @@ const PLAYOUT_SUBDEVICE_CONFIG: ImplementedSubDeviceConfig = {
 					{
 						id: 'temporalPriority',
 						name: 'Temporal Priority',
-						type: ConfigManifestEntryType.NUMBER,
+						type: ConfigManifestEntryType.INT,
 					},
 					{
 						id: 'queueId',
@@ -259,7 +259,7 @@ const PLAYOUT_SUBDEVICE_CONFIG: ImplementedSubDeviceConfig = {
 		{
 			id: 'options.minRecordingTime',
 			name: 'Minimum recording time',
-			type: ConfigManifestEntryType.NUMBER,
+			type: ConfigManifestEntryType.INT,
 		},
 	],
 	[TSRDeviceType.PHAROS]: [
@@ -297,7 +297,7 @@ const PLAYOUT_SUBDEVICE_CONFIG: ImplementedSubDeviceConfig = {
 		{
 			id: 'options.expectedHttpResponse',
 			name: 'Expected HTTP Response',
-			type: ConfigManifestEntryType.NUMBER,
+			type: ConfigManifestEntryType.INT,
 		},
 		{
 			id: 'options.keyword',
@@ -307,7 +307,7 @@ const PLAYOUT_SUBDEVICE_CONFIG: ImplementedSubDeviceConfig = {
 		{
 			id: 'options.interval',
 			name: 'Interval',
-			type: ConfigManifestEntryType.NUMBER,
+			type: ConfigManifestEntryType.INT,
 		},
 	],
 	[TSRDeviceType.SISYFOS]: [...PLAYOUT_SUBDEVICE_COMMON, ...PLAYOUT_SUBDEVICE_HOST_PORT],
@@ -336,7 +336,7 @@ const PLAYOUT_SUBDEVICE_CONFIG: ImplementedSubDeviceConfig = {
 		{
 			id: 'options.serverId',
 			name: 'Quantel Server ID',
-			type: ConfigManifestEntryType.NUMBER,
+			type: ConfigManifestEntryType.INT,
 		},
 		{
 			id: 'options.allowCloneClips',
@@ -350,12 +350,12 @@ const PLAYOUT_SUBDEVICE_CONFIG: ImplementedSubDeviceConfig = {
 		{
 			id: 'options.restPort',
 			name: '(Optional) REST port',
-			type: ConfigManifestEntryType.NUMBER,
+			type: ConfigManifestEntryType.INT,
 		},
 		{
 			id: 'options.wsPort',
 			name: '(Optional) Websocket port',
-			type: ConfigManifestEntryType.NUMBER,
+			type: ConfigManifestEntryType.INT,
 		},
 		{
 			id: 'options.engineRestPort',
@@ -505,7 +505,7 @@ const MAPPING_MANIFEST: ImplementedMappingsManifest = {
 		{
 			id: 'options.retryInterval',
 			name: 'Media retry interval (ms), -1 disables, 0 default',
-			type: ConfigManifestEntryType.NUMBER,
+			type: ConfigManifestEntryType.INT,
 		},
 	],
 	[TSRDeviceType.HYPERDECK]: [
@@ -537,7 +537,7 @@ const MAPPING_MANIFEST: ImplementedMappingsManifest = {
 		},
 		{
 			id: 'priority',
-			type: ConfigManifestEntryType.NUMBER,
+			type: ConfigManifestEntryType.INT,
 			name: 'Priority',
 		},
 	],

--- a/packages/server-core-integration/src/lib/configManifest.ts
+++ b/packages/server-core-integration/src/lib/configManifest.ts
@@ -45,8 +45,6 @@ export enum ConfigManifestEntryType {
 	STRING = 'string',
 	MULTILINE_STRING = 'multiline_string',
 	BOOLEAN = 'boolean',
-	/** @deprecated use INT/FLOAT instead */
-	NUMBER = 'float',
 	FLOAT = 'float',
 	INT = 'int',
 	TABLE = 'table',

--- a/packages/yarn.lock
+++ b/packages/yarn.lock
@@ -2936,13 +2936,13 @@
     tslib "^2.4.0"
     type-fest "^2.12.2"
 
-"@sofie-automation/code-standard-preset@~2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@sofie-automation/code-standard-preset/-/code-standard-preset-2.0.1.tgz#0b0a4e05fb24ddd44303505cf184876ae7e941be"
-  integrity sha512-VasJgINuSyJ5nGl+P2FxNDpZalW17urgdFprWlag2Xxl9KDR9RrkHe53xeiCE2+ZClSBNSeMCg1xtsFUkYA9gg==
+"@sofie-automation/code-standard-preset@~2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@sofie-automation/code-standard-preset/-/code-standard-preset-2.0.2.tgz#e2bff6e75bd7cd8638fc624a40aea087fddb3a7b"
+  integrity sha512-ksQ8feMBxDVjZACMQhP5Irebjwde6OaS9mAASicS2MNs9VEaltl4sgwlbYIL5jkxISrdzvLiYk2PtdWm4rJHew==
   dependencies:
-    "@typescript-eslint/eslint-plugin" "^5.12.0"
-    "@typescript-eslint/parser" "^5.12.0"
+    "@typescript-eslint/eslint-plugin" "^5.24.0"
+    "@typescript-eslint/parser" "^5.24.0"
     eslint "^8.9.0"
     eslint-config-prettier "^8.3.0"
     eslint-plugin-jest "^26.1.1"
@@ -3671,7 +3671,7 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^5.12.0":
+"@typescript-eslint/eslint-plugin@^5.24.0":
   version "5.25.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.25.0.tgz#e8ce050990e4d36cc200f2de71ca0d3eb5e77a31"
   integrity sha512-icYrFnUzvm+LhW0QeJNKkezBu6tJs9p/53dpPLFH8zoM9w1tfaKzVurkPotEpAqQ8Vf8uaFyL5jHd0Vs6Z0ZQg==
@@ -3686,7 +3686,7 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/parser@^5.12.0":
+"@typescript-eslint/parser@^5.24.0":
   version "5.25.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.25.0.tgz#fb533487147b4b9efd999a4d2da0b6c263b64f7f"
   integrity sha512-r3hwrOWYbNKP1nTcIw/aZoH+8bBnh/Lh1iDHoFpyG4DnCpvEdctrSl6LOo19fZbzypjQMHdajolxs6VpYoChgA==


### PR DESCRIPTION
This PR updates the code-standard-preset dependency, and as a consequence from this, a deprecated enum (`ConfigManifestEntryType.NUMBER`) has been removed.
