### PR TITLE
chore(docs): Fix typo and remove repeated sentence

### DIFF
--- a/packages/documentation/docs/user-guide/features/prompter.md
+++ b/packages/documentation/docs/user-guide/features/prompter.md
@@ -21,7 +21,7 @@ The prompter UI can be configured using query parameters:
 | Query parameter | Type   | Description                                                                                                                                                         | Default |
 | :-------------- | :----- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :------ |
 | `mirror`        | 0 / 1  | Mirror the display horizontally                                                                                                                                     | `0`     |
-| `vmirror`       | 0 / 1  | Mirror the display vertically                                                                                                                                       | `0`     |
+| `mirrorv`       | 0 / 1  | Mirror the display vertically                                                                                                                                       | `0`     |
 | `fontsize`      | number | Set a custom font size of the text. 20 will fit in 5 lines of text, 14 will fit 7 lines etc..                                                                       | `14`    |
 | `marker`        | string | Set position of the read-marker. Possible values: "center", "top", "bottom", "hide"                                                                                 | `hide`  |
 | `margin`        | number | Set margin of screen \(used on monitors with overscan\), in %.                                                                                                      | `0`     |

--- a/packages/documentation/docs/user-guide/features/prompter.md
+++ b/packages/documentation/docs/user-guide/features/prompter.md
@@ -30,7 +30,7 @@ The prompter UI can be configured using query parameters:
 | `followtake`    | 0 / 1  | Whether the prompter should automatically scroll to current segment when the operator TAKE:s it                                                                     | `1`     |
 | `debug`         | 0 / 1  | Whether to display a debug box showing controller input values and the calculated speed the prompter is currently scrolling at. Used to tweak speedMaps and ranges. | `0`     |
 
