### PR TITLE
Feat/yellow line only play

### DIFF
--- a/packages/job-worker/src/events/handle.ts
+++ b/packages/job-worker/src/events/handle.ts
@@ -308,23 +308,23 @@ async function notifyCurrentPlayingPartMOS(
 	newPlayingPartExternalId: string | null
 ): Promise<void> {
 	if (oldPlayingPartExternalId !== newPlayingPartExternalId) {
-		// Note: In an older version of sofie, we sent the PLAY command before sending the STOP command,
-		// since tests showed slightly better performance when doing so.
-		// However, this is not compatible with ENPS anymore, so we now send the STOP command first.
-
-		if (oldPlayingPartExternalId) {
-			try {
-				await setStoryStatusMOS(
-					context,
-					peripheralDevice._id,
-					rundownExternalId,
-					oldPlayingPartExternalId,
-					MOS.IMOSObjectStatus.STOP
-				)
-			} catch (error) {
-				logger.error(`Error in setStoryStatus STOP: ${stringifyError(error)}`)
-			}
-		}
+		// Experiment: only send PLAY
+		// Reason 1: NRK ENPS "sendt tid" (elapsed time) stopped working in ENPS 8/9 when doing STOP prior to PLAY
+		// Reason 2: there's a delay between the STOP (yellow line disappears) and PLAY (yellow line re-appears), which annoys the users
+		// Reason 3: Troubleshooting/investigation: Test if this implementation changes the behaviour of the NOM-commands which spawn from the roElementsStat
+		// if (oldPlayingPartExternalId) {
+		// 	try {
+		// 		await setStoryStatusMOS(
+		// 			context,
+		// 			peripheralDevice._id,
+		// 			rundownExternalId,
+		// 			oldPlayingPartExternalId,
+		// 			MOS.IMOSObjectStatus.STOP
+		// 		)
+		// 	} catch (error) {
+		// 		logger.error(`Error in setStoryStatus STOP: ${stringifyError(error)}`)
+		// 	}
+		// }
 
 		if (newPlayingPartExternalId) {
 			try {

--- a/packages/job-worker/src/events/handle.ts
+++ b/packages/job-worker/src/events/handle.ts
@@ -308,24 +308,9 @@ async function notifyCurrentPlayingPartMOS(
 	newPlayingPartExternalId: string | null
 ): Promise<void> {
 	if (oldPlayingPartExternalId !== newPlayingPartExternalId) {
-		// Experiment: only send PLAY
+		// New implementation 2022 only sends PLAY, never stop, after getting advice from AP
 		// Reason 1: NRK ENPS "sendt tid" (elapsed time) stopped working in ENPS 8/9 when doing STOP prior to PLAY
 		// Reason 2: there's a delay between the STOP (yellow line disappears) and PLAY (yellow line re-appears), which annoys the users
-		// Reason 3: Troubleshooting/investigation: Test if this implementation changes the behaviour of the NOM-commands which spawn from the roElementsStat
-		// if (oldPlayingPartExternalId) {
-		// 	try {
-		// 		await setStoryStatusMOS(
-		// 			context,
-		// 			peripheralDevice._id,
-		// 			rundownExternalId,
-		// 			oldPlayingPartExternalId,
-		// 			MOS.IMOSObjectStatus.STOP
-		// 		)
-		// 	} catch (error) {
-		// 		logger.error(`Error in setStoryStatus STOP: ${stringifyError(error)}`)
-		// 	}
-		// }
-
 		if (newPlayingPartExternalId) {
 			try {
 				await setStoryStatusMOS(


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix affecting ENPS.



* **What is the current behavior?** (You can also link to an open issue here)
Sending roElementStat STOP before roElementStat PLAY triggers a bug in the ENPS NOM.


* **What is the new behavior (if this is a feature change)?**
Advised by AP, we only send roElementStat PLAY.


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
