### PR TITLE
fix: guard against sending multiple timelines to PoGw

### DIFF
--- a/meteor/server/publications/timeline.ts
+++ b/meteor/server/publications/timeline.ts
@@ -102,10 +102,11 @@ function createObserverForTimelinePublication(
 			// Initial data fetch
 			return {
 				studioId: studioId,
-				incomingTimeline: Timeline.findOne({
-					_id: studioId,
-				}),
-				timeline: undefined,
+				incomingTimeline:
+					Timeline.findOne({
+						_id: studioId,
+					}) ?? null,
+				timeline: null,
 				timelineHash: undefined,
 				timelineGenerated: 0,
 
@@ -173,7 +174,7 @@ function createObserverForTimelinePublication(
 					logger.warn('Incoming timeline is older than the last sent timeline, rejecting the update')
 				}
 
-				context.incomingTimeline = undefined
+				context.incomingTimeline = null
 			}
 
 			if (context.timelineHash !== context.timeline.timelineHash) {

--- a/meteor/server/publications/timeline.ts
+++ b/meteor/server/publications/timeline.ts
@@ -20,6 +20,7 @@ import { PeripheralDeviceReadAccess } from '../security/peripheralDevice'
 import { StudioReadAccess } from '../security/studio'
 import { fetchStudioLight, StudioLight } from '../../lib/collections/optimizations'
 import { FastTrackObservers, setupFastTrackObserver } from './fastTrack'
+import { logger } from '../logging'
 
 meteorPublish(PubSub.timeline, function (selector, token) {
 	if (!selector) throw new Meteor.Error(400, 'selector argument missing')
@@ -86,13 +87,13 @@ function createObserverForTimelinePublication(
 				Timeline.find({
 					_id: studioId,
 				}).observe({
-					added: (timeline) => triggerUpdate({ timeline: timeline }),
-					changed: (timeline) => triggerUpdate({ timeline: timeline }),
-					removed: () => triggerUpdate({ timeline: null }),
+					added: (timeline) => triggerUpdate({ incomingTimeline: timeline }),
+					changed: (timeline) => triggerUpdate({ incomingTimeline: timeline }),
+					removed: () => triggerUpdate({ timeline: null, incomingTimeline: null }),
 				}),
 				setupFastTrackObserver(FastTrackObservers.TIMELINE, [studioId], (timeline: TimelineComplete) => {
 					triggerUpdate({
-						timeline: timeline,
+						incomingTimeline: timeline,
 					})
 				}),
 			]
@@ -101,21 +102,24 @@ function createObserverForTimelinePublication(
 			// Initial data fetch
 			return {
 				studioId: studioId,
-				timeline: Timeline.findOne({
+				incomingTimeline: Timeline.findOne({
 					_id: studioId,
 				}),
+				timeline: undefined,
+				timelineHash: undefined,
+				timelineGenerated: 0,
 
 				invalidateStudio: true,
 				studio: undefined,
 				routes: undefined,
 
-				timelineHash: undefined,
 				routedTimeline: [],
 			}
 		},
 		(context: {
 			studioId: StudioId | undefined
-			timeline: TimelineComplete | undefined
+			incomingTimeline: TimelineComplete | null
+			timeline: TimelineComplete | null
 
 			invalidateStudio: boolean
 			studio: StudioLight | undefined
@@ -123,6 +127,7 @@ function createObserverForTimelinePublication(
 
 			// re-calc of timeline using timelineHash:
 			timelineHash: TimelineHash | undefined
+			timelineGenerated: number
 			routedTimeline: TimelineObjGeneric[]
 		}) => {
 			// Prepare data for publication:
@@ -144,12 +149,40 @@ function createObserverForTimelinePublication(
 			if (!context.studio) return []
 			if (!context.routes) return []
 
+			if (context.incomingTimeline) {
+				if (context.timelineGenerated > Date.now() + 10000) {
+					// Take height for something going really really wrong with the generated time,
+					// like if a NTP-sync sets it to 50 years into the future or something...
+					logger.warn(
+						`Existing timeline is from the future, resetting time: ${new Date(
+							context.timelineGenerated
+						).toISOString()}`
+					)
+					context.timelineGenerated = 0
+				}
+
+				if (
+					!context.timeline ||
+					!context.timelineGenerated ||
+					context.timelineGenerated <= context.incomingTimeline.generated
+				) {
+					context.timeline = context.incomingTimeline
+				} else {
+					// Hm, the generated is actually older than what we've already sent
+					// Ignore the incoming timline
+					logger.warn('Incoming timeline is older than the last sent timeline, rejecting the update')
+				}
+
+				context.incomingTimeline = undefined
+			}
+
 			if (context.timelineHash !== context.timeline.timelineHash) {
 				invalidateTimeline = true
 			}
 
 			if (invalidateTimeline) {
 				context.timelineHash = context.timeline.timelineHash
+				context.timelineGenerated = context.timeline.generated
 				const timeline = deserializeTimelineBlob(context.timeline.timelineBlob)
 				context.routedTimeline = getRoutedTimeline(timeline, context.routes)
 				changedData = true

--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -441,7 +441,11 @@ export class TSRHandler {
 			return
 		}
 
-		this.logger.debug(`Trigger new resolving (${context})`)
+		this.logger.debug(
+			`Trigger new resolving (${context}, hash: ${timeline.timelineHash}, gen: ${new Date(
+				timeline.generated
+			).toISOString()}, pub: ${new Date(timeline.published).toISOString()})`
+		)
 		if (fromTlChange) {
 			const trace = {
 				measurement: 'playout-gateway:timelineReceived',


### PR DESCRIPTION
Co-authored-by: Julian Waller <Julusian@users.noreply.github.com>
Co-authored-by: Johan Nyman <nytamin@users.noreply.github.com>

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR introduces a guard against non-monotonic timeline resolution

* **What is the current behavior?** (You can also link to an open issue here)

It is possible that, when using the timeline fast-track, an "old" timeline can be sent, even though the new one has already been sent.

* **What is the new behavior (if this is a feature change)?**

The generated timestamp is compared to ensure that "old" timelines aren't sent. This should also probably resolve issues where some sort of NTP-snafu would cause sending multiple timelines, as only one timeline will be sent.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
