### PR TITLE
chore: log the reason why triggerupdateTimelineAndMappings is called

### DIFF
--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -152,7 +152,7 @@ export class TSRHandler {
 			proActiveResolve: true,
 		}
 		this.tsr = new Conductor(c)
-		this._triggerupdateTimelineAndMappings()
+		this._triggerupdateTimelineAndMappings('TSRHandler.init()')
 
 		coreHandler.onConnected(() => {
 			this.setupObservers()
@@ -263,7 +263,7 @@ export class TSRHandler {
 		await this.tsr.init()
 
 		this._initialized = true
-		this._triggerupdateTimelineAndMappings()
+		this._triggerupdateTimelineAndMappings('TSRHandler.init(), later')
 		this.onSettingsChanged()
 		this._triggerUpdateDevices()
 		this.logger.debug('tsr init done')
@@ -280,25 +280,25 @@ export class TSRHandler {
 
 		const timelineObserver = this._coreHandler.core.observe('studioTimeline')
 		timelineObserver.added = () => {
-			this._triggerupdateTimelineAndMappings(true)
+			this._triggerupdateTimelineAndMappings('studioTimeline.added', true)
 		}
 		timelineObserver.changed = () => {
-			this._triggerupdateTimelineAndMappings(true)
+			this._triggerupdateTimelineAndMappings('studioTimeline.changed', true)
 		}
 		timelineObserver.removed = () => {
-			this._triggerupdateTimelineAndMappings(true)
+			this._triggerupdateTimelineAndMappings('studioTimeline.removed', true)
 		}
 		this._observers.push(timelineObserver)
 
 		const mappingsObserver = this._coreHandler.core.observe('studioMappings')
 		mappingsObserver.added = () => {
-			this._triggerupdateTimelineAndMappings()
+			this._triggerupdateTimelineAndMappings('studioMappings.added')
 		}
 		mappingsObserver.changed = () => {
-			this._triggerupdateTimelineAndMappings()
+			this._triggerupdateTimelineAndMappings('studioMappings.changed')
 		}
 		mappingsObserver.removed = () => {
-			this._triggerupdateTimelineAndMappings()
+			this._triggerupdateTimelineAndMappings('studioMappings.removed')
 		}
 		this._observers.push(mappingsObserver)
 
@@ -416,12 +416,12 @@ export class TSRHandler {
 			this._triggerUpdateDevices()
 		}
 	}
-	private _triggerupdateTimelineAndMappings(fromTlChange?: boolean) {
+	private _triggerupdateTimelineAndMappings(context: string, fromTlChange?: boolean) {
 		if (!this._initialized) return
 
-		this._updateTimelineAndMappings(fromTlChange)
+		this._updateTimelineAndMappings(context, fromTlChange)
 	}
-	private _updateTimelineAndMappings(fromTlChange?: boolean) {
+	private _updateTimelineAndMappings(context: string, fromTlChange?: boolean) {
 		const timeline = this.getTimeline()
 		const mappingsObject = this.getMappings()
 
@@ -441,7 +441,7 @@ export class TSRHandler {
 			return
 		}
 
-		this.logger.debug(`Trigger new resolving`)
+		this.logger.debug(`Trigger new resolving (${context})`)
 		if (fromTlChange) {
 			const trace = {
 				measurement: 'playout-gateway:timelineReceived',


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR adds tracing of why an update to the timeline was triggered

* **What is the current behavior?** (You can also link to an open issue here)

No trace of why `TSRHandler._updateTimelineAndMappings` is recorded.

* **What is the new behavior (if this is a feature change)?**

The context in which `TSRHandler._updateTimelineAndMappings` is being called is recorded.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
