### PR TITLE
fix: make `isolatedAutorunWithCleanup` independent from `currentComputation`

### DIFF
--- a/meteor/client/lib/triggers/TriggersHandler.tsx
+++ b/meteor/client/lib/triggers/TriggersHandler.tsx
@@ -172,7 +172,7 @@ export interface MountedGenericTrigger {
 export const MountedGenericTriggers = new Mongo.Collection<MountedGenericTrigger>(null)
 
 function isolatedAutorunWithCleanup(autorun: () => void | (() => void)): Tracker.Computation {
-	const computation = Tracker.nonreactive(() =>
+	return Tracker.nonreactive(() =>
 		Tracker.autorun((computation) => {
 			const cleanUp = autorun()
 
@@ -181,12 +181,6 @@ function isolatedAutorunWithCleanup(autorun: () => void | (() => void)): Tracker
 			}
 		})
 	)
-	if (Tracker.currentComputation) {
-		Tracker.currentComputation.onStop(() => {
-			computation.stop()
-		})
-	}
-	return computation
 }
 
 /**


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bugfix regarding Action Triggers

* **What is the current behavior?** (You can also link to an open issue here)

MountedAdLibTriggers are lost when ShowStyle config is updated (and in other scenarios causing the tracker in RundownView to rerun)

* **What is the new behavior (if this is a feature change)?**

* **Other information**:

In a scenario when `isolatedAutorunWithCleanup` is called within an effect, the `currentComputation` might be stopped and replaced, triggering the cleanup, but the effect might not rerun due to the dependencies being identical. Manually stop trackers made with `isolatedAutorunWithCleanup` when no longer needed.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
