### PR TITLE
fix(Playout): don't destroy stuff going from rehearsal to broadcast

### DIFF
--- a/packages/job-worker/src/playout/playout.ts
+++ b/packages/job-worker/src/playout/playout.ts
@@ -212,7 +212,8 @@ export async function activateRundownPlaylist(context: JobContext, data: Activat
 			await checkNoOtherPlaylistsActive(context, playlist)
 		},
 		async (cache) => {
-			await prepareStudioForBroadcast(context, cache, true)
+			const okToDestroyStuff = !cache.Playlist.doc.activationId // will be false if already activated (probably in rehearsal)
+			await prepareStudioForBroadcast(context, cache, okToDestroyStuff)
 
 			await libActivateRundownPlaylist(context, cache, data.rehearsal)
 		}

--- a/packages/job-worker/src/playout/playout.ts
+++ b/packages/job-worker/src/playout/playout.ts
@@ -212,7 +212,8 @@ export async function activateRundownPlaylist(context: JobContext, data: Activat
 			await checkNoOtherPlaylistsActive(context, playlist)
 		},
 		async (cache) => {
-			const okToDestroyStuff = !cache.Playlist.doc.activationId // will be false if already activated (probably in rehearsal)
+			// This will be false if already activated (like when going from rehearsal to broadcast)
+			const okToDestroyStuff = !cache.Playlist.doc.activationId
 			await prepareStudioForBroadcast(context, cache, okToDestroyStuff)
 
 			await libActivateRundownPlaylist(context, cache, data.rehearsal)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Whenever doing any activation, the `devicesMakeReady` method will be called for on the playoutDevices with `okToDestroyStuff` flag set to true.

* **What is the new behavior (if this is a feature change)?**

If the rundown is already active, the `okToDestroyStuff` flag will be set to `false`, which should prevent visible glitches from the playout devices being reset.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
