### PR TITLE
feat: strongly type meteor publications

### DIFF
--- a/meteor/client/lib/ConnectionStatusNotification.tsx
+++ b/meteor/client/lib/ConnectionStatusNotification.tsx
@@ -30,7 +30,7 @@ export class ConnectionStatusNotifier extends WithManagedTracker {
 	constructor(t: i18next.TFunction) {
 		super()
 
-		this.subscribe(PubSub.coreSystem, null)
+		this.subscribe(PubSub.coreSystem)
 
 		this._translator = t
 

--- a/meteor/client/lib/MeteorReactComponent.ts
+++ b/meteor/client/lib/MeteorReactComponent.ts
@@ -2,7 +2,7 @@ import { Tracker } from 'meteor/tracker'
 import * as React from 'react'
 import { stringifyObjects } from '../../lib/lib'
 import { Meteor } from 'meteor/meteor'
-import { PubSub } from '../../lib/api/pubsub'
+import { PubSubTypes } from '../../lib/api/pubsub'
 export class MeteorReactComponent<IProps, IState = {}> extends React.Component<IProps, IState> {
 	private _subscriptions: { [id: string]: Meteor.SubscriptionHandle } = {}
 	private _computations: Array<Tracker.Computation> = []
@@ -13,7 +13,7 @@ export class MeteorReactComponent<IProps, IState = {}> extends React.Component<I
 	componentWillUnmount() {
 		this._cleanUp()
 	}
-	subscribe(name: PubSub, ...args: any[]): Meteor.SubscriptionHandle {
+	subscribe<K extends keyof PubSubTypes>(name: K, ...args: Parameters<PubSubTypes[K]>): Meteor.SubscriptionHandle {
 		// @ts-ignore
 		return Tracker.nonreactive(() => {
 			// let id = name + '_' + JSON.stringify(args.join())

--- a/meteor/client/lib/ReactMeteorData/ReactMeteorData.tsx
+++ b/meteor/client/lib/ReactMeteorData/ReactMeteorData.tsx
@@ -6,7 +6,7 @@ import { Mongo } from 'meteor/mongo'
 import { Tracker } from 'meteor/tracker'
 import { withTranslation, WithTranslation } from 'react-i18next'
 import { MeteorReactComponent } from '../MeteorReactComponent'
-import { meteorSubscribe, PubSub } from '../../../lib/api/pubsub'
+import { meteorSubscribe, PubSubTypes } from '../../../lib/api/pubsub'
 import { stringifyObjects } from '../../../lib/lib'
 
 const globalTrackerQueue: Array<Function> = []
@@ -334,7 +334,7 @@ export function useTracker<T, K extends undefined | T = undefined>(
  * @param {...any[]} args A list of arugments for the subscription. This is used for optimizing the subscription across
  * 		renders so that it isn't torn down and created for every render.
  */
-export function useSubscription(sub: PubSub, ...args: any[]): boolean {
+export function useSubscription<K extends keyof PubSubTypes>(sub: K, ...args: Parameters<PubSubTypes[K]>): boolean {
 	const [ready, setReady] = useState<boolean>(false)
 
 	useEffect(() => {

--- a/meteor/client/lib/reactiveData/reactiveDataHelper.ts
+++ b/meteor/client/lib/reactiveData/reactiveDataHelper.ts
@@ -1,7 +1,7 @@
 import * as _ from 'underscore'
 import { ReactiveVar } from 'meteor/reactive-var'
 import { Tracker } from 'meteor/tracker'
-import { PubSub } from '../../../lib/api/pubsub'
+import { meteorSubscribe, PubSubTypes } from '../../../lib/api/pubsub'
 import { Meteor } from 'meteor/meteor'
 
 export namespace ReactiveDataHelper {
@@ -190,8 +190,8 @@ export abstract class WithManagedTracker {
 		return this._subs.every((e) => e.ready())
 	}
 
-	protected subscribe(sub: PubSub, ...args: any[]) {
-		this._subs.push(Meteor.subscribe(sub, ...args))
+	protected subscribe<K extends keyof PubSubTypes>(sub: K, ...args: Parameters<PubSubTypes[K]>) {
+		this._subs.push(meteorSubscribe(sub, ...args))
 	}
 
 	protected autorun(

--- a/meteor/client/lib/triggers/TriggersHandler.tsx
+++ b/meteor/client/lib/triggers/TriggersHandler.tsx
@@ -71,9 +71,7 @@ function useSubscriptions(
 		useSubscription(PubSub.rundownPlaylists, {
 			_id: rundownPlaylistId,
 		}),
-		useSubscription(PubSub.rundowns, {
-			playlistId: rundownPlaylistId,
-		}),
+		useSubscription(PubSub.rundowns, [rundownPlaylistId], null),
 
 		useSubscription(PubSub.adLibActions, {
 			rundownId: {

--- a/meteor/client/ui/ActiveRundownView.tsx
+++ b/meteor/client/ui/ActiveRundownView.tsx
@@ -76,9 +76,7 @@ export const ActiveRundownView = translateWithTracker<IProps, {}, ITrackedProps>
 
 			this.autorun(() => {
 				if (this.props.playlist) {
-					this.subscribe(PubSub.rundowns, {
-						playlistId: this.props.playlist._id,
-					})
+					this.subscribe(PubSub.rundowns, [this.props.playlist._id], null)
 				}
 
 				const subsReady = this.subscriptionsReady()

--- a/meteor/client/ui/App.tsx
+++ b/meteor/client/ui/App.tsx
@@ -218,7 +218,7 @@ export const App = translateWithTracker(() => {
 
 		componentDidMount() {
 			// Global subscription of the currently logged in user:
-			this.subscribe(PubSub.loggedInUser, {})
+			this.subscribe(PubSub.loggedInUser)
 			this.autorun(() => {
 				const user = getUser()
 				if (user?.organizationId) {

--- a/meteor/client/ui/ClockView/PresenterScreen.tsx
+++ b/meteor/client/ui/ClockView/PresenterScreen.tsx
@@ -306,9 +306,7 @@ export class PresenterScreenBase extends MeteorReactComponent<
 				},
 			}) as Pick<RundownPlaylist, '_id' | 'activationId'> | undefined
 			if (playlist) {
-				this.subscribe(PubSub.rundowns, {
-					playlistId: playlist._id,
-				})
+				this.subscribe(PubSub.rundowns, [playlist._id], null)
 
 				this.autorun(() => {
 					const rundowns = RundownPlaylistCollectionUtil.getRundownsUnordered(playlist, undefined, {
@@ -325,14 +323,8 @@ export class PresenterScreenBase extends MeteorReactComponent<
 					this.subscribe(PubSub.segments, {
 						rundownId: { $in: rundownIds },
 					})
-					this.subscribe(PubSub.parts, {
-						rundownId: { $in: rundownIds },
-					})
-					this.subscribe(PubSub.partInstances, {
-						rundownId: { $in: rundownIds },
-						playlistActivationId: playlist.activationId,
-						reset: { $ne: true },
-					})
+					this.subscribe(PubSub.parts, rundownIds)
+					this.subscribe(PubSub.partInstances, rundownIds, playlist.activationId)
 					this.subscribe(PubSub.showStyleBases, {
 						_id: {
 							$in: showStyleBaseIds,

--- a/meteor/client/ui/Prompter/PrompterView.tsx
+++ b/meteor/client/ui/Prompter/PrompterView.tsx
@@ -233,9 +233,7 @@ export class PrompterViewInner extends MeteorReactComponent<Translated<IProps & 
 				}
 			) as Pick<RundownPlaylist, '_id'> | undefined
 			if (playlist?._id) {
-				this.subscribe(PubSub.rundowns, {
-					playlistId: playlist._id,
-				})
+				this.subscribe(PubSub.rundowns, [playlist._id], null)
 			}
 		})
 
@@ -594,7 +592,7 @@ export const Prompter = translateWithTracker<IPrompterProps, {}, IPrompterTracke
 		}
 
 		componentDidMount() {
-			this.subscribe(PubSub.rundowns, { playlistId: this.props.rundownPlaylistId })
+			this.subscribe(PubSub.rundowns, [this.props.rundownPlaylistId], null)
 
 			this.autorun(() => {
 				const playlist = RundownPlaylists.findOne(this.props.rundownPlaylistId, {
@@ -608,14 +606,8 @@ export const Prompter = translateWithTracker<IPrompterProps, {}, IPrompterTracke
 					this.subscribe(PubSub.segments, {
 						rundownId: { $in: rundownIDs },
 					})
-					this.subscribe(PubSub.parts, {
-						rundownId: { $in: rundownIDs },
-					})
-					this.subscribe(PubSub.partInstances, {
-						rundownId: { $in: rundownIDs },
-						playlistActivationId: playlist.activationId,
-						reset: { $ne: true },
-					})
+					this.subscribe(PubSub.parts, rundownIDs)
+					this.subscribe(PubSub.partInstances, rundownIDs, playlist.activationId)
 					this.subscribe(PubSub.pieces, {
 						startRundownId: { $in: rundownIDs },
 					})

--- a/meteor/client/ui/RundownList.tsx
+++ b/meteor/client/ui/RundownList.tsx
@@ -213,9 +213,7 @@ export const RundownList = translateWithTracker((): IRundownsListProps => {
 					this.subscribe(PubSub.showStyleVariants, {
 						_id: { $in: Array.from(showStyleVariantIds) },
 					})
-					this.subscribe(PubSub.rundowns, {
-						playlistId: { $in: Array.from(playlistIds) },
-					})
+					this.subscribe(PubSub.rundowns, Array.from(playlistIds), null)
 				})
 
 				this.autorun(() => {

--- a/meteor/client/ui/RundownList.tsx
+++ b/meteor/client/ui/RundownList.tsx
@@ -16,14 +16,15 @@ import { RundownLayoutBase, RundownLayouts } from '../../lib/collections/Rundown
 import {
 	RundownPlaylist,
 	RundownPlaylistCollectionUtil,
+	RundownPlaylistId,
 	RundownPlaylists,
 } from '../../lib/collections/RundownPlaylists'
 import { Rundown, RundownId, Rundowns } from '../../lib/collections/Rundowns'
 import { getAllowConfigure, getHelpMode } from '../lib/localStorage'
 import { NotificationCenter, Notification, NoticeLevel } from '../lib/notifications/notifications'
 import { Studios } from '../../lib/collections/Studios'
-import { ShowStyleBases } from '../../lib/collections/ShowStyleBases'
-import { ShowStyleVariants } from '../../lib/collections/ShowStyleVariants'
+import { ShowStyleBaseId, ShowStyleBases } from '../../lib/collections/ShowStyleBases'
+import { ShowStyleVariantId, ShowStyleVariants } from '../../lib/collections/ShowStyleVariants'
 import { extendMandadory, unprotectString } from '../../lib/lib'
 import { MeteorReactComponent } from '../lib/MeteorReactComponent'
 import { Translated, translateWithTracker } from '../lib/ReactMeteorData/react-meteor-data'
@@ -193,17 +194,17 @@ export const RundownList = translateWithTracker((): IRundownsListProps => {
 				this.subscribe(PubSub.rundownLayouts, {})
 
 				this.autorun(() => {
-					const showStyleBaseIds: Set<string> = new Set()
-					const showStyleVariantIds: Set<string> = new Set()
-					const playlistIds: Set<string> = new Set(
+					const showStyleBaseIds: Set<ShowStyleBaseId> = new Set()
+					const showStyleVariantIds: Set<ShowStyleVariantId> = new Set()
+					const playlistIds: Set<RundownPlaylistId> = new Set(
 						RundownPlaylists.find()
 							.fetch()
-							.map((i) => unprotectString(i._id))
+							.map((i) => i._id)
 					)
 
 					for (const rundown of Rundowns.find().fetch()) {
-						showStyleBaseIds.add(unprotectString(rundown.showStyleBaseId))
-						showStyleVariantIds.add(unprotectString(rundown.showStyleVariantId))
+						showStyleBaseIds.add(rundown.showStyleBaseId)
+						showStyleVariantIds.add(rundown.showStyleVariantId)
 					}
 
 					this.subscribe(PubSub.showStyleBases, {

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -70,7 +70,7 @@ import { PeripheralDevices, PeripheralDevice, PeripheralDeviceType } from '../..
 import { doUserAction, UserAction } from '../lib/userAction'
 import { ReloadRundownPlaylistResponse, TriggerReloadDataResponse } from '../../lib/api/userActions'
 import { ClipTrimDialog } from './ClipTrimPanel/ClipTrimDialog'
-import { PubSub } from '../../lib/api/pubsub'
+import { meteorSubscribe, PubSub } from '../../lib/api/pubsub'
 import {
 	RundownLayouts,
 	RundownLayoutType,
@@ -91,7 +91,7 @@ import { MeteorCall } from '../../lib/api/methods'
 import { Settings } from '../../lib/Settings'
 import { PointerLockCursor } from '../lib/PointerLockCursor'
 import { documentTitle } from '../lib/DocumentTitleProvider'
-import { PartInstance } from '../../lib/collections/PartInstances'
+import { PartInstance, PartInstanceId } from '../../lib/collections/PartInstances'
 import { RundownDividerHeader } from './RundownView/RundownDividerHeader'
 import { PlaylistLoopingHeader } from './RundownView/PlaylistLoopingHeader'
 import { memoizedIsolatedAutorun } from '../lib/reactiveData/reactiveDataHelper'
@@ -1620,7 +1620,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 					// Use Meteor.subscribe so that this subscription doesn't mess with this.subscriptionsReady()
 					// it's run in this.autorun, so the subscription will be stopped along with the autorun,
 					// so we don't have to manually clean up after ourselves.
-					Meteor.subscribe(PubSub.pieceInstances, {
+					meteorSubscribe(PubSub.pieceInstances, {
 						rundownId: {
 							$in: rundownIds,
 						},
@@ -1629,7 +1629,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 								playlist.currentPartInstanceId,
 								playlist.nextPartInstanceId,
 								playlist.previousPartInstanceId,
-							].filter((p) => p !== null),
+							].filter((p): p is PartInstanceId => p !== null),
 						},
 						reset: {
 							$ne: true,
@@ -1639,13 +1639,13 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 						RundownPlaylistCollectionUtil.getSelectedPartInstances(playlist)
 
 					if (previousPartInstance) {
-						Meteor.subscribe(PubSub.partInstancesForSegmentPlayout, {
+						meteorSubscribe(PubSub.partInstancesForSegmentPlayout, {
 							rundownId: previousPartInstance.rundownId,
 							segmentPlayoutId: previousPartInstance.segmentPlayoutId,
 						})
 					}
 					if (currentPartInstance) {
-						Meteor.subscribe(PubSub.partInstancesForSegmentPlayout, {
+						meteorSubscribe(PubSub.partInstancesForSegmentPlayout, {
 							rundownId: currentPartInstance.rundownId,
 							segmentPlayoutId: currentPartInstance.segmentPlayoutId,
 						})

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1511,9 +1511,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 			this.subscribe(PubSub.rundownPlaylists, {
 				_id: playlistId,
 			})
-			this.subscribe(PubSub.rundowns, {
-				playlistId,
-			})
+			this.subscribe(PubSub.rundowns, [playlistId], null)
 			this.autorun(() => {
 				const playlist = RundownPlaylists.findOne(playlistId, {
 					fields: {
@@ -1590,20 +1588,8 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 						$in: rundownIDs,
 					},
 				})
-				this.subscribe(PubSub.parts, {
-					rundownId: {
-						$in: rundownIDs,
-					},
-				})
-				this.subscribe(PubSub.partInstances, {
-					rundownId: {
-						$in: rundownIDs,
-					},
-					playlistActivationId: playlist.activationId,
-					reset: {
-						$ne: true,
-					},
-				})
+				this.subscribe(PubSub.parts, rundownIDs)
+				this.subscribe(PubSub.partInstances, rundownIDs, playlist.activationId)
 			})
 			this.autorun(() => {
 				const playlist = RundownPlaylists.findOne(playlistId, {

--- a/meteor/client/ui/SegmentStoryboard/SegmentStoryboardContainer.tsx
+++ b/meteor/client/ui/SegmentStoryboard/SegmentStoryboardContainer.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
-import { Meteor } from 'meteor/meteor'
 import { PieceLifespan } from '@sofie-automation/blueprints-integration'
-import { PubSub } from '../../../lib/api/pubsub'
+import { meteorSubscribe, PubSub } from '../../../lib/api/pubsub'
 import { PartInstances } from '../../../lib/collections/PartInstances'
 import { Parts } from '../../../lib/collections/Parts'
 import { Segments } from '../../../lib/collections/Segments'
@@ -45,16 +44,12 @@ export const SegmentStoryboardContainer = withResolvedSegment<IProps>(function S
 		[segmentId]
 	)
 
-	const piecesReady = useSubscription(
-		PubSub.pieces,
-		{
-			startRundownId: rundownId,
-			startPartId: {
-				$in: partIds,
-			},
+	const piecesReady = useSubscription(PubSub.pieces, {
+		startRundownId: rundownId,
+		startPartId: {
+			$in: partIds,
 		},
-		[partIds]
-	)
+	})
 
 	const partInstanceIds = useTracker(
 		() =>
@@ -75,19 +70,15 @@ export const SegmentStoryboardContainer = withResolvedSegment<IProps>(function S
 		[segmentId]
 	)
 
-	const pieceInstancesReady = useSubscription(
-		PubSub.pieceInstances,
-		{
-			rundownId: rundownId,
-			partInstanceId: {
-				$in: partInstanceIds,
-			},
-			reset: {
-				$ne: true,
-			},
+	const pieceInstancesReady = useSubscription(PubSub.pieceInstances, {
+		rundownId: rundownId,
+		partInstanceId: {
+			$in: partInstanceIds,
 		},
-		[rundownId, partInstanceIds]
-	)
+		reset: {
+			$ne: true,
+		},
+	})
 
 	useTracker(() => {
 		const segment = Segments.findOne(segmentId, {
@@ -97,7 +88,7 @@ export const SegmentStoryboardContainer = withResolvedSegment<IProps>(function S
 			},
 		})
 		segment &&
-			Meteor.subscribe(PubSub.pieces, {
+			meteorSubscribe(PubSub.pieces, {
 				invalid: {
 					$ne: true,
 				},

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -12,7 +12,7 @@ import { MAGIC_TIME_SCALE_FACTOR } from '../RundownView'
 import { SpeechSynthesiser } from '../../lib/speechSynthesis'
 import { getElementWidth } from '../../utils/dimensions'
 import { isMaintainingFocus, scrollToSegment, getHeaderHeight } from '../../lib/viewPort'
-import { PubSub } from '../../../lib/api/pubsub'
+import { meteorSubscribe, PubSub } from '../../../lib/api/pubsub'
 import { unprotectString, equalSets, equivalentArrays } from '../../../lib/lib'
 import { Settings } from '../../../lib/Settings'
 import { PartInstanceId, PartInstances } from '../../../lib/collections/PartInstances'
@@ -413,7 +413,7 @@ export const SegmentTimelineContainer = withResolvedSegment(
 					this.partInstanceSub.stop()
 				}
 				// we handle this subscription manually
-				this.partInstanceSub = Meteor.subscribe(PubSub.pieceInstances, {
+				this.partInstanceSub = meteorSubscribe(PubSub.pieceInstances, {
 					rundownId: this.props.rundownId,
 					partInstanceId: {
 						$in: partInstanceIds,

--- a/meteor/client/ui/Settings/SystemManagement.tsx
+++ b/meteor/client/ui/Settings/SystemManagement.tsx
@@ -26,7 +26,7 @@ export default translateWithTracker<IProps, {}, ITrackedProps>((_props: IProps) 
 })(
 	class SystemManagement extends MeteorReactComponent<Translated<IProps & ITrackedProps>> {
 		componentDidMount() {
-			meteorSubscribe(PubSub.coreSystem, null)
+			meteorSubscribe(PubSub.coreSystem)
 		}
 		cleanUpOldDatabaseIndexes(): void {
 			const { t } = this.props

--- a/meteor/client/ui/Settings/components/triggeredActions/TriggeredActionsEditor.tsx
+++ b/meteor/client/ui/Settings/components/triggeredActions/TriggeredActionsEditor.tsx
@@ -11,7 +11,7 @@ import {
 import { faCaretDown, faCaretRight, faDownload, faPlus, faUpload } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { TriggeredActionEntry, TRIGGERED_ACTION_ENTRY_DRAG_TYPE } from './TriggeredActionEntry'
-import { literal, omit, protectString, unprotectString } from '../../../../../lib/lib'
+import { literal, omit, unprotectString } from '../../../../../lib/lib'
 import { TriggersHandler } from '../../../../lib/triggers/TriggersHandler'
 import {
 	RundownPlaylist,
@@ -97,9 +97,7 @@ export const TriggeredActionsEditor: React.FC<IProps> = function TriggeredAction
 	}
 
 	useSubscription(PubSub.triggeredActions, showStyleBaseSelector)
-	useSubscription(PubSub.rundowns, {
-		showStyleBaseId: showStyleBaseId ?? protectString('Ignore All'),
-	})
+	useSubscription(PubSub.rundowns, null, showStyleBaseId ? [showStyleBaseId] : [])
 
 	useEffect(() => {
 		const debounce = setTimeout(() => {
@@ -213,13 +211,8 @@ export const TriggeredActionsEditor: React.FC<IProps> = function TriggeredAction
 		null
 	)
 
-	useSubscription(PubSub.partInstances, {
-		rundownId: rundown?._id ?? protectString('Ignore All'),
-		playlistActivationId: rundownPlaylist?.activationId,
-	})
-	useSubscription(PubSub.parts, {
-		rundownId: rundown?._id ?? protectString('Ignore All'),
-	})
+	useSubscription(PubSub.partInstances, rundown ? [rundown._id] : [], rundownPlaylist?.activationId)
+	useSubscription(PubSub.parts, rundown ? [rundown._id] : [])
 
 	const previewContext = useTracker(
 		() => {

--- a/meteor/client/ui/Settings/components/triggeredActions/TriggeredActionsEditor.tsx
+++ b/meteor/client/ui/Settings/components/triggeredActions/TriggeredActionsEditor.tsx
@@ -3,11 +3,15 @@ import { useTranslation } from 'react-i18next'
 import { useSubscription, useTracker } from '../../../../lib/ReactMeteorData/ReactMeteorData'
 import { PubSub } from '../../../../../lib/api/pubsub'
 import { ShowStyleBaseId, ShowStyleBases } from '../../../../../lib/collections/ShowStyleBases'
-import { TriggeredActionId, TriggeredActions } from '../../../../../lib/collections/TriggeredActions'
+import {
+	TriggeredActionId,
+	TriggeredActions,
+	TriggeredActionsObj,
+} from '../../../../../lib/collections/TriggeredActions'
 import { faCaretDown, faCaretRight, faDownload, faPlus, faUpload } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { TriggeredActionEntry, TRIGGERED_ACTION_ENTRY_DRAG_TYPE } from './TriggeredActionEntry'
-import { literal, omit, unprotectString } from '../../../../../lib/lib'
+import { literal, omit, protectString, unprotectString } from '../../../../../lib/lib'
 import { TriggersHandler } from '../../../../lib/triggers/TriggersHandler'
 import {
 	RundownPlaylist,
@@ -30,6 +34,8 @@ import { fetchFrom } from '../../../../lib/lib'
 import { NotificationCenter, Notification, NoticeLevel } from '../../../../lib/notifications/notifications'
 import { Meteor } from 'meteor/meteor'
 import { doModalDialog } from '../../../../lib/ModalDialog'
+import { MongoQuery } from '../../../../../lib/typings/meteor'
+import _ from 'underscore'
 
 export interface PreviewContext {
 	rundownPlaylist: RundownPlaylist | null
@@ -77,8 +83,8 @@ export const TriggeredActionsEditor: React.FC<IProps> = function TriggeredAction
 	)
 
 	const { showStyleBaseId } = props
-	const showStyleBaseSelector = {
-		$or: [
+	const showStyleBaseSelector: MongoQuery<TriggeredActionsObj> = {
+		$or: _.compact([
 			{
 				showStyleBaseId: null,
 			},
@@ -87,12 +93,12 @@ export const TriggeredActionsEditor: React.FC<IProps> = function TriggeredAction
 						showStyleBaseId: showStyleBaseId,
 				  }
 				: undefined,
-		].filter(Boolean),
+		]),
 	}
 
 	useSubscription(PubSub.triggeredActions, showStyleBaseSelector)
 	useSubscription(PubSub.rundowns, {
-		showStyleBaseId,
+		showStyleBaseId: showStyleBaseId ?? protectString('Ignore All'),
 	})
 
 	useEffect(() => {
@@ -208,11 +214,11 @@ export const TriggeredActionsEditor: React.FC<IProps> = function TriggeredAction
 	)
 
 	useSubscription(PubSub.partInstances, {
-		rundownId: rundown?._id ?? false,
+		rundownId: rundown?._id ?? protectString('Ignore All'),
 		playlistActivationId: rundownPlaylist?.activationId,
 	})
 	useSubscription(PubSub.parts, {
-		rundownId: rundown?._id ?? false,
+		rundownId: rundown?._id ?? protectString('Ignore All'),
 	})
 
 	const previewContext = useTracker(

--- a/meteor/client/ui/Shelf/BucketPanel.tsx
+++ b/meteor/client/ui/Shelf/BucketPanel.tsx
@@ -380,9 +380,11 @@ export const BucketPanel = translateWithTracker<Translated<IBucketPanelProps>, I
 						_id: this.props.playlist.studioId,
 					})
 					this.autorun(() => {
-						const showStyles = RundownPlaylistCollectionUtil.getRundownsUnordered(this.props.playlist).map(
-							(rundown) => [rundown.showStyleBaseId, rundown.showStyleVariantId]
-						)
+						const showStyles: Array<[ShowStyleBaseId, ShowStyleVariantId]> =
+							RundownPlaylistCollectionUtil.getRundownsUnordered(this.props.playlist).map((rundown) => [
+								rundown.showStyleBaseId,
+								rundown.showStyleVariantId,
+							])
 						const showStyleBases = showStyles.map((showStyle) => showStyle[0])
 						const showStyleVariants = showStyles.map((showStyle) => showStyle[1])
 						this.subscribe(PubSub.bucketAdLibPieces, {

--- a/meteor/lib/api/pubsub.ts
+++ b/meteor/lib/api/pubsub.ts
@@ -29,10 +29,10 @@ import { Piece } from '../collections/Pieces'
 import { RundownBaselineAdLibAction } from '../collections/RundownBaselineAdLibActions'
 import { RundownBaselineAdLibItem } from '../collections/RundownBaselineAdLibPieces'
 import { RundownLayoutBase } from '../collections/RundownLayouts'
-import { DBRundownPlaylist } from '../collections/RundownPlaylists'
-import { DBRundown } from '../collections/Rundowns'
+import { DBRundownPlaylist, RundownPlaylistActivationId, RundownPlaylistId } from '../collections/RundownPlaylists'
+import { DBRundown, RundownId } from '../collections/Rundowns'
 import { DBSegment } from '../collections/Segments'
-import { DBShowStyleBase } from '../collections/ShowStyleBases'
+import { DBShowStyleBase, ShowStyleBaseId } from '../collections/ShowStyleBases'
 import { DBShowStyleVariant } from '../collections/ShowStyleVariants'
 import { SnapshotItem } from '../collections/Snapshots'
 import { DBStudio, RoutedMappings, StudioId } from '../collections/Studios'
@@ -130,14 +130,24 @@ export interface PubSubTypes {
 	) => RundownBaselineAdLibAction
 	[PubSub.ingestDataCache]: (selector: MongoQuery<IngestDataCacheObj>, token?: string) => IngestDataCacheObj
 	[PubSub.rundownPlaylists]: (selector: MongoQuery<DBRundownPlaylist>, token?: string) => DBRundownPlaylist
-	[PubSub.rundowns]: (selector: MongoQuery<DBRundown>, token?: string) => DBRundown
+	[PubSub.rundowns]: (
+		/** RundownPlaylistId to fetch for, or null to not check */
+		playlistIds: RundownPlaylistId[] | null,
+		/** ShowStyleBaseId to fetch for, or null to not check */
+		showStyleBaseIds: ShowStyleBaseId[] | null,
+		token?: string
+	) => DBRundown
 	[PubSub.adLibActions]: (selector: MongoQuery<AdLibAction>, token?: string) => AdLibAction
 	[PubSub.adLibPieces]: (selector: MongoQuery<AdLibPiece>, token?: string) => AdLibPiece
 	[PubSub.pieces]: (selector: MongoQuery<Piece>, token?: string) => Piece
 	[PubSub.pieceInstances]: (selector: MongoQuery<PieceInstance>, token?: string) => PieceInstance
 	[PubSub.pieceInstancesSimple]: (selector: MongoQuery<PieceInstance>, token?: string) => PieceInstance
-	[PubSub.parts]: (selector: MongoQuery<DBPart>, token?: string) => DBPart
-	[PubSub.partInstances]: (selector: MongoQuery<PartInstance>, token?: string) => PartInstance
+	[PubSub.parts]: (rundownIds: RundownId[], token?: string) => DBPart
+	[PubSub.partInstances]: (
+		rundownIds: RundownId[],
+		playlistActivationId: RundownPlaylistActivationId | undefined,
+		token?: string
+	) => PartInstance
 	[PubSub.partInstancesSimple]: (selector: MongoQuery<PartInstance>, token?: string) => PartInstance
 	[PubSub.partInstancesForSegmentPlayout]: (selector: MongoQuery<PartInstance>, token?: string) => PartInstance
 	[PubSub.segments]: (selector: MongoQuery<DBSegment>, token?: string) => DBSegment

--- a/meteor/lib/api/pubsub.ts
+++ b/meteor/lib/api/pubsub.ts
@@ -1,4 +1,48 @@
 import { Meteor } from 'meteor/meteor'
+import { AdLibAction } from '../collections/AdLibActions'
+import { AdLibPiece } from '../collections/AdLibPieces'
+import { Blueprint } from '../collections/Blueprints'
+import { BucketAdLibAction } from '../collections/BucketAdlibActions'
+import { BucketAdLib } from '../collections/BucketAdlibs'
+import { Bucket } from '../collections/Buckets'
+import { ICoreSystem } from '../collections/CoreSystem'
+import { Evaluation } from '../collections/Evaluations'
+import { ExpectedMediaItem } from '../collections/ExpectedMediaItems'
+import { ExpectedPackageDB, ExpectedPackageId } from '../collections/ExpectedPackages'
+import { ExpectedPackageWorkStatus } from '../collections/ExpectedPackageWorkStatuses'
+import { ExpectedPlayoutItem } from '../collections/ExpectedPlayoutItems'
+import { ExternalMessageQueueObj } from '../collections/ExternalMessageQueue'
+import { IngestDataCacheObj } from '../collections/IngestDataCache'
+import { MediaObject } from '../collections/MediaObjects'
+import { MediaWorkFlow } from '../collections/MediaWorkFlows'
+import { MediaWorkFlowStep } from '../collections/MediaWorkFlowSteps'
+import { DBOrganization } from '../collections/Organization'
+import { PackageContainerPackageStatusDB } from '../collections/PackageContainerPackageStatus'
+import { PackageContainerStatusDB } from '../collections/PackageContainerStatus'
+import { PackageInfoDB } from '../collections/PackageInfos'
+import { PartInstance } from '../collections/PartInstances'
+import { DBPart } from '../collections/Parts'
+import { PeripheralDeviceCommand } from '../collections/PeripheralDeviceCommands'
+import { PeripheralDevice, PeripheralDeviceId } from '../collections/PeripheralDevices'
+import { PieceInstance } from '../collections/PieceInstances'
+import { Piece } from '../collections/Pieces'
+import { RundownBaselineAdLibAction } from '../collections/RundownBaselineAdLibActions'
+import { RundownBaselineAdLibItem } from '../collections/RundownBaselineAdLibPieces'
+import { RundownLayoutBase } from '../collections/RundownLayouts'
+import { DBRundownPlaylist } from '../collections/RundownPlaylists'
+import { DBRundown } from '../collections/Rundowns'
+import { DBSegment } from '../collections/Segments'
+import { DBShowStyleBase } from '../collections/ShowStyleBases'
+import { DBShowStyleVariant } from '../collections/ShowStyleVariants'
+import { SnapshotItem } from '../collections/Snapshots'
+import { DBStudio, RoutedMappings, StudioId } from '../collections/Studios'
+import { RoutedTimeline, TimelineComplete } from '../collections/Timeline'
+import { TranslationsBundle } from '../collections/TranslationsBundles'
+import { DBTriggeredActions } from '../collections/TriggeredActions'
+import { UserActionsLogItem } from '../collections/UserActionsLog'
+import { DBUser } from '../collections/Users'
+import { DBObj } from '../lib'
+import { MongoQuery } from '../typings/meteor'
 
 export enum PubSub {
 	blueprints = 'blueprints',
@@ -57,6 +101,126 @@ export enum PubSub {
 	mappingsForStudio = 'mappingsForStudio',
 	timelineForStudio = 'timelineForStudio',
 	expectedPackagesForDevice = 'expectedPackagesForDevice',
+}
+
+export interface PubSubTypes {
+	[PubSub.blueprints]: (selector: MongoQuery<Blueprint>, token: string | undefined) => Blueprint
+	[PubSub.coreSystem]: (token: string | undefined) => ICoreSystem
+	[PubSub.evaluations]: (selector: MongoQuery<Evaluation>, token: string | undefined) => Evaluation
+	[PubSub.expectedPlayoutItems]: (
+		selector: MongoQuery<ExpectedPlayoutItem>,
+		token: string | undefined
+	) => ExpectedPlayoutItem
+	[PubSub.expectedMediaItems]: (
+		selector: MongoQuery<ExpectedMediaItem>,
+		token: string | undefined
+	) => ExpectedMediaItem
+	[PubSub.externalMessageQueue]: (
+		selector: MongoQuery<ExternalMessageQueueObj>,
+		token: string | undefined
+	) => ExternalMessageQueueObj
+	[PubSub.mediaObjects]: (
+		studioId: StudioId,
+		selector: MongoQuery<MediaObject>,
+		token: string | undefined
+	) => MediaObject
+	[PubSub.peripheralDeviceCommands]: (
+		deviceId: PeripheralDeviceId,
+		token: string | undefined
+	) => PeripheralDeviceCommand
+	[PubSub.peripheralDevices]: (selector: MongoQuery<PeripheralDevice>, token: string | undefined) => PeripheralDevice
+	[PubSub.peripheralDevicesAndSubDevices]: (
+		selector: MongoQuery<PeripheralDevice>,
+		token: string | undefined
+	) => PeripheralDevice
+	[PubSub.rundownBaselineAdLibPieces]: (
+		selector: MongoQuery<RundownBaselineAdLibItem>,
+		token: string | undefined
+	) => RundownBaselineAdLibItem
+	[PubSub.rundownBaselineAdLibActions]: (
+		selector: MongoQuery<RundownBaselineAdLibAction>,
+		token: string | undefined
+	) => RundownBaselineAdLibAction
+	[PubSub.ingestDataCache]: (
+		selector: MongoQuery<IngestDataCacheObj>,
+		token: string | undefined
+	) => IngestDataCacheObj
+	[PubSub.rundownPlaylists]: (selector: MongoQuery<DBRundownPlaylist>, token: string | undefined) => DBRundownPlaylist
+	[PubSub.rundowns]: (selector: MongoQuery<DBRundown>, token: string | undefined) => DBRundown
+	[PubSub.adLibActions]: (selector: MongoQuery<AdLibAction>, token: string | undefined) => AdLibAction
+	[PubSub.adLibPieces]: (selector: MongoQuery<AdLibPiece>, token: string | undefined) => AdLibPiece
+	[PubSub.pieces]: (selector: MongoQuery<Piece>, token: string | undefined) => Piece
+	[PubSub.pieceInstances]: (selector: MongoQuery<PieceInstance>, token: string | undefined) => PieceInstance
+	[PubSub.pieceInstancesSimple]: (selector: MongoQuery<PieceInstance>, token: string | undefined) => PieceInstance
+	[PubSub.parts]: (selector: MongoQuery<DBPart>, token: string | undefined) => DBPart
+	[PubSub.partInstances]: (selector: MongoQuery<PartInstance>, token: string | undefined) => PartInstance
+	[PubSub.partInstancesSimple]: (selector: MongoQuery<PartInstance>, token: string | undefined) => PartInstance
+	[PubSub.partInstancesForSegmentPlayout]: (
+		selector: MongoQuery<PartInstance>,
+		token: string | undefined
+	) => PartInstance
+	[PubSub.segments]: (selector: MongoQuery<DBSegment>, token: string | undefined) => DBSegment
+	[PubSub.showStyleBases]: (selector: MongoQuery<DBShowStyleBase>, token: string | undefined) => DBShowStyleBase
+	[PubSub.showStyleVariants]: (
+		selector: MongoQuery<DBShowStyleVariant>,
+		token: string | undefined
+	) => DBShowStyleVariant
+	[PubSub.triggeredActions]: (
+		selector: MongoQuery<DBTriggeredActions>,
+		token: string | undefined
+	) => DBTriggeredActions
+	[PubSub.snapshots]: (selector: MongoQuery<SnapshotItem>, token: string | undefined) => SnapshotItem
+	[PubSub.studios]: (selector: MongoQuery<DBStudio>, token: string | undefined) => DBStudio
+	[PubSub.studioOfDevice]: (deviceId: PeripheralDeviceId, token: string | undefined) => DBStudio
+	[PubSub.timeline]: (selector: MongoQuery<TimelineComplete>, token: string | undefined) => TimelineComplete
+	[PubSub.userActionsLog]: (selector: MongoQuery<UserActionsLogItem>, token: string | undefined) => UserActionsLogItem
+	/** @deprecated */
+	[PubSub.mediaWorkFlows]: (selector: MongoQuery<MediaWorkFlow>, token: string | undefined) => MediaWorkFlow
+	/** @deprecated */
+	[PubSub.mediaWorkFlowSteps]: (
+		selector: MongoQuery<MediaWorkFlowStep>,
+		token: string | undefined
+	) => MediaWorkFlowStep
+	[PubSub.rundownLayouts]: (selector: MongoQuery<RundownLayoutBase>, token: string | undefined) => RundownLayoutBase
+	[PubSub.loggedInUser]: (token: string | undefined) => DBUser
+	[PubSub.usersInOrganization]: (selector: MongoQuery<DBUser>, token: string | undefined) => DBUser
+	[PubSub.organization]: (selector: MongoQuery<DBOrganization>, token: string | undefined) => DBOrganization
+	[PubSub.buckets]: (selector: MongoQuery<Bucket>, token: string | undefined) => Bucket
+	[PubSub.bucketAdLibPieces]: (selector: MongoQuery<BucketAdLib>, token: string | undefined) => BucketAdLib
+	[PubSub.bucketAdLibActions]: (
+		selector: MongoQuery<BucketAdLibAction>,
+		token: string | undefined
+	) => BucketAdLibAction
+	[PubSub.translationsBundles]: (
+		selector: MongoQuery<TranslationsBundle>,
+		token: string | undefined
+	) => TranslationsBundle
+	[PubSub.expectedPackages]: (selector: MongoQuery<ExpectedPackageDB>, token: string | undefined) => ExpectedPackageDB
+	[PubSub.expectedPackageWorkStatuses]: (
+		selector: MongoQuery<ExpectedPackageWorkStatus>,
+		token: string | undefined
+	) => ExpectedPackageWorkStatus
+	[PubSub.packageContainerPackageStatuses]: (
+		studioId: StudioId,
+		containerId?: string | null,
+		packageId?: ExpectedPackageId | null
+	) => PackageContainerPackageStatusDB
+	[PubSub.packageContainerStatuses]: (
+		selector: MongoQuery<PackageContainerStatusDB>,
+		token: string | undefined
+	) => PackageContainerStatusDB
+	[PubSub.packageInfos]: (selector: MongoQuery<PackageInfoDB>, token: string | undefined) => PackageInfoDB
+
+	// custom publications:
+	[PubSub.mappingsForDevice]: (deviceId: PeripheralDeviceId, token: string | undefined) => RoutedMappings
+	[PubSub.timelineForDevice]: (deviceId: PeripheralDeviceId, token: string | undefined) => RoutedTimeline
+	[PubSub.mappingsForStudio]: (studioId: StudioId, token: string | undefined) => RoutedMappings
+	[PubSub.timelineForStudio]: (studioId: StudioId, token: string | undefined) => RoutedTimeline
+	[PubSub.expectedPackagesForDevice]: (
+		deviceId: PeripheralDeviceId,
+		filterPlayoutDeviceIds: PeripheralDeviceId[] | undefined,
+		token: string | undefined
+	) => DBObj
 }
 
 export function meteorSubscribe(name: PubSub, ...args: any[]): Meteor.SubscriptionHandle {

--- a/meteor/lib/api/pubsub.ts
+++ b/meteor/lib/api/pubsub.ts
@@ -104,101 +104,67 @@ export enum PubSub {
 }
 
 export interface PubSubTypes {
-	[PubSub.blueprints]: (selector: MongoQuery<Blueprint>, token: string | undefined) => Blueprint
-	[PubSub.coreSystem]: (token: string | undefined) => ICoreSystem
-	[PubSub.evaluations]: (selector: MongoQuery<Evaluation>, token: string | undefined) => Evaluation
-	[PubSub.expectedPlayoutItems]: (
-		selector: MongoQuery<ExpectedPlayoutItem>,
-		token: string | undefined
-	) => ExpectedPlayoutItem
-	[PubSub.expectedMediaItems]: (
-		selector: MongoQuery<ExpectedMediaItem>,
-		token: string | undefined
-	) => ExpectedMediaItem
+	[PubSub.blueprints]: (selector: MongoQuery<Blueprint>, token?: string) => Blueprint
+	[PubSub.coreSystem]: (token?: string) => ICoreSystem
+	[PubSub.evaluations]: (selector: MongoQuery<Evaluation>, token?: string) => Evaluation
+	[PubSub.expectedPlayoutItems]: (selector: MongoQuery<ExpectedPlayoutItem>, token?: string) => ExpectedPlayoutItem
+	[PubSub.expectedMediaItems]: (selector: MongoQuery<ExpectedMediaItem>, token?: string) => ExpectedMediaItem
 	[PubSub.externalMessageQueue]: (
 		selector: MongoQuery<ExternalMessageQueueObj>,
-		token: string | undefined
+		token?: string
 	) => ExternalMessageQueueObj
-	[PubSub.mediaObjects]: (
-		studioId: StudioId,
-		selector: MongoQuery<MediaObject>,
-		token: string | undefined
-	) => MediaObject
-	[PubSub.peripheralDeviceCommands]: (
-		deviceId: PeripheralDeviceId,
-		token: string | undefined
-	) => PeripheralDeviceCommand
-	[PubSub.peripheralDevices]: (selector: MongoQuery<PeripheralDevice>, token: string | undefined) => PeripheralDevice
+	[PubSub.mediaObjects]: (studioId: StudioId, selector: MongoQuery<MediaObject>, token?: string) => MediaObject
+	[PubSub.peripheralDeviceCommands]: (deviceId: PeripheralDeviceId, token?: string) => PeripheralDeviceCommand
+	[PubSub.peripheralDevices]: (selector: MongoQuery<PeripheralDevice>, token?: string) => PeripheralDevice
 	[PubSub.peripheralDevicesAndSubDevices]: (
 		selector: MongoQuery<PeripheralDevice>,
-		token: string | undefined
+		token?: string
 	) => PeripheralDevice
 	[PubSub.rundownBaselineAdLibPieces]: (
 		selector: MongoQuery<RundownBaselineAdLibItem>,
-		token: string | undefined
+		token?: string
 	) => RundownBaselineAdLibItem
 	[PubSub.rundownBaselineAdLibActions]: (
 		selector: MongoQuery<RundownBaselineAdLibAction>,
-		token: string | undefined
+		token?: string
 	) => RundownBaselineAdLibAction
-	[PubSub.ingestDataCache]: (
-		selector: MongoQuery<IngestDataCacheObj>,
-		token: string | undefined
-	) => IngestDataCacheObj
-	[PubSub.rundownPlaylists]: (selector: MongoQuery<DBRundownPlaylist>, token: string | undefined) => DBRundownPlaylist
-	[PubSub.rundowns]: (selector: MongoQuery<DBRundown>, token: string | undefined) => DBRundown
-	[PubSub.adLibActions]: (selector: MongoQuery<AdLibAction>, token: string | undefined) => AdLibAction
-	[PubSub.adLibPieces]: (selector: MongoQuery<AdLibPiece>, token: string | undefined) => AdLibPiece
-	[PubSub.pieces]: (selector: MongoQuery<Piece>, token: string | undefined) => Piece
-	[PubSub.pieceInstances]: (selector: MongoQuery<PieceInstance>, token: string | undefined) => PieceInstance
-	[PubSub.pieceInstancesSimple]: (selector: MongoQuery<PieceInstance>, token: string | undefined) => PieceInstance
-	[PubSub.parts]: (selector: MongoQuery<DBPart>, token: string | undefined) => DBPart
-	[PubSub.partInstances]: (selector: MongoQuery<PartInstance>, token: string | undefined) => PartInstance
-	[PubSub.partInstancesSimple]: (selector: MongoQuery<PartInstance>, token: string | undefined) => PartInstance
-	[PubSub.partInstancesForSegmentPlayout]: (
-		selector: MongoQuery<PartInstance>,
-		token: string | undefined
-	) => PartInstance
-	[PubSub.segments]: (selector: MongoQuery<DBSegment>, token: string | undefined) => DBSegment
-	[PubSub.showStyleBases]: (selector: MongoQuery<DBShowStyleBase>, token: string | undefined) => DBShowStyleBase
-	[PubSub.showStyleVariants]: (
-		selector: MongoQuery<DBShowStyleVariant>,
-		token: string | undefined
-	) => DBShowStyleVariant
-	[PubSub.triggeredActions]: (
-		selector: MongoQuery<DBTriggeredActions>,
-		token: string | undefined
-	) => DBTriggeredActions
-	[PubSub.snapshots]: (selector: MongoQuery<SnapshotItem>, token: string | undefined) => SnapshotItem
-	[PubSub.studios]: (selector: MongoQuery<DBStudio>, token: string | undefined) => DBStudio
-	[PubSub.studioOfDevice]: (deviceId: PeripheralDeviceId, token: string | undefined) => DBStudio
-	[PubSub.timeline]: (selector: MongoQuery<TimelineComplete>, token: string | undefined) => TimelineComplete
-	[PubSub.userActionsLog]: (selector: MongoQuery<UserActionsLogItem>, token: string | undefined) => UserActionsLogItem
+	[PubSub.ingestDataCache]: (selector: MongoQuery<IngestDataCacheObj>, token?: string) => IngestDataCacheObj
+	[PubSub.rundownPlaylists]: (selector: MongoQuery<DBRundownPlaylist>, token?: string) => DBRundownPlaylist
+	[PubSub.rundowns]: (selector: MongoQuery<DBRundown>, token?: string) => DBRundown
+	[PubSub.adLibActions]: (selector: MongoQuery<AdLibAction>, token?: string) => AdLibAction
+	[PubSub.adLibPieces]: (selector: MongoQuery<AdLibPiece>, token?: string) => AdLibPiece
+	[PubSub.pieces]: (selector: MongoQuery<Piece>, token?: string) => Piece
+	[PubSub.pieceInstances]: (selector: MongoQuery<PieceInstance>, token?: string) => PieceInstance
+	[PubSub.pieceInstancesSimple]: (selector: MongoQuery<PieceInstance>, token?: string) => PieceInstance
+	[PubSub.parts]: (selector: MongoQuery<DBPart>, token?: string) => DBPart
+	[PubSub.partInstances]: (selector: MongoQuery<PartInstance>, token?: string) => PartInstance
+	[PubSub.partInstancesSimple]: (selector: MongoQuery<PartInstance>, token?: string) => PartInstance
+	[PubSub.partInstancesForSegmentPlayout]: (selector: MongoQuery<PartInstance>, token?: string) => PartInstance
+	[PubSub.segments]: (selector: MongoQuery<DBSegment>, token?: string) => DBSegment
+	[PubSub.showStyleBases]: (selector: MongoQuery<DBShowStyleBase>, token?: string) => DBShowStyleBase
+	[PubSub.showStyleVariants]: (selector: MongoQuery<DBShowStyleVariant>, token?: string) => DBShowStyleVariant
+	[PubSub.triggeredActions]: (selector: MongoQuery<DBTriggeredActions>, token?: string) => DBTriggeredActions
+	[PubSub.snapshots]: (selector: MongoQuery<SnapshotItem>, token?: string) => SnapshotItem
+	[PubSub.studios]: (selector: MongoQuery<DBStudio>, token?: string) => DBStudio
+	[PubSub.studioOfDevice]: (deviceId: PeripheralDeviceId, token?: string) => DBStudio
+	[PubSub.timeline]: (selector: MongoQuery<TimelineComplete>, token?: string) => TimelineComplete
+	[PubSub.userActionsLog]: (selector: MongoQuery<UserActionsLogItem>, token?: string) => UserActionsLogItem
 	/** @deprecated */
-	[PubSub.mediaWorkFlows]: (selector: MongoQuery<MediaWorkFlow>, token: string | undefined) => MediaWorkFlow
+	[PubSub.mediaWorkFlows]: (selector: MongoQuery<MediaWorkFlow>, token?: string) => MediaWorkFlow
 	/** @deprecated */
-	[PubSub.mediaWorkFlowSteps]: (
-		selector: MongoQuery<MediaWorkFlowStep>,
-		token: string | undefined
-	) => MediaWorkFlowStep
-	[PubSub.rundownLayouts]: (selector: MongoQuery<RundownLayoutBase>, token: string | undefined) => RundownLayoutBase
-	[PubSub.loggedInUser]: (token: string | undefined) => DBUser
-	[PubSub.usersInOrganization]: (selector: MongoQuery<DBUser>, token: string | undefined) => DBUser
-	[PubSub.organization]: (selector: MongoQuery<DBOrganization>, token: string | undefined) => DBOrganization
-	[PubSub.buckets]: (selector: MongoQuery<Bucket>, token: string | undefined) => Bucket
-	[PubSub.bucketAdLibPieces]: (selector: MongoQuery<BucketAdLib>, token: string | undefined) => BucketAdLib
-	[PubSub.bucketAdLibActions]: (
-		selector: MongoQuery<BucketAdLibAction>,
-		token: string | undefined
-	) => BucketAdLibAction
-	[PubSub.translationsBundles]: (
-		selector: MongoQuery<TranslationsBundle>,
-		token: string | undefined
-	) => TranslationsBundle
-	[PubSub.expectedPackages]: (selector: MongoQuery<ExpectedPackageDB>, token: string | undefined) => ExpectedPackageDB
+	[PubSub.mediaWorkFlowSteps]: (selector: MongoQuery<MediaWorkFlowStep>, token?: string) => MediaWorkFlowStep
+	[PubSub.rundownLayouts]: (selector: MongoQuery<RundownLayoutBase>, token?: string) => RundownLayoutBase
+	[PubSub.loggedInUser]: (token?: string) => DBUser
+	[PubSub.usersInOrganization]: (selector: MongoQuery<DBUser>, token?: string) => DBUser
+	[PubSub.organization]: (selector: MongoQuery<DBOrganization>, token?: string) => DBOrganization
+	[PubSub.buckets]: (selector: MongoQuery<Bucket>, token?: string) => Bucket
+	[PubSub.bucketAdLibPieces]: (selector: MongoQuery<BucketAdLib>, token?: string) => BucketAdLib
+	[PubSub.bucketAdLibActions]: (selector: MongoQuery<BucketAdLibAction>, token?: string) => BucketAdLibAction
+	[PubSub.translationsBundles]: (selector: MongoQuery<TranslationsBundle>, token?: string) => TranslationsBundle
+	[PubSub.expectedPackages]: (selector: MongoQuery<ExpectedPackageDB>, token?: string) => ExpectedPackageDB
 	[PubSub.expectedPackageWorkStatuses]: (
 		selector: MongoQuery<ExpectedPackageWorkStatus>,
-		token: string | undefined
+		token?: string
 	) => ExpectedPackageWorkStatus
 	[PubSub.packageContainerPackageStatuses]: (
 		studioId: StudioId,
@@ -207,23 +173,26 @@ export interface PubSubTypes {
 	) => PackageContainerPackageStatusDB
 	[PubSub.packageContainerStatuses]: (
 		selector: MongoQuery<PackageContainerStatusDB>,
-		token: string | undefined
+		token?: string
 	) => PackageContainerStatusDB
-	[PubSub.packageInfos]: (selector: MongoQuery<PackageInfoDB>, token: string | undefined) => PackageInfoDB
+	[PubSub.packageInfos]: (selector: MongoQuery<PackageInfoDB>, token?: string) => PackageInfoDB
 
 	// custom publications:
-	[PubSub.mappingsForDevice]: (deviceId: PeripheralDeviceId, token: string | undefined) => RoutedMappings
-	[PubSub.timelineForDevice]: (deviceId: PeripheralDeviceId, token: string | undefined) => RoutedTimeline
-	[PubSub.mappingsForStudio]: (studioId: StudioId, token: string | undefined) => RoutedMappings
-	[PubSub.timelineForStudio]: (studioId: StudioId, token: string | undefined) => RoutedTimeline
+	[PubSub.mappingsForDevice]: (deviceId: PeripheralDeviceId, token?: string) => RoutedMappings
+	[PubSub.timelineForDevice]: (deviceId: PeripheralDeviceId, token?: string) => RoutedTimeline
+	[PubSub.mappingsForStudio]: (studioId: StudioId, token?: string) => RoutedMappings
+	[PubSub.timelineForStudio]: (studioId: StudioId, token?: string) => RoutedTimeline
 	[PubSub.expectedPackagesForDevice]: (
 		deviceId: PeripheralDeviceId,
 		filterPlayoutDeviceIds: PeripheralDeviceId[] | undefined,
-		token: string | undefined
+		token?: string
 	) => DBObj
 }
 
-export function meteorSubscribe(name: PubSub, ...args: any[]): Meteor.SubscriptionHandle {
+export function meteorSubscribe<K extends keyof PubSubTypes>(
+	name: K,
+	...args: Parameters<PubSubTypes[K]>
+): Meteor.SubscriptionHandle {
 	if (Meteor.isClient) {
 		return Meteor.subscribe(name, ...args)
 	} else throw new Meteor.Error(500, 'meteorSubscribe is only available client-side')

--- a/meteor/server/publications/buckets.ts
+++ b/meteor/server/publications/buckets.ts
@@ -1,5 +1,5 @@
 import { Meteor } from 'meteor/meteor'
-import { MongoQuery, FindOptions } from '../../lib/typings/meteor'
+import { FindOptions } from '../../lib/typings/meteor'
 import { BucketSecurity } from '../security/buckets'
 import { meteorPublish } from './lib'
 import { PubSub } from '../../lib/api/pubsub'
@@ -9,7 +9,7 @@ import { BucketAdLibActions, BucketAdLibAction } from '../../lib/collections/Buc
 import { StudioReadAccess } from '../security/studio'
 import { isProtectedString } from '@sofie-automation/corelib/dist/protectedString'
 
-meteorPublish(PubSub.buckets, function (selector: MongoQuery<Bucket>, _token) {
+meteorPublish(PubSub.buckets, function (selector, _token) {
 	if (!selector) throw new Meteor.Error(400, 'selector argument missing')
 	const modifier: FindOptions<Bucket> = {
 		fields: {},
@@ -23,7 +23,7 @@ meteorPublish(PubSub.buckets, function (selector: MongoQuery<Bucket>, _token) {
 	return null
 })
 
-meteorPublish(PubSub.bucketAdLibPieces, function (selector: MongoQuery<BucketAdLib>, _token) {
+meteorPublish(PubSub.bucketAdLibPieces, function (selector, _token) {
 	if (!selector) throw new Meteor.Error(400, 'selector argument missing')
 	const modifier: FindOptions<BucketAdLib> = {
 		fields: {},
@@ -34,7 +34,7 @@ meteorPublish(PubSub.bucketAdLibPieces, function (selector: MongoQuery<BucketAdL
 	return null
 })
 
-meteorPublish(PubSub.bucketAdLibActions, function (selector: MongoQuery<BucketAdLibAction>, _token) {
+meteorPublish(PubSub.bucketAdLibActions, function (selector, _token) {
 	if (!selector) throw new Meteor.Error(400, 'selector argument missing')
 	const modifier: FindOptions<BucketAdLibAction> = {
 		fields: {},

--- a/meteor/server/publications/expectedPackages.ts
+++ b/meteor/server/publications/expectedPackages.ts
@@ -301,7 +301,7 @@ meteorCustomPublishArray(
 		pub,
 		deviceId: PeripheralDeviceId,
 		filterPlayoutDeviceIds: PeripheralDeviceId[] | undefined,
-		token: string
+		token: string | undefined
 	) {
 		if (
 			PeripheralDeviceReadAccess.peripheralDeviceContent({ deviceId: deviceId }, { userId: this.userId, token })

--- a/meteor/server/publications/rundown.ts
+++ b/meteor/server/publications/rundown.ts
@@ -11,8 +11,8 @@ import { DBPart, Parts } from '../../lib/collections/Parts'
 import { Piece, Pieces } from '../../lib/collections/Pieces'
 import { PieceInstance, PieceInstances } from '../../lib/collections/PieceInstances'
 import { PartInstances, DBPartInstance } from '../../lib/collections/PartInstances'
-import { ExpectedMediaItem, ExpectedMediaItems } from '../../lib/collections/ExpectedMediaItems'
-import { ExpectedPlayoutItem, ExpectedPlayoutItems } from '../../lib/collections/ExpectedPlayoutItems'
+import { ExpectedMediaItems } from '../../lib/collections/ExpectedMediaItems'
+import { ExpectedPlayoutItems } from '../../lib/collections/ExpectedPlayoutItems'
 import { IngestDataCache, IngestDataCacheObj } from '../../lib/collections/IngestDataCache'
 import { RundownBaselineAdLibItem, RundownBaselineAdLibPieces } from '../../lib/collections/RundownBaselineAdLibPieces'
 import { NoSecurityReadAccess } from '../security/noSecurity'
@@ -24,7 +24,7 @@ import {
 	RundownBaselineAdLibActions,
 } from '../../lib/collections/RundownBaselineAdLibActions'
 
-meteorPublish(PubSub.rundowns, function (selector0, token: string) {
+meteorPublish(PubSub.rundowns, function (selector0, token) {
 	const { cred, selector } = AutoFillSelector.organizationId<DBRundown>(this.userId, selector0, token)
 	if (!selector) throw new Meteor.Error(400, 'selector argument missing')
 	const modifier: FindOptions<DBRundown> = {
@@ -42,7 +42,7 @@ meteorPublish(PubSub.rundowns, function (selector0, token: string) {
 	}
 	return null
 })
-meteorPublish(PubSub.segments, function (selector: MongoQuery<DBSegment>, token?: string) {
+meteorPublish(PubSub.segments, function (selector, token) {
 	if (!selector) throw new Meteor.Error(400, 'selector argument missing')
 	const modifier: FindOptions<DBSegment> = {
 		fields: {
@@ -59,7 +59,7 @@ meteorPublish(PubSub.segments, function (selector: MongoQuery<DBSegment>, token?
 	return null
 })
 
-meteorPublish(PubSub.parts, function (selector: MongoQuery<DBPart>, token?: string) {
+meteorPublish(PubSub.parts, function (selector, token) {
 	if (!selector) throw new Meteor.Error(400, 'selector argument missing')
 	const modifier: FindOptions<DBPart> = {
 		fields: {
@@ -91,7 +91,7 @@ meteorPublish(PubSub.partInstances, function (selector: MongoQuery<DBPartInstanc
 	}
 	return null
 })
-meteorPublish(PubSub.partInstancesSimple, function (selector: MongoQuery<DBPartInstance>, token?: string) {
+meteorPublish(PubSub.partInstancesSimple, function (selector, token) {
 	if (!selector) throw new Meteor.Error(400, 'selector argument missing')
 	const modifier: FindOptions<DBPartInstance> = {
 		fields: {
@@ -110,7 +110,7 @@ meteorPublish(PubSub.partInstancesSimple, function (selector: MongoQuery<DBPartI
 	}
 	return null
 })
-meteorPublish(PubSub.partInstancesForSegmentPlayout, function (selector: MongoQuery<DBPartInstance>, token?: string) {
+meteorPublish(PubSub.partInstancesForSegmentPlayout, function (selector, token) {
 	if (!selector) throw new Meteor.Error(400, 'selector argument missing')
 	const modifier: FindOptions<DBPartInstance> = {
 		fields: {
@@ -144,7 +144,7 @@ meteorPublish(PubSub.pieces, function (selector: MongoQuery<Piece>, token?: stri
 	return null
 })
 
-meteorPublish(PubSub.adLibPieces, function (selector: MongoQuery<AdLibPiece>, token?: string) {
+meteorPublish(PubSub.adLibPieces, function (selector, token) {
 	if (!selector) throw new Meteor.Error(400, 'selector argument missing')
 	const modifier: FindOptions<AdLibPiece> = {
 		fields: {
@@ -158,7 +158,7 @@ meteorPublish(PubSub.adLibPieces, function (selector: MongoQuery<AdLibPiece>, to
 	}
 	return null
 })
-meteorPublish(PubSub.pieceInstances, function (selector: MongoQuery<PieceInstance>, token?: string) {
+meteorPublish(PubSub.pieceInstances, function (selector, token) {
 	if (!selector) throw new Meteor.Error(400, 'selector argument missing')
 	const modifier: FindOptions<PieceInstance> = {
 		fields: {
@@ -178,7 +178,7 @@ meteorPublish(PubSub.pieceInstances, function (selector: MongoQuery<PieceInstanc
 	return null
 })
 
-meteorPublish(PubSub.pieceInstancesSimple, function (selector: MongoQuery<PieceInstance>, token?: string) {
+meteorPublish(PubSub.pieceInstancesSimple, function (selector, token) {
 	if (!selector) throw new Meteor.Error(400, 'selector argument missing')
 	const modifier: FindOptions<PieceInstance> = {
 		fields: {
@@ -201,7 +201,7 @@ meteorPublish(PubSub.pieceInstancesSimple, function (selector: MongoQuery<PieceI
 	}
 	return null
 })
-meteorPublish(PubSub.expectedMediaItems, function (selector: MongoQuery<ExpectedMediaItem>, token?: string) {
+meteorPublish(PubSub.expectedMediaItems, function (selector, token) {
 	const allowed = RundownReadAccess.expectedMediaItems(selector, { userId: this.userId, token })
 	if (!allowed) {
 		return null
@@ -216,7 +216,7 @@ meteorPublish(PubSub.expectedMediaItems, function (selector: MongoQuery<Expected
 	}
 	return null
 })
-meteorPublish(PubSub.expectedPlayoutItems, function (selector: MongoQuery<ExpectedPlayoutItem>, token?: string) {
+meteorPublish(PubSub.expectedPlayoutItems, function (selector, token) {
 	const allowed = RundownReadAccess.expectedPlayoutItems(selector, { userId: this.userId, token })
 	if (!allowed) {
 		return null
@@ -232,7 +232,7 @@ meteorPublish(PubSub.expectedPlayoutItems, function (selector: MongoQuery<Expect
 	return null
 })
 // Note: this publication is for dev purposes only:
-meteorPublish(PubSub.ingestDataCache, function (selector: MongoQuery<IngestDataCacheObj>, token?: string) {
+meteorPublish(PubSub.ingestDataCache, function (selector, token) {
 	if (!selector) throw new Meteor.Error(400, 'selector argument missing')
 	const modifier: FindOptions<IngestDataCacheObj> = {
 		fields: {},

--- a/meteor/server/publications/studio.ts
+++ b/meteor/server/publications/studio.ts
@@ -158,7 +158,7 @@ meteorPublish(
 	}
 )
 
-meteorCustomPublishArray<RoutedMappings>(
+meteorCustomPublishArray(
 	PubSub.mappingsForDevice,
 	'studioMappings',
 	async function (pub, deviceId: PeripheralDeviceId, token) {
@@ -177,15 +177,11 @@ meteorCustomPublishArray<RoutedMappings>(
 	}
 )
 
-meteorCustomPublishArray<RoutedMappings>(
-	PubSub.mappingsForStudio,
-	'studioMappings',
-	async function (pub, studioId: StudioId, token) {
-		if (StudioReadAccess.studio({ _id: studioId }, { userId: this.userId, token })) {
-			await createObserverForMappingsPublication(pub, PubSub.mappingsForStudio, studioId)
-		}
+meteorCustomPublishArray(PubSub.mappingsForStudio, 'studioMappings', async function (pub, studioId: StudioId, token) {
+	if (StudioReadAccess.studio({ _id: studioId }, { userId: this.userId, token })) {
+		await createObserverForMappingsPublication(pub, PubSub.mappingsForStudio, studioId)
 	}
-)
+})
 
 interface RoutedMappingsArgs {
 	readonly studioId: StudioId

--- a/meteor/server/publications/timeline.ts
+++ b/meteor/server/publications/timeline.ts
@@ -36,7 +36,7 @@ meteorPublish(PubSub.timeline, function (selector, token) {
 	return null
 })
 
-meteorCustomPublishArray<RoutedTimeline>(
+meteorCustomPublishArray(
 	PubSub.timelineForDevice,
 	'studioTimeline',
 	async function (pub, deviceId: PeripheralDeviceId, token) {
@@ -55,15 +55,11 @@ meteorCustomPublishArray<RoutedTimeline>(
 	}
 )
 
-meteorCustomPublishArray<RoutedTimeline>(
-	PubSub.timelineForStudio,
-	'studioTimeline',
-	async function (pub, studioId: StudioId, token) {
-		if (StudioReadAccess.studio({ _id: studioId }, { userId: this.userId, token })) {
-			await createObserverForTimelinePublication(pub, PubSub.timelineForStudio, studioId)
-		}
+meteorCustomPublishArray(PubSub.timelineForStudio, 'studioTimeline', async function (pub, studioId: StudioId, token) {
+	if (StudioReadAccess.studio({ _id: studioId }, { userId: this.userId, token })) {
+		await createObserverForTimelinePublication(pub, PubSub.timelineForStudio, studioId)
 	}
-)
+})
 
 interface RoutedTimelineArgs {
 	readonly studioId: StudioId

--- a/meteor/server/security/showStyle.ts
+++ b/meteor/server/security/showStyle.ts
@@ -15,7 +15,6 @@ import { TriggeredActionId, TriggeredActions, TriggeredActionsObj } from '../../
 import { SystemWriteAccess } from './system'
 import { fetchShowStyleBaseLight, ShowStyleBaseLight } from '../../lib/collections/optimizations'
 
-type ShowStyleContent = { showStyleBaseId: ShowStyleBaseId }
 export namespace ShowStyleReadAccess {
 	export function showStyleBase(
 		selector: MongoQuery<{ _id: ShowStyleBaseId }>,
@@ -24,13 +23,14 @@ export namespace ShowStyleReadAccess {
 		return showStyleBaseContent({ showStyleBaseId: selector._id }, cred)
 	}
 	/** Handles read access for all studioId content */
-	export function showStyleBaseContent(
-		selector: MongoQuery<ShowStyleContent>,
+	export function showStyleBaseContent<T extends { showStyleBaseId: ShowStyleBaseId | null }>(
+		selector: MongoQuery<T>,
 		cred: Credentials | ResolvedCredentials
 	): boolean {
 		check(selector, Object)
 		if (!Settings.enableUserAccounts) return true
-		if (!selector.showStyleBaseId) throw new Meteor.Error(400, 'selector must contain showStyleBaseId')
+		if (!selector.showStyleBaseId || !isProtectedString(selector.showStyleBaseId))
+			throw new Meteor.Error(400, 'selector must contain showStyleBaseId')
 
 		const access = allowAccessToShowStyleBase(cred, selector.showStyleBaseId)
 		if (!access.read) return logNotAllowed('ShowStyleBase content', access.reason)

--- a/meteor/server/security/translationsBundles.ts
+++ b/meteor/server/security/translationsBundles.ts
@@ -1,7 +1,7 @@
 import { TranslationsBundles } from '../../lib/collections/TranslationsBundles'
 
 export namespace TranslationsBundlesSecurity {
-	export function allowReadAccess(_selector: object, _token: string, _context: any): boolean {
+	export function allowReadAccess(_selector: object, _token: string | undefined, _context: any): boolean {
 		return true
 	}
 	export function allowWriteAccess(): boolean {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

code quality

* **What is the current behavior?** (You can also link to an open issue here)

Most of the meteor publications are using parameters which are implicitly any. A few were defining types, but many were not.
In the UI, when subscribing to these, there was no type safety in place except for the id of the publication.

* **What is the new behavior (if this is a feature change)?**

Our wrappings around the meteor methods have been updated to have strongly defined typings.
There is an interface describing the possible combinations which with some generics and some infered types, provides us with a type safe usages where typescript knows what the valid parameters are and what we are calling it with.

* **Other information**:

So far this is limited to meteor (core and ui), and not the gateways. We should look at getting the same types there too, but that is more effort than doing it inside of meteor.

As a follow up we should discuss whether we should have these mongo selectors as parameters to the publications. While it is easy to implement, it would be safer if we were to construct the mongo queries on the server side based on a few simple parameters provided.
Also, almost every publication accepts an auth token as the last parameter. I think this is for gateways to be able to use them. Should gateways be able to use all the publications? And is this token parameter the best way to achieve this?


**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
