### PR TITLE
fix(Playout Gateway): remove uninitialized devices from the list

### DIFF
--- a/meteor/yarn.lock
+++ b/meteor/yarn.lock
@@ -9860,10 +9860,10 @@ timecode@0.0.4:
   resolved "https://registry.yarnpkg.com/timecode/-/timecode-0.0.4.tgz#cdea9d2352009700e50da657cb7fb7c1720f5704"
   integrity sha512-xFVZlWnqls5eVphtUJo0UuXeJa0grBmxESSn5QPQB7CMsaVgTnLdP9PTZqb4KyFmLdrE+PUu3eEt42zHsMxCtw==
 
-timeline-state-resolver-types@7.3.0-release44.0:
-  version "7.3.0-release44.0"
-  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-7.3.0-release44.0.tgz#15e08df938f56c5cad68760a809ececb580ccd6c"
-  integrity sha512-hAfdSGvlR/Aynh5gFVU8YZF+VaabkFT/YXHVwwz03elvrNL0YNFXkVuS0gntUFLNnZ5058KbCO1qm/v3chZaGg==
+timeline-state-resolver-types@7.3.0-release44.2:
+  version "7.3.0-release44.2"
+  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-7.3.0-release44.2.tgz#2f4c0fed777d93445365bec1647e5f6bd0df9aad"
+  integrity sha512-ZwQi1qTIR0YcDkzQAlI8Zq5mWX9gHaB8SMLOhO/XMQ5OZj3D9yIFDXFfIdIxO70jSZgKzJzTFscjA9hEQ6xMGw==
   dependencies:
     tslib "^2.3.1"
 