-Example: [http://127.0.0.1/prompter/studio0/?mode=mouse&followTake=0&fontsize=20](http://127.0.0.1/prompter/studio0/?mode=mouse&followTake=0&fontsize=20)
+Example: [http://127.0.0.1/prompter/studio0/?mode=mouse&followtake=0&fontsize=20](http://127.0.0.1/prompter/studio0/?mode=mouse&followtake=0&fontsize=20)
 
 ## Controlling the prompter
 

--- a/packages/documentation/docs/user-guide/features/sofie-views.mdx
+++ b/packages/documentation/docs/user-guide/features/sofie-views.mdx
@@ -157,15 +157,13 @@ Technically, the switchboard activates and deactivates Route Sets. The Route Set
 
 A fullscreen page which displays the prompter text for the currently active rundown. The prompter can be controlled and configured in various ways, see more at the [Prompter](prompter) documentation. If no Rundown is active in a given studio, the [Screensaver](sofie-views#screensaver) will be displayed.
 
-A full-screen page which displays the prompter text for the currently active rundown. The prompter can be controlled and configured in various ways, see more at the [Prompter](prompter) documentation.
-
 ## Presenter View
 
 `/countdowns/:studioId/presenter`
 
 ![Presenter View](/img/docs/main/features/presenter-screen-example.png)
 
-A full-screen page, intended to be shown to the studio presenter. It displays countdown timers for the current and next items in the rundown. If no Rundown is active in a given studio, the [Screensaver](sofie-views#screensaver) will be shown.
+A fullscreen page, intended to be shown to the studio presenter. It displays countdown timers for the current and next items in the rundown. If no Rundown is active in a given studio, the [Screensaver](sofie-views#screensaver) will be shown.
 
 ### Presenter View Overlay
 

--- a/packages/documentation/versioned_docs/version-1.37.0/user-guide/features/prompter.md
+++ b/packages/documentation/versioned_docs/version-1.37.0/user-guide/features/prompter.md
@@ -21,7 +21,7 @@ The prompter UI can be configured using query parameters:
 | Query parameter | Type   | Description                                                                                                                                                         | Default |
 | :-------------- | :----- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :------ |
 | `mirror`        | 0 / 1  | Mirror the display horizontally                                                                                                                                     | `0`     |
-| `vmirror`       | 0 / 1  | Mirror the display vertically                                                                                                                                       | `0`     |
+| `mirrorv`       | 0 / 1  | Mirror the display vertically                                                                                                                                       | `0`     |
 | `fontsize`      | number | Set a custom font size of the text. 20 will fit in 5 lines of text, 14 will fit 7 lines etc..                                                                       | `14`    |
 | `marker`        | string | Set position of the read-marker. Possible values: "center", "top", "bottom", "hide"                                                                                 | `hide`  |
 | `margin`        | number | Set margin of screen \(used on monitors with overscan\), in %.                                                                                                      | `0`     |

--- a/packages/documentation/versioned_docs/version-1.37.0/user-guide/features/prompter.md
+++ b/packages/documentation/versioned_docs/version-1.37.0/user-guide/features/prompter.md
@@ -30,7 +30,7 @@ The prompter UI can be configured using query parameters:
 | `followtake`    | 0 / 1  | Whether the prompter should automatically scroll to current segment when the operator TAKE:s it                                                                     | `1`     |
 | `debug`         | 0 / 1  | Whether to display a debug box showing controller input values and the calculated speed the prompter is currently scrolling at. Used to tweak speedMaps and ranges. | `0`     |
 
-Example: [http://127.0.0.1/prompter/studio0/?mode=mouse&followTake=0&fontsize=20](http://127.0.0.1/prompter/studio0/?mode=mouse&followTake=0&fontsize=20)
+Example: [http://127.0.0.1/prompter/studio0/?mode=mouse&followtake=0&fontsize=20](http://127.0.0.1/prompter/studio0/?mode=mouse&followtake=0&fontsize=20)
 
 ## Controlling the prompter
 

--- a/packages/documentation/versioned_docs/version-1.37.0/user-guide/features/sofie-views.mdx
+++ b/packages/documentation/versioned_docs/version-1.37.0/user-guide/features/sofie-views.mdx
@@ -157,15 +157,13 @@ Technically, the switchboard activates and deactivates Route Sets. The Route Set
 
 A fullscreen page which displays the prompter text for the currently active rundown. The prompter can be controlled and configured in various ways, see more at the [Prompter](prompter) documentation. If no Rundown is active in a given studio, the [Screensaver](sofie-views#screensaver) will be displayed.
 
-A full-screen page which displays the prompter text for the currently active rundown. The prompter can be controlled and configured in various ways, see more at the [Prompter](prompter) documentation.
-
 ## Presenter View
 
 `/countdowns/:studioId/presenter`
 
 ![Presenter View](/img/docs/main/features/presenter-screen-example.png)
 
-A full-screen page, intended to be shown to the studio presenter. It displays countdown timers for the current and next items in the rundown. If no Rundown is active in a given studio, the [Screensaver](sofie-views#screensaver) will be shown.
+A fullscreen page, intended to be shown to the studio presenter. It displays countdown timers for the current and next items in the rundown. If no Rundown is active in a given studio, the [Screensaver](sofie-views#screensaver) will be shown.
 
 ### Presenter View Overlay
 

--- a/packages/documentation/versioned_docs/version-1.38.0/user-guide/features/prompter.md
+++ b/packages/documentation/versioned_docs/version-1.38.0/user-guide/features/prompter.md
@@ -21,7 +21,7 @@ The prompter UI can be configured using query parameters:
 | Query parameter | Type   | Description                                                                                                                                                         | Default |
 | :-------------- | :----- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :------ |
 | `mirror`        | 0 / 1  | Mirror the display horizontally                                                                                                                                     | `0`     |
-| `vmirror`       | 0 / 1  | Mirror the display vertically                                                                                                                                       | `0`     |
+| `mirrorv`       | 0 / 1  | Mirror the display vertically                                                                                                                                       | `0`     |
 | `fontsize`      | number | Set a custom font size of the text. 20 will fit in 5 lines of text, 14 will fit 7 lines etc..                                                                       | `14`    |
 | `marker`        | string | Set position of the read-marker. Possible values: "center", "top", "bottom", "hide"                                                                                 | `hide`  |
 | `margin`        | number | Set margin of screen \(used on monitors with overscan\), in %.                                                                                                      | `0`     |

--- a/packages/documentation/versioned_docs/version-1.38.0/user-guide/features/prompter.md
+++ b/packages/documentation/versioned_docs/version-1.38.0/user-guide/features/prompter.md
@@ -30,7 +30,7 @@ The prompter UI can be configured using query parameters:
 | `followtake`    | 0 / 1  | Whether the prompter should automatically scroll to current segment when the operator TAKE:s it                                                                     | `1`     |
 | `debug`         | 0 / 1  | Whether to display a debug box showing controller input values and the calculated speed the prompter is currently scrolling at. Used to tweak speedMaps and ranges. | `0`     |
 
-Example: [http://127.0.0.1/prompter/studio0/?mode=mouse&followTake=0&fontsize=20](http://127.0.0.1/prompter/studio0/?mode=mouse&followTake=0&fontsize=20)
+Example: [http://127.0.0.1/prompter/studio0/?mode=mouse&followtake=0&fontsize=20](http://127.0.0.1/prompter/studio0/?mode=mouse&followtake=0&fontsize=20)
 
 ## Controlling the prompter
 

--- a/packages/documentation/versioned_docs/version-1.38.0/user-guide/features/sofie-views.mdx
+++ b/packages/documentation/versioned_docs/version-1.38.0/user-guide/features/sofie-views.mdx
@@ -157,15 +157,13 @@ Technically, the switchboard activates and deactivates Route Sets. The Route Set
 
 A fullscreen page which displays the prompter text for the currently active rundown. The prompter can be controlled and configured in various ways, see more at the [Prompter](prompter) documentation. If no Rundown is active in a given studio, the [Screensaver](sofie-views#screensaver) will be displayed.
 
-A full-screen page which displays the prompter text for the currently active rundown. The prompter can be controlled and configured in various ways, see more at the [Prompter](prompter) documentation.
-
 ## Presenter View
 
 `/countdowns/:studioId/presenter`
 
 ![Presenter View](/img/docs/main/features/presenter-screen-example.png)
 
-A full-screen page, intended to be shown to the studio presenter. It displays countdown timers for the current and next items in the rundown. If no Rundown is active in a given studio, the [Screensaver](sofie-views#screensaver) will be shown.
+A fullscreen page, intended to be shown to the studio presenter. It displays countdown timers for the current and next items in the rundown. If no Rundown is active in a given studio, the [Screensaver](sofie-views#screensaver) will be shown.
 
 ### Presenter View Overlay
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Docs update: Fixes a typo in the param for vertical mirroring, which is really called `mirrorv`. Removes a repeated sentence. Makes spelling of _fullscreen_ consistent in the following paragraph (though I think both spellings are correct).
Fixes typo in the example url.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
