### PR TITLE
fix: stoppedPlayback is sometimes incorrectly reported for PartInstances

### DIFF
--- a/meteor/lib/collections/Timeline.ts
+++ b/meteor/lib/collections/Timeline.ts
@@ -10,7 +10,6 @@ import {
 	updateLookaheadLayer,
 	TimelineBlob,
 } from '@sofie-automation/corelib/dist/dataModel/Timeline'
-import { Time } from '@sofie-automation/blueprints-integration'
 export * from '@sofie-automation/corelib/dist/dataModel/Timeline'
 
 export function getRoutedTimeline(
@@ -70,8 +69,6 @@ export interface RoutedTimeline {
 	/** serialized JSON Array containing all timeline-objects */
 	timelineBlob: TimelineBlob
 	generated: TimelineComplete['generated']
-	/** The point in time the data was published */
-	published: Time
 }
 
 export const Timeline = createMongoCollection<TimelineComplete>(CollectionName.Timelines)

--- a/meteor/server/lib/customPublication.ts
+++ b/meteor/server/lib/customPublication.ts
@@ -81,6 +81,7 @@ export class CustomPublishArray<DBObj extends { _id: ProtectedString<any> }> {
 				this._publication.added(id, newDoc)
 			} else if (
 				this._docs[id]['mappingsHash'] !== newDoc['mappingsHash'] || // Fast-track for the timeline publications
+				this._docs[id]['timelineHash'] !== newDoc['timelineHash'] ||
 				!_.isEqual(this._docs[id], newDoc)
 			) {
 				// changed

--- a/meteor/server/publications/timeline.ts
+++ b/meteor/server/publications/timeline.ts
@@ -195,7 +195,6 @@ async function manipulateTimelinePublicationData(
 			timelineHash: state.timelineHash,
 			timelineBlob: state.routedTimeline,
 			generated: state.timeline?.generated ?? Date.now(),
-			published: Date.now(),
 		}),
 	]
 }
