### PR TITLE
fix: add migration step for RundowmBaselineObjects.objects -> .timeli…

### DIFF
--- a/meteor/server/migration/1_41_0.ts
+++ b/meteor/server/migration/1_41_0.ts
@@ -21,34 +21,6 @@ import { TimelineObjGeneric } from '@sofie-automation/corelib/dist/dataModel/Tim
 // Release 41
 export const addSteps = addMigrationSteps('1.41.0', [
 	{
-		id: `RundownBaselineObj.timelineObjectsString`,
-		canBeRunAutomatically: true,
-		validate: () => {
-			const objects = RundownBaselineObjs.find({
-				timelineObjects: { $exists: true },
-			}).count()
-			if (objects > 0) {
-				return `timelineObjects needs to be converted`
-			}
-			return false
-		},
-		migrate: () => {
-			const objects = RundownBaselineObjs.find({
-				timelineObjects: { $exists: true },
-			}).fetch()
-			for (const obj of objects) {
-				RundownBaselineObjs.update(obj._id, {
-					$set: {
-						timelineObjectsString: serializePieceTimelineObjectsBlob((obj as any).timelineObjects),
-					},
-					$unset: {
-						timelineObjects: 1,
-					},
-				})
-			}
-		},
-	},
-	{
 		id: `RundownBaselineObj.timelineObjectsString from objects`,
 		canBeRunAutomatically: true,
 		validate: () => {

--- a/meteor/server/migration/1_41_0.ts
+++ b/meteor/server/migration/1_41_0.ts
@@ -6,6 +6,7 @@ import { AdLibPieces } from '../../lib/collections/AdLibPieces'
 import { BucketAdLibs } from '../../lib/collections/BucketAdlibs'
 import { PieceInstances } from '../../lib/collections/PieceInstances'
 import { RundownBaselineAdLibPieces } from '../../lib/collections/RundownBaselineAdLibPieces'
+import { TimelineObjGeneric } from '@sofie-automation/corelib/dist/dataModel/Timeline'
 
 /*
  * **************************************************************************************
@@ -42,6 +43,36 @@ export const addSteps = addMigrationSteps('1.41.0', [
 					},
 					$unset: {
 						timelineObjects: 1,
+					},
+				})
+			}
+		},
+	},
+	{
+		id: `RundownBaselineObj.timelineObjectsString from objects`,
+		canBeRunAutomatically: true,
+		validate: () => {
+			const objects = RundownBaselineObjs.find({
+				objects: { $exists: true },
+			}).count()
+			if (objects > 0) {
+				return `timelineObjects needs to be converted`
+			}
+			return false
+		},
+		migrate: () => {
+			const objects = RundownBaselineObjs.find({
+				objects: { $exists: true },
+			}).fetch()
+			for (const obj of objects) {
+				RundownBaselineObjs.update(obj._id, {
+					$set: {
+						timelineObjectsString: serializePieceTimelineObjectsBlob(
+							(obj as any).objects as TimelineObjGeneric[]
+						),
+					},
+					$unset: {
+						objects: 1,
 					},
 				})
 			}

--- a/packages/corelib/src/dataModel/Piece.ts
+++ b/packages/corelib/src/dataModel/Piece.ts
@@ -75,7 +75,13 @@ export interface Piece extends PieceGeneric, Omit<IBlueprintPieceDB, '_id' | 'co
 export type PieceTimelineObjectsBlob = ProtectedString<'PieceTimelineObjectsBlob'>
 
 export function deserializePieceTimelineObjectsBlob(timelineBlob: PieceTimelineObjectsBlob): TimelineObjectCoreExt[] {
-	return JSON.parse(unprotectString(timelineBlob)) as Array<TimelineObjectCoreExt>
+	const str = unprotectString(timelineBlob) + ''
+	try {
+		return JSON.parse(str) as Array<TimelineObjectCoreExt>
+	} catch (err) {
+		;(err as Error).message += ` Blob: ${str.slice(0, 100)}`
+		throw err
+	}
 }
 export function serializePieceTimelineObjectsBlob(timeline: TimelineObjectCoreExt[]): PieceTimelineObjectsBlob {
 	return protectString(JSON.stringify(timeline))


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Add missing migration


* **What is the current behavior?** (You can also link to an open issue here)
The migrations for 1.41.0 has a step to handle `RundownBaselineObj.timelineObjects` which I believe is an err.


* **What is the new behavior (if this is a feature change)?**
Added a migration step to 1.41.0 to handle the removed property `RundownBaselineObjs.objects`.


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