--- a/packages/blueprints-integration/package.json
+++ b/packages/blueprints-integration/package.json
@@ -1,4 +1,4 @@
- {
+{
 	"name": "@sofie-automation/blueprints-integration",
 	"version": "1.44.0-in-testing.1",
 	"description": "Library to define the interaction between core and the blueprints.",
@@ -39,7 +39,7 @@
 	],
 	"dependencies": {
 		"@sofie-automation/shared-lib": "link:../shared-lib",
-		"timeline-state-resolver-types": "7.3.0-release44.0",
+		"timeline-state-resolver-types": "7.3.0-release44.2",
 		"tslib": "^2.4.0",
 		"type-fest": "^2.12.2"
 	},

--- a/packages/playout-gateway/package.json
+++ b/packages/playout-gateway/package.json
@@ -61,7 +61,7 @@
 		"debug": "^4.3.3",
 		"fast-clone": "^1.5.13",
 		"influx": "^5.9.3",
-		"timeline-state-resolver": "7.3.0-release44.1",
+		"timeline-state-resolver": "7.3.0-release44.2",
 		"tslib": "^2.4.0",
 		"underscore": "^1.13.3",
 		"winston": "^3.7.2"

--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -121,10 +121,12 @@ export interface TimelineContentObjectTmp extends TSRTimelineObjBase {
 /** Max time for initializing devices */
 const INIT_TIMEOUT = 10000
 
+type DeviceAction = 'add' | 'remove' | 're-add'
+
 type DeviceActionResult = {
 	success: boolean
 	deviceId: string
-	action: 'add' | 'remove'
+	action: DeviceAction
 }
 
 type UpdateDeviceOperationsResult =
@@ -134,7 +136,7 @@ type UpdateDeviceOperationsResult =
 	  }
 	| {
 			success: false
-			reason: 'timeout'
+			reason: 'timeout' | 'error'
 			details: string[]
 	  }
 
@@ -533,9 +535,13 @@ export class TSRHandler {
 		const peripheralDevice = peripheralDevices.findOne(this._coreHandler.core.deviceId)
 
 		const ps: Promise<DeviceActionResult>[] = []
-		const promiseOperations: { [id: string]: true } = {}
-		const keepTrack = async <T>(p: Promise<T>, name: string) => {
-			promiseOperations[name] = true
+		const promiseOperations: { [id: string]: { deviceId: string; operation: DeviceAction } } = {}
+		const keepTrack = async <T>(p: Promise<T>, deviceId: string, operation: DeviceAction) => {
+			const name = `${operation}_${deviceId}`
+			promiseOperations[name] = {
+				deviceId,
+				operation,
+			}
 			return p.then((result) => {
 				delete promiseOperations[name]
 				return result
@@ -576,7 +582,7 @@ export class TSRHandler {
 					if (deviceOptions.options) {
 						this.logger.info('Initializing device: ' + deviceId)
 						this.logger.info('new', deviceOptions)
-						ps.push(keepTrack(this._addDevice(deviceId, deviceOptions), 'add_' + deviceId))
+						ps.push(keepTrack(this._addDevice(deviceId, deviceOptions), deviceId, 'add'))
 					}
 				} else {
 					if (deviceOptions.options) {
@@ -596,8 +602,8 @@ export class TSRHandler {
 							this.logger.info('old', oldDevice.deviceOptions)
 							this.logger.info('new', deviceOptions)
 							ps.push(
-								keepTrack(this._removeDevice(deviceId), 'remove_' + deviceId).then(async () => {
-									return keepTrack(this._addDevice(deviceId, deviceOptions), 're-add_' + deviceId)
+								keepTrack(this._removeDevice(deviceId), deviceId, 'remove').then(async () => {
+									return keepTrack(this._addDevice(deviceId, deviceOptions), deviceId, 're-add')
 								})
 							)
 						}
@@ -609,7 +615,7 @@ export class TSRHandler {
 				const deviceId = oldDevice.deviceId
 				if (!devices.has(deviceId)) {
 					this.logger.info('Un-initializing device: ' + deviceId)
-					ps.push(keepTrack(this._removeDevice(deviceId), 'remove_' + deviceId))
+					ps.push(keepTrack(this._removeDevice(deviceId), deviceId, 'remove'))
 				}
 			}
 		}
@@ -621,15 +627,43 @@ export class TSRHandler {
 			})),
 			new Promise<UpdateDeviceOperationsResult>((resolve) =>
 				setTimeout(() => {
-					const keys = _.keys(promiseOperations)
+					const keys = Object.keys(promiseOperations)
 					if (keys.length) {
-						this.logger.warn(`Timeout in _updateDevices: ${keys.join(',')}`)
+						this.logger.warn(
+							`Timeout in _updateDevices: ${Object.values(promiseOperations)
+								.map((op) => op.deviceId)
+								.join(',')}`
+						)
 					}
-					resolve({
-						success: false,
-						reason: 'timeout',
-						details: keys,
-					})
+
+					Promise.all(
+						Object.values(promiseOperations)
+							.filter((op) => op.operation === 'add' || op.operation === 're-add')
+							.map(async (op) =>
+								// the device was never added, should retry next round
+								this._removeDevice(op.deviceId)
+							)
+					)
+						.then(() => {
+							resolve({
+								success: false,
+								reason: 'timeout',
+								details: keys,
+							})
+						})
+						.catch((e) => {
+							this.logger.error(
+								`Error when trying to remove unsuccessfully initialized devices: ${stringifyIds(
+									Object.values(promiseOperations).map((op) => op.deviceId)
+								)}`,
+								e
+							)
+							resolve({
+								success: false,
+								reason: 'error',
+								details: keys,
+							})
+						})
 				}, INIT_TIMEOUT)
 			), // Timeout if not all are resolved within INIT_TIMEOUT
 		])
@@ -659,6 +693,7 @@ export class TSRHandler {
 		return deviceOptions.debug || this._coreHandler.logDebug || false
 	}
 	private async _reportResult(resultsOrTimeout: UpdateDeviceOperationsResult): Promise<void> {
+		this.logger.warn(JSON.stringify(resultsOrTimeout))
 		// Check if the updateDevice operation failed before completing
 		if (!resultsOrTimeout.success) {
 			// It failed because there was a global timeout (not a device-specific failure)
@@ -675,7 +710,11 @@ export class TSRHandler {
 			} else {
 				await this._coreHandler.core.setStatus({
 					statusCode: StatusCode.BAD,
-					messages: [`Unknown error during device update: ${resultsOrTimeout.reason}`],
+					messages: [
+						`Unknown error during device update: ${resultsOrTimeout.reason}. Devices: ${stringifyIds(
+							resultsOrTimeout.details
+						)}`,
+					],
 				})
 			}
 

--- a/packages/yarn.lock
+++ b/packages/yarn.lock
@@ -2933,7 +2933,7 @@
   version "1.44.0-in-testing.1"
   dependencies:
     "@sofie-automation/shared-lib" "link:shared-lib"
-    timeline-state-resolver-types "7.3.0-release44.0"
+    timeline-state-resolver-types "7.3.0-release44.2"
     tslib "^2.4.0"
     type-fest "^2.12.2"
 
@@ -13748,7 +13748,7 @@ threadedclass@^0.8.0:
     is-running "^2.1.0"
     tslib "^1.13.0"
 
-threadedclass@^1.1.0:
+threadedclass@^1.1.0, threadedclass@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/threadedclass/-/threadedclass-1.1.1.tgz#6813b3c401b3d55264f6225c9d2c15516d7efa97"
   integrity sha512-HffBjerRZGOlhUBt9Ue8nYCuV6khK9er86w4svTvf1Xn6ibAyJok290o2MJ/qJ1vy0A4UphEo3DSsxFN5g+TBQ==
@@ -13793,24 +13793,17 @@ timecode@0.0.4:
   resolved "https://registry.yarnpkg.com/timecode/-/timecode-0.0.4.tgz#cdea9d2352009700e50da657cb7fb7c1720f5704"
   integrity sha512-xFVZlWnqls5eVphtUJo0UuXeJa0grBmxESSn5QPQB7CMsaVgTnLdP9PTZqb4KyFmLdrE+PUu3eEt42zHsMxCtw==
 
-timeline-state-resolver-types@7.3.0-release44.0:
-  version "7.3.0-release44.0"
-  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-7.3.0-release44.0.tgz#15e08df938f56c5cad68760a809ececb580ccd6c"
-  integrity sha512-hAfdSGvlR/Aynh5gFVU8YZF+VaabkFT/YXHVwwz03elvrNL0YNFXkVuS0gntUFLNnZ5058KbCO1qm/v3chZaGg==
+timeline-state-resolver-types@7.3.0-release44.2:
+  version "7.3.0-release44.2"
+  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-7.3.0-release44.2.tgz#2f4c0fed777d93445365bec1647e5f6bd0df9aad"
+  integrity sha512-ZwQi1qTIR0YcDkzQAlI8Zq5mWX9gHaB8SMLOhO/XMQ5OZj3D9yIFDXFfIdIxO70jSZgKzJzTFscjA9hEQ6xMGw==
   dependencies:
     tslib "^2.3.1"
 
-timeline-state-resolver-types@7.3.0-release44.1:
-  version "7.3.0-release44.1"
-  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-7.3.0-release44.1.tgz#dbaf950ba64154d98508d3cb921c02c7f900fbc3"
-  integrity sha512-3A0diZtEAIQYjGbc5xemKRPT485xi7nDOYmUiBT/O8M0tyGmHU2e8P5P32MircNDF3556EaXA2hCgpnXAzimGw==
-  dependencies:
-    tslib "^2.3.1"
-
-timeline-state-resolver@7.3.0-release44.1:
-  version "7.3.0-release44.1"
-  resolved "https://registry.yarnpkg.com/timeline-state-resolver/-/timeline-state-resolver-7.3.0-release44.1.tgz#9414a252c48b5d5b358ee0cb99d8e10a5b762967"
-  integrity sha512-t6l2aevjlkdy6fIiQIjg3BiShpydosOsBuZtZpaAgNzHsanEiRx0mshQ1RnR0iBZzaXNaAkcYrCBHJUCnIQ9vA==
+timeline-state-resolver@7.3.0-release44.2:
+  version "7.3.0-release44.2"
+  resolved "https://registry.yarnpkg.com/timeline-state-resolver/-/timeline-state-resolver-7.3.0-release44.2.tgz#b6ee11bc1dd44daa28458d85a092ae4c4c116e75"
+  integrity sha512-qPiRGDdUVdMFgJ3Jz7cOZOSpduyXSijYIuVvJRj8vwBvxTwsaA6yIhl6LAAz+ND+1JevD60Wxt43I+b+QLx7mA==
   dependencies:
     "@tv2media/v-connection" "^6.0.2"
     atem-connection "2.4.0"
@@ -13831,8 +13824,8 @@ timeline-state-resolver@7.3.0-release44.1:
     request "^2.88.0"
     sprintf-js "^1.1.2"
     superfly-timeline "^8.2.7"
-    threadedclass "^1.1.0"
-    timeline-state-resolver-types "7.3.0-release44.1"
+    threadedclass "^1.1.1"
+    timeline-state-resolver-types "7.3.0-release44.2"
     tslib "^2.3.1"
     tv-automation-quantel-gateway-client "^2.0.4"
     underscore "^1.12.0"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

If a device fails to initialize correctly in a `_updateDevices` pass due to a crash or a timeout, it still stays in TSR's "devices" list. Because there is no change in device settings, the device is never retried to initialize, causing it to be potentially stuck forever, even if it could initialize later correctly (say, the hardware device comes back online) and the overall Peripheral Device status cannot be properly evaluated.

* **What is the new behavior (if this is a feature change)?**

Remove them from TSR if they failed to initialize and retry initializing them in `_updateDevices`.

* **Other information**:

Requires https://github.com/nrkno/sofie-timeline-state-resolver/pull/220 to be merged

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
