### PR TITLE
Fix: JSONBlob

### DIFF
--- a/meteor/server/api/snapshot.ts
+++ b/meteor/server/api/snapshot.ts
@@ -73,6 +73,7 @@ import { StudioJobs } from '@sofie-automation/corelib/dist/worker/studio'
 import { ReadonlyDeep } from 'type-fest'
 import { checkAccessToPlaylist, VerifiedRundownPlaylistContentAccess } from './lib'
 import { PackageInfo } from '../coreSystem'
+import { JSONBlobParse, JSONBlobStringify } from '@sofie-automation/shared-lib/dist/lib/JSONBlob'
 
 interface RundownPlaylistSnapshot extends CoreRundownPlaylistSnapshot {
 	versionExtended: string | undefined
@@ -316,7 +317,7 @@ async function createRundownPlaylistSnapshot(
 		full,
 	})
 	const coreResult = await queuedJob.complete
-	const coreSnapshot: CoreRundownPlaylistSnapshot = JSON.parse(coreResult.snapshotJson)
+	const coreSnapshot: CoreRundownPlaylistSnapshot = JSONBlobParse(coreResult.snapshotJson)
 
 	const mediaObjectIds: Array<string> = [
 		...getPiecesMediaObjects(coreSnapshot.pieces),
@@ -529,7 +530,7 @@ async function restoreFromRundownPlaylistSnapshot(
 	}
 
 	const queuedJob = await QueueStudioJob(StudioJobs.RestorePlaylistSnapshot, studioId, {
-		snapshotJson: JSON.stringify(omit(snapshot, 'mediaObjects', 'userActions')),
+		snapshotJson: JSONBlobStringify(omit(snapshot, 'mediaObjects', 'userActions')),
 	})
 	await queuedJob.complete
 

--- a/packages/corelib/src/worker/studio.ts
+++ b/packages/corelib/src/worker/studio.ts
@@ -11,6 +11,8 @@ import {
 	SegmentId,
 	StudioId,
 } from '../dataModel/Ids'
+import { JSONBlob } from '@sofie-automation/shared-lib/dist/lib/JSONBlob'
+import { CoreRundownPlaylistSnapshot } from '../snapshots'
 
 /** List of all Jobs performed by the Worker related to a certain Studio */
 export enum StudioJobs {
@@ -147,14 +149,14 @@ export interface GeneratePlaylistSnapshotResult {
 	 * Stringified JSON of the snapshot
 	 * Note: it is kept as a string to avoid needing to parse the very large blob unnecesarily
 	 */
-	snapshotJson: string
+	snapshotJson: JSONBlob<CoreRundownPlaylistSnapshot>
 }
 export interface RestorePlaylistSnapshotProps {
 	/**
 	 * Stringified JSON of the snapshot
 	 * Note: it is kept as a string to avoid needing to parse the very large blob unnecesarily
 	 */
-	snapshotJson: string
+	snapshotJson: JSONBlob<CoreRundownPlaylistSnapshot>
 }
 export interface RestorePlaylistSnapshotResult {
 	playlistId: RundownPlaylistId

--- a/packages/job-worker/src/playout/snapshot.ts
+++ b/packages/job-worker/src/playout/snapshot.ts
@@ -27,6 +27,7 @@ import { saveIntoDb } from '../db/changes'
 import { getPartId, getSegmentId } from '../ingest/lib'
 import { assertNever, getRandomId, literal } from '@sofie-automation/corelib/dist/lib'
 import { logger } from '../logging'
+import { JSONBlobParse, JSONBlobStringify } from '@sofie-automation/shared-lib/dist/lib/JSONBlob'
 
 export async function handleGeneratePlaylistSnapshot(
 	context: JobContext,
@@ -123,7 +124,7 @@ export async function handleGeneratePlaylistSnapshot(
 	})
 
 	return {
-		snapshotJson: JSON.stringify(snapshot, undefined, 2),
+		snapshotJson: JSONBlobStringify(snapshot),
 	}
 }
 
@@ -132,7 +133,7 @@ export async function handleRestorePlaylistSnapshot(
 	props: RestorePlaylistSnapshotProps
 ): Promise<RestorePlaylistSnapshotResult> {
 	// Future: we should validate this against a schema or something
-	const snapshot: CoreRundownPlaylistSnapshot = JSON.parse(props.snapshotJson)
+	const snapshot: CoreRundownPlaylistSnapshot = JSONBlobParse(props.snapshotJson)
 
 	const oldPlaylistId = snapshot.playlistId
 

--- a/packages/shared-lib/src/__tests__/JSONBlob.spec.ts
+++ b/packages/shared-lib/src/__tests__/JSONBlob.spec.ts
@@ -1,0 +1,49 @@
+import { JSONBlobParse, JSONBlobStringify } from '../lib/JSONBlob'
+
+test('JSONBlob', () => {
+	// Unit test:
+	interface A {
+		a: number
+	}
+	const a: A = {
+		a: 1,
+	}
+	const checkTypeIsA = (_o: A) => {
+		// nothing
+	}
+	interface B {
+		b: number
+	}
+	const b: B = {
+		b: 1,
+	}
+
+	try {
+		// Note: This part is not intended to actually be executed, just to check types
+
+		// @ts-expect-error JSONBlobParse should only accept a JSONBlob
+		JSONBlobParse(a)
+		// @ts-expect-error JSONBlobParse should only accept a JSONBlob
+		JSONBlobParse(str)
+		// @ts-expect-error JSON.parse should not accept a JSONBlob
+		JSON.parse(a)
+	} catch (_err) {
+		// ignore execution errors
+	}
+
+	const str = 'string'
+
+	const aBlob = JSONBlobStringify(a)
+	const a2 = JSONBlobParse(aBlob)
+
+	checkTypeIsA(a2)
+
+	const bBlob = JSONBlobStringify(b)
+	const b2 = JSONBlobParse(bBlob)
+
+	// @ts-expect-error verify that A !== B
+	checkTypeIsA(b2)
+
+	expect(a2).toMatchObject(a)
+	expect(b2).toMatchObject(b)
+})

--- a/packages/shared-lib/src/lib/JSONBlob.ts
+++ b/packages/shared-lib/src/lib/JSONBlob.ts
@@ -1,0 +1,30 @@
+/***************************************************************************************
+ * JSONBlob is intended to be used instead of JSON.parse/JSON.stringify,
+ * in order to share stricter typings between the stringifying (sending) and the
+ * parsing (receiving) side.
+ *
+ * Usage:
+ * interface A {
+ *   a: number
+ * }
+ * const aBlob: JSONBlob<A> = JSONBlobStringify({ a: 1 })
+ * const a: A = JSONBlobParse(aBlob)
+ *
+ ************************************************************************************** /
+
+/**
+ * Data type for stringified data using JSONBlobStringify().
+ * To parse the data, use JSONBlobParse()
+ */
+export interface JSONBlob<T> extends String {
+	__internal: T
+}
+
+/** Equivalent to JSON.stringify, but returns a JSONBlob instead, which could only be parsed by JSONBlobParse */
+export function JSONBlobStringify<T>(o: T, pretty = false): JSONBlob<T> {
+	return JSON.stringify(o, undefined, pretty ? 2 : undefined) as any as JSONBlob<T>
+}
+
+export function JSONBlobParse<T>(blob: JSONBlob<T>): T {
+	return JSON.parse(blob as any)
+}


### PR DESCRIPTION

* **What is the current behavior?** (You can also link to an open issue here)
Wherever we do JSON.stringify and then JSON.parse() we risk bugs, because JSON.parse accepts `any`.


* **What is the new behavior (if this is a feature change)?**
By using JSONBlob we ensure that typings are kept and it's not as risky to parse strings anymore.

Usage:
```typescript
interface A {
  a: number
}
const aBlob: JSONBlob<A> = JSONBlobStringify({ a: 1 })
const a: A = JSONBlobParse(aBlob)
```

