### PR TITLE
fix: reset focus when dragging from iframe

### DIFF
--- a/meteor/client/ui/Shelf/ExternalFramePanel.tsx
+++ b/meteor/client/ui/Shelf/ExternalFramePanel.tsx
@@ -458,6 +458,14 @@ export const ExternalFramePanel = withTranslation()(
 				cancelable: false,
 			})
 			window.dispatchEvent(event)
+
+			// When dragging from an iframe, the focus stays within the iframe.
+			// This can cause confusion among users, since Sofie-keyboard shortcuts doesn't work, until they click somewhere in Sofie.
+			// To solve this, we simply reset the focus so that the iframe doesn't have the focus anymore.
+			const activeElement = document.activeElement as HTMLElement | undefined
+			if (activeElement?.tagName === 'IFRAME') {
+				activeElement.blur?.()
+			}
 		}
 
 		registerHandlers = () => {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
When dragging an object from the external_frame iframe, keyboard shortcuts stop working


* **What is the new behavior (if this is a feature change)?**
Keyboard shortcuts still work.

* **Other information**:
This has been tested to work


**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [X] The functionality has been tested by NRK