@@ -216,9 +215,9 @@ async function createObserverForTimelinePublication(
 		{ studioId },
 		setupTimelinePublicationObservers,
 		manipulateTimelinePublicationData,
-		(_args, newData) => {
-			// Don't need to perform any deep diffing
-			pub.updatedDocs(newData)
+		(_args, data) => {
+			// Don't need to perform any deep diffing, that's being done by CustomPublishArray
+			pub.updatedDocs(data)
 		},
 		0 // ms
 	)

--- a/packages/job-worker/src/cache/CacheBase.ts
+++ b/packages/job-worker/src/cache/CacheBase.ts
@@ -171,12 +171,19 @@ export abstract class ReadOnlyCacheBase<T extends ReadOnlyCacheBase<never>> {
 	hasChanges(): boolean {
 		const { allDBs } = this.getAllCollections()
 
-		if (this._deferredFunctions.length > 0) return true
+		if (this._deferredFunctions.length > 0) {
+			logger.warn(`hasChanges: _deferredFunctions.length=${this._deferredFunctions.length}`)
+			return true
+		}
 
-		if (this._deferredAfterSaveFunctions.length > 0) return true
+		if (this._deferredAfterSaveFunctions.length > 0) {
+			logger.warn(`hasChanges: _deferredAfterSaveFunctions.length=${this._deferredAfterSaveFunctions.length}`)
+			return true
+		}
 
 		for (const db of allDBs) {
 			if (db.isModified()) {
+				logger.warn(`hasChanges: db=${db.name}`)
 				return true
 			}
 		}

--- a/packages/job-worker/src/cache/CacheBase.ts
+++ b/packages/job-worker/src/cache/CacheBase.ts
@@ -172,18 +172,18 @@ export abstract class ReadOnlyCacheBase<T extends ReadOnlyCacheBase<never>> {
 		const { allDBs } = this.getAllCollections()
 
 		if (this._deferredFunctions.length > 0) {
-			logger.warn(`hasChanges: _deferredFunctions.length=${this._deferredFunctions.length}`)
+			logger.silly(`hasChanges: _deferredFunctions.length=${this._deferredFunctions.length}`)
 			return true
 		}
 
 		if (this._deferredAfterSaveFunctions.length > 0) {
-			logger.warn(`hasChanges: _deferredAfterSaveFunctions.length=${this._deferredAfterSaveFunctions.length}`)
+			logger.silly(`hasChanges: _deferredAfterSaveFunctions.length=${this._deferredAfterSaveFunctions.length}`)
 			return true
 		}
 
 		for (const db of allDBs) {
 			if (db.isModified()) {
-				logger.warn(`hasChanges: db=${db.name}`)
+				logger.silly(`hasChanges: db=${db.name}`)
 				return true
 			}
 		}

--- a/packages/job-worker/src/cache/CacheObject.ts
+++ b/packages/job-worker/src/cache/CacheObject.ts
@@ -169,8 +169,6 @@ export class DbCacheWriteObject<
 
 		if (!_.isEqual(this.doc, newDoc)) {
 			this._document = newDoc
-
-			if (!this._updated) logger.warn(`MODIFY ${this.name}`)
 			this._updated = true
 			return true
 		}

--- a/packages/job-worker/src/cache/CacheObject.ts
+++ b/packages/job-worker/src/cache/CacheObject.ts
@@ -170,6 +170,7 @@ export class DbCacheWriteObject<
 		if (!_.isEqual(this.doc, newDoc)) {
 			this._document = newDoc
 
+			if (!this._updated) logger.warn(`MODIFY ${this.name}`)
 			this._updated = true
 			return true
 		}
@@ -187,6 +188,8 @@ export class DbCacheWriteObject<
 			}
 
 			if (span) span.end()
+
+			this._updated = false
 
 			return {
 				added: 0,

--- a/packages/job-worker/src/playout/cache.ts
+++ b/packages/job-worker/src/playout/cache.ts
@@ -21,6 +21,7 @@ import { unprotectString } from '@sofie-automation/corelib/dist/protectedString'
 import { PlaylistLock } from '../jobs/lock'
 import { CacheForIngest } from '../ingest/cache'
 import { MongoQuery } from '../db'
+import { logger } from '../logging'
 
 /**
  * This is a cache used for playout operations.
@@ -369,6 +370,7 @@ export class CacheForPlayout extends CacheForPlayoutPreInit implements CacheForS
 	}
 
 	async saveAllToDatabase(): Promise<void> {
+		logger.warn('saveAllToDatabase')
 		// TODO - ideally we should make sure to preserve the lock during this operation
 		if (!this.PlaylistLock.isLocked) {
 			throw new Error('Cannot save changes with released playlist lock')

--- a/packages/job-worker/src/playout/cache.ts
+++ b/packages/job-worker/src/playout/cache.ts
@@ -370,7 +370,7 @@ export class CacheForPlayout extends CacheForPlayoutPreInit implements CacheForS
 	}
 
 	async saveAllToDatabase(): Promise<void> {
-		logger.debug('saveAllToDatabase')
+		logger.silly('saveAllToDatabase')
 		// TODO - ideally we should make sure to preserve the lock during this operation
 		if (!this.PlaylistLock.isLocked) {
 			throw new Error('Cannot save changes with released playlist lock')

--- a/packages/job-worker/src/playout/cache.ts
+++ b/packages/job-worker/src/playout/cache.ts
@@ -370,7 +370,7 @@ export class CacheForPlayout extends CacheForPlayoutPreInit implements CacheForS
 	}
 
 	async saveAllToDatabase(): Promise<void> {
-		logger.warn('saveAllToDatabase')
+		logger.debug('saveAllToDatabase')
 		// TODO - ideally we should make sure to preserve the lock during this operation
 		if (!this.PlaylistLock.isLocked) {
 			throw new Error('Cannot save changes with released playlist lock')

--- a/packages/job-worker/src/playout/lock.ts
+++ b/packages/job-worker/src/playout/lock.ts
@@ -1,6 +1,7 @@
 import { RundownPlaylistId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { RundownPlayoutPropsBase } from '@sofie-automation/corelib/dist/worker/studio'
+import { logger } from '../logging'
 import { ReadonlyDeep } from 'type-fest'
 import { ReadOnlyCache } from '../cache/CacheBase'
 import { JobContext } from '../jobs'
@@ -91,7 +92,7 @@ export async function runWithPlaylistCache<TRes>(
 
 	try {
 		const res = await fcn(fullCache)
-
+		logger.warn('runWithPlaylistCache: saveAllToDatabase')
 		await fullCache.saveAllToDatabase()
 
 		return res

--- a/packages/job-worker/src/playout/lock.ts
+++ b/packages/job-worker/src/playout/lock.ts
@@ -92,7 +92,7 @@ export async function runWithPlaylistCache<TRes>(
 
 	try {
 		const res = await fcn(fullCache)
-		logger.warn('runWithPlaylistCache: saveAllToDatabase')
+		logger.silly('runWithPlaylistCache: saveAllToDatabase')
 		await fullCache.saveAllToDatabase()
 
 		return res

--- a/packages/job-worker/src/playout/playout.ts
+++ b/packages/job-worker/src/playout/playout.ts
@@ -783,8 +783,8 @@ async function _onPartPlaybackStarted(
 		throw new Error(`PartInstance "${data.partInstanceId}" in RundownPlayst "${data.playlistId}" not found!`)
 
 	// make sure we don't run multiple times, even if TSR calls us multiple times
-	const isPlaying = !!playingPartInstance.timings?.startedPlayback
-	if (!isPlaying) {
+	const hasStartedPlaying = !!playingPartInstance.timings?.startedPlayback
+	if (!hasStartedPlaying) {
 		logger.debug(
 			`Playout reports PartInstance "${data.partInstanceId}" has started playback on timestamp ${new Date(
 				data.startedPlayback

--- a/packages/job-worker/src/playout/playout.ts
+++ b/packages/job-worker/src/playout/playout.ts
@@ -783,7 +783,7 @@ async function _onPartPlaybackStarted(
 		throw new Error(`PartInstance "${data.partInstanceId}" in RundownPlayst "${data.playlistId}" not found!`)
 
 	// make sure we don't run multiple times, even if TSR calls us multiple times
-	const isPlaying = playingPartInstance.timings?.startedPlayback && !playingPartInstance.timings?.stoppedPlayback
+	const isPlaying = !!playingPartInstance.timings?.startedPlayback
 	if (!isPlaying) {
 		logger.debug(
 			`Playout reports PartInstance "${data.partInstanceId}" has started playback on timestamp ${new Date(

--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -1168,7 +1168,7 @@ export class TSRHandler {
 
 			if (this.sendCallbacksTimeout) {
 				// Max limit for debouncing:
-				if (this.sendCallbacksDebounceCount < 10) {
+				if (this.sendCallbacksDebounceCount < 50) {
 					this.sendCallbacksDebounceCount++
 					clearTimeout(this.sendCallbacksTimeout)
 					this.sendCallbacksTimeout = undefined
@@ -1184,7 +1184,7 @@ export class TSRHandler {
 							this.logger.error('Error in timelineCallback', e)
 						})
 					this.changedResults = undefined
-				}, 100)
+				}, 40)
 			}
 		} else {
 			// @ts-expect-error Untyped bunch of methods

--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -1176,6 +1176,8 @@ export class TSRHandler {
 				assertNever(callbackName)
 			}
 
+			// Based on the use-case, we generally expect the callbacks to come in batches, so it only makes sense
+			// to wait a little bit to collect the changed callbacks
 			if (!this.sendCallbacksTimeout) {
 				this.sendCallbacksTimeout = setTimeout(this.sendChangedResults, 20)
 			}

--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -104,8 +104,6 @@ export interface RoutedTimeline {
 	/** serialized JSON Array containing all timeline-objects */
 	timelineBlob: string
 	generated: number
-	/** The point in time the data was published */
-	published: number
 
 	// this is the old way of storing the timeline, kept for backwards-compatibility
 	timeline?: TimelineObjGeneric[]
@@ -446,23 +444,15 @@ export class TSRHandler {
 		this.logger.debug(
 			`Trigger new resolving (${context}, hash: ${timeline.timelineHash}, gen: ${new Date(
 				timeline.generated
-			).toISOString()}, pub: ${new Date(timeline.published).toISOString()})`
+			).toISOString()})`
 		)
 		if (fromTlChange) {
-			const trace = {
+			sendTrace({
 				measurement: 'playout-gateway:timelineReceived',
 				start: timeline.generated,
 				tags: {},
 				ended: Date.now(),
 				duration: Date.now() - timeline.generated,
-			}
-			sendTrace(trace)
-			sendTrace({
-				measurement: 'playout-gateway:timelinePublicationLatency',
-				start: timeline.published,
-				tags: {},
-				ended: Date.now(),
-				duration: Date.now() - timeline.published,
 			})
 		}
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

The `stoppedPlayback` timestamp can be incorrectly reported by the playout gateway, due to Core sending multiples of the same timeline.

* **What is the new behavior (if this is a feature change)?**

The `published` property on the RoutedTimeline is removed, so that subsequent republishings of the same timeline through Timeline fast-track do not trigger a timeline update in playout-gateway. This is especially important when using the 'now' feature.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
