### PR TITLE
Feat: timeline datastore

### DIFF
--- a/meteor/client/ui/TestTools/TimelineDatastore.tsx
+++ b/meteor/client/ui/TestTools/TimelineDatastore.tsx
@@ -1,0 +1,113 @@
+import * as React from 'react'
+import {
+	Translated,
+	translateWithTracker,
+	useSubscription,
+	useTracker,
+} from '../../lib/ReactMeteorData/react-meteor-data'
+import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
+import { StudioSelect } from './StudioSelect'
+import { StudioId } from '../../../lib/collections/Studios'
+import { Mongo } from 'meteor/mongo'
+import { TimelineDatastoreEntry } from '../../../lib/collections/TimelineDatastore'
+import { PubSub } from '../../../lib/api/pubsub'
+
+const TimelineDatastore = new Mongo.Collection<TimelineDatastoreEntry>('timelineDatastore')
+
+interface ITimelineDatastoreViewProps {
+	match?: {
+		params?: {
+			studioId: StudioId
+		}
+	}
+}
+interface ITimelineDatastoreViewState {}
+const TimelineDatastoreView = translateWithTracker<ITimelineDatastoreViewProps, ITimelineDatastoreViewState, {}>(
+	(_props: ITimelineDatastoreViewProps) => {
+		return {}
+	}
+)(
+	class TimelineDatastoreView extends MeteorReactComponent<
+		Translated<ITimelineDatastoreViewProps>,
+		ITimelineDatastoreViewState
+	> {
+		constructor(props: Translated<ITimelineDatastoreViewProps>) {
+			super(props)
+		}
+
+		render() {
+			const { t } = this.props
+
+			return (
+				<div className="mtl gutter">
+					<header className="mvs">
+						<h1>{t('Timeline Datastore')}</h1>
+					</header>
+					<div className="mod mvl">
+						{this.props.match && this.props.match.params && (
+							<div>
+								{/* <ComponentMappingsTable studioId={this.props.match.params.studioId} /> */}
+								<ComponentDatastoreControls studioId={this.props.match.params.studioId} />
+							</div>
+						)}
+					</div>
+				</div>
+			)
+		}
+	}
+)
+
+interface IDatastoreControlsProps {
+	studioId: StudioId
+}
+function ComponentDatastoreControls({ studioId }: IDatastoreControlsProps) {
+	useSubscription(PubSub.timelineDatastore, { studioId })
+
+	const datastore = useTracker(() => TimelineDatastore.find().fetch(), [studioId])
+
+	const createOrEdit = (key: string, value: any) => {
+		const doc = datastore?.find((entry) => entry.studioId === studioId && entry.key === key)
+		if (doc) {
+			TimelineDatastore.update(doc._id, {
+				$set: {
+					value,
+					modified: Date.now(),
+				},
+			})
+		} else {
+			TimelineDatastore.insert({
+				studioId,
+
+				key,
+				value,
+
+				modified: Date.now(),
+			})
+		}
+	}
+
+	return (
+		<div>
+			<div>
+				<button className="btn btn-primary" onMouseDown={() => createOrEdit('input', 1)}>
+					1
+				</button>
+				<button className="btn btn-primary" onMouseDown={() => createOrEdit('input', 2)}>
+					2
+				</button>
+				<button className="btn btn-primary" onMouseDown={() => createOrEdit('input', 3)}>
+					3
+				</button>
+			</div>
+			<div>{JSON.stringify(datastore)}</div>
+		</div>
+	)
+}
+
+class TimelineDatastoreStudioSelect extends React.Component<{}, {}> {
+	render() {
+		return <StudioSelect path="timelinedatastore" title="Timeline Datastore" />
+	}
+}
+
+export { TimelineDatastoreView, TimelineDatastoreStudioSelect }

--- a/meteor/client/ui/TestTools/TimelineDatastore.tsx
+++ b/meteor/client/ui/TestTools/TimelineDatastore.tsx
@@ -1,113 +1,76 @@
 import * as React from 'react'
-import {
-	Translated,
-	translateWithTracker,
-	useSubscription,
-	useTracker,
-} from '../../lib/ReactMeteorData/react-meteor-data'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
+import { useSubscription, useTracker } from '../../lib/ReactMeteorData/react-meteor-data'
 import { StudioSelect } from './StudioSelect'
 import { StudioId } from '../../../lib/collections/Studios'
 import { Mongo } from 'meteor/mongo'
 import { TimelineDatastoreEntry } from '../../../lib/collections/TimelineDatastore'
 import { PubSub } from '../../../lib/api/pubsub'
+import { protectString, unprotectString } from '@sofie-automation/corelib/dist/protectedString'
+import { useTranslation } from 'react-i18next'
+import { useParams } from 'react-router-dom'
 
 const TimelineDatastore = new Mongo.Collection<TimelineDatastoreEntry>('timelineDatastore')
 
-interface ITimelineDatastoreViewProps {
-	match?: {
-		params?: {
-			studioId: StudioId
-		}
-	}
+interface TimelineDatastoreViewRouteParams {
+	studioId: string
 }
-interface ITimelineDatastoreViewState {}
-const TimelineDatastoreView = translateWithTracker<ITimelineDatastoreViewProps, ITimelineDatastoreViewState, {}>(
-	(_props: ITimelineDatastoreViewProps) => {
-		return {}
-	}
-)(
-	class TimelineDatastoreView extends MeteorReactComponent<
-		Translated<ITimelineDatastoreViewProps>,
-		ITimelineDatastoreViewState
-	> {
-		constructor(props: Translated<ITimelineDatastoreViewProps>) {
-			super(props)
-		}
 
-		render() {
-			const { t } = this.props
+const TimelineDatastoreView: React.FC = function TimelineDatastoreView() {
+	const { t } = useTranslation()
+	const { studioId } = useParams<TimelineDatastoreViewRouteParams>()
 
-			return (
-				<div className="mtl gutter">
-					<header className="mvs">
-						<h1>{t('Timeline Datastore')}</h1>
-					</header>
-					<div className="mod mvl">
-						{this.props.match && this.props.match.params && (
-							<div>
-								{/* <ComponentMappingsTable studioId={this.props.match.params.studioId} /> */}
-								<ComponentDatastoreControls studioId={this.props.match.params.studioId} />
-							</div>
-						)}
+	return (
+		<div className="mtl gutter">
+			<header className="mvs">
+				<h1>{t('Timeline Datastore')}</h1>
+			</header>
+			<div className="mod mvl">
+				{studioId && (
+					<div>
+						<ComponentDatastoreControls studioId={protectString(studioId)} />
 					</div>
-				</div>
-			)
-		}
-	}
-)
+				)}
+			</div>
+		</div>
+	)
+}
 
 interface IDatastoreControlsProps {
 	studioId: StudioId
 }
 function ComponentDatastoreControls({ studioId }: IDatastoreControlsProps) {
-	useSubscription(PubSub.timelineDatastore, { studioId })
+	useSubscription(PubSub.timelineDatastore, studioId)
 
 	const datastore = useTracker(() => TimelineDatastore.find().fetch(), [studioId])
-
-	const createOrEdit = (key: string, value: any) => {
-		const doc = datastore?.find((entry) => entry.studioId === studioId && entry.key === key)
-		if (doc) {
-			TimelineDatastore.update(doc._id, {
-				$set: {
-					value,
-					modified: Date.now(),
-				},
-			})
-		} else {
-			TimelineDatastore.insert({
-				studioId,
-
-				key,
-				value,
-
-				modified: Date.now(),
-			})
-		}
-	}
 
 	return (
 		<div>
 			<div>
-				<button className="btn btn-primary" onMouseDown={() => createOrEdit('input', 1)}>
-					1
-				</button>
-				<button className="btn btn-primary" onMouseDown={() => createOrEdit('input', 2)}>
-					2
-				</button>
-				<button className="btn btn-primary" onMouseDown={() => createOrEdit('input', 3)}>
-					3
-				</button>
+				<table className="testtools-timelinetable">
+					<tbody>
+						<tr>
+							<th>Key</th>
+							<th>Last modified</th>
+							<th>Type</th>
+							<th>Value</th>
+						</tr>
+						{datastore?.map((entry) => (
+							<tr key={unprotectString(entry._id)}>
+								<td>{entry.key}</td>
+								<td>{entry.modified}</td>
+								<td>{entry.mode}</td>
+								<td>{entry.value}</td>
+							</tr>
+						))}
+					</tbody>
+				</table>
 			</div>
-			<div>{JSON.stringify(datastore)}</div>
 		</div>
 	)
 }
 
-class TimelineDatastoreStudioSelect extends React.Component<{}, {}> {
-	render() {
-		return <StudioSelect path="timelinedatastore" title="Timeline Datastore" />
-	}
+const TimelineDatastoreStudioSelect: React.FC = function TimelineDatastoreStudioSelect() {
+	return <StudioSelect path="timelinedatastore" title="Timeline Datastore" />
 }
 
 export { TimelineDatastoreView, TimelineDatastoreStudioSelect }

--- a/meteor/client/ui/TestTools/TimelineDatastore.tsx
+++ b/meteor/client/ui/TestTools/TimelineDatastore.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react'
 import { useSubscription, useTracker } from '../../lib/ReactMeteorData/react-meteor-data'
 import { StudioSelect } from './StudioSelect'
-import { StudioId } from '../../../lib/collections/Studios'
 import { Mongo } from 'meteor/mongo'
 import { TimelineDatastoreEntry } from '../../../lib/collections/TimelineDatastore'
 import { PubSub } from '../../../lib/api/pubsub'
 import { protectString, unprotectString } from '@sofie-automation/corelib/dist/protectedString'
 import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router-dom'
+import { StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 
 const TimelineDatastore = new Mongo.Collection<TimelineDatastoreEntry>('timelineDatastore')
 

--- a/meteor/client/ui/TestTools/index.tsx
+++ b/meteor/client/ui/TestTools/index.tsx
@@ -7,6 +7,7 @@ import { TimelineView, TimelineStudioSelect } from './Timeline'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { PubSub } from '../../../lib/api/pubsub'
 import { MappingsStudioSelect, MappingsView } from './Mappings'
+import { TimelineDatastoreStudioSelect, TimelineDatastoreView } from './TimelineDatastore'
 
 interface IStatusMenuProps {
 	match?: any
@@ -25,6 +26,13 @@ const StatusMenu = withTranslation()(
 						to={'/testTools/timeline'}
 					>
 						<h3>{t('Timeline')}</h3>
+					</NavLink>
+					<NavLink
+						activeClassName="selectable-selected"
+						className="testTools-menu__testTools-menu-item selectable clickable"
+						to={'/testTools/timelinedatastore'}
+					>
+						<h3>{t('Timeline Datastore')}</h3>
 					</NavLink>
 					<NavLink
 						activeClassName="selectable-selected"
@@ -72,6 +80,8 @@ class Status extends MeteorReactComponent<Translated<IStatusProps>> {
 								<Route path="/testTools/timeline" component={TimelineStudioSelect} />
 								<Route path="/testTools/mappings/:studioId" component={MappingsView} />
 								<Route path="/testTools/mappings" component={MappingsStudioSelect} />
+								<Route path="/testTools/timelinedatastore/:studioId" component={TimelineDatastoreView} />
+								<Route path="/testTools/timelinedatastore" component={TimelineDatastoreStudioSelect} />
 								<Redirect to="/testTools/timeline" />
 							</Switch>
 						</div>

--- a/meteor/lib/api/pubsub.ts
+++ b/meteor/lib/api/pubsub.ts
@@ -7,6 +7,7 @@ import {
 	ShowStyleBaseId,
 	StudioId,
 } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { DBTimelineDatastoreEntry } from '@sofie-automation/corelib/dist/dataModel/TimelineDatastore'
 import { Meteor } from 'meteor/meteor'
 import { AdLibAction } from '../collections/AdLibActions'
 import { AdLibPiece } from '../collections/AdLibPieces'
@@ -185,6 +186,7 @@ export interface PubSubTypes {
 	[PubSub.studios]: (selector: MongoQuery<DBStudio>, token?: string) => DBStudio
 	[PubSub.studioOfDevice]: (deviceId: PeripheralDeviceId, token?: string) => DBStudio
 	[PubSub.timeline]: (selector: MongoQuery<TimelineComplete>, token?: string) => TimelineComplete
+	[PubSub.timelineDatastore]: (studioId: StudioId, token?: string) => DBTimelineDatastoreEntry
 	[PubSub.userActionsLog]: (selector: MongoQuery<UserActionsLogItem>, token?: string) => UserActionsLogItem
 	/** @deprecated */
 	[PubSub.mediaWorkFlows]: (selector: MongoQuery<MediaWorkFlow>, token?: string) => MediaWorkFlow
@@ -220,6 +222,7 @@ export interface PubSubTypes {
 	// custom publications:
 	[PubSub.mappingsForDevice]: (deviceId: PeripheralDeviceId, token?: string) => RoutedMappings
 	[PubSub.timelineForDevice]: (deviceId: PeripheralDeviceId, token?: string) => RoutedTimeline
+	[PubSub.timelineDatastoreForDevice]: (deviceId: PeripheralDeviceId, token?: string) => DBTimelineDatastoreEntry
 	[PubSub.mappingsForStudio]: (studioId: StudioId, token?: string) => RoutedMappings
 	[PubSub.timelineForStudio]: (studioId: StudioId, token?: string) => RoutedTimeline
 	[PubSub.expectedPackagesForDevice]: (

--- a/meteor/lib/api/pubsub.ts
+++ b/meteor/lib/api/pubsub.ts
@@ -91,6 +91,7 @@ export enum PubSub {
 	studios = 'studios',
 	studioOfDevice = 'studioOfDevice',
 	timeline = 'timeline',
+	timelineDatastore = 'timelineDatastore',
 	userActionsLog = 'userActionsLog',
 	/** @deprecated */
 	mediaWorkFlows = 'mediaWorkFlows',
@@ -116,6 +117,7 @@ export enum PubSub {
 	// custom publications:
 	mappingsForDevice = 'mappingsForDevice',
 	timelineForDevice = 'timelineForDevice',
+	timelineDatastoreForDevice = 'timelineDatastoreForDevice',
 	mappingsForStudio = 'mappingsForStudio',
 	timelineForStudio = 'timelineForStudio',
 	expectedPackagesForDevice = 'expectedPackagesForDevice',

--- a/meteor/lib/collections/TimelineDatastore.ts
+++ b/meteor/lib/collections/TimelineDatastore.ts
@@ -1,0 +1,16 @@
+import { createMongoCollection } from './lib'
+import { registerIndex } from '../database'
+import { TimelineDatastoreEntryId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+export { TimelineDatastoreEntryId }
+import { CollectionName } from '@sofie-automation/corelib/dist/dataModel/Collections'
+
+import { DBTimelineDatastoreEntry } from '@sofie-automation/corelib/dist/dataModel/TimelineDatastore'
+export * from '@sofie-automation/corelib/dist/dataModel/Segment'
+
+export type TimelineDatastoreEntry = DBTimelineDatastoreEntry
+
+export const TimelineDatastore = createMongoCollection<TimelineDatastoreEntry>(CollectionName.TimelineDatastore)
+
+registerIndex(TimelineDatastore, {
+	studioId: 1,
+})

--- a/meteor/lib/collections/TimelineDatastore.ts
+++ b/meteor/lib/collections/TimelineDatastore.ts
@@ -1,11 +1,8 @@
 import { createMongoCollection } from './lib'
 import { registerIndex } from '../database'
-import { TimelineDatastoreEntryId } from '@sofie-automation/corelib/dist/dataModel/Ids'
-export { TimelineDatastoreEntryId }
 import { CollectionName } from '@sofie-automation/corelib/dist/dataModel/Collections'
 
 import { DBTimelineDatastoreEntry } from '@sofie-automation/corelib/dist/dataModel/TimelineDatastore'
-export * from '@sofie-automation/corelib/dist/dataModel/Segment'
 
 export type TimelineDatastoreEntry = DBTimelineDatastoreEntry
 

--- a/meteor/server/lib.ts
+++ b/meteor/server/lib.ts
@@ -31,6 +31,7 @@ const public_dir = path.join(process.cwd(), '../web.browser/app')
  * Get the i18next locale object for a given `languageCode`. If the translations file can not be found or it can't be
  * parsed, it will return an empty object.
  *
+ *
  * @export
  * @param {string} languageCode
  * @return {*}  {Promise<Translations>}

--- a/meteor/server/publications/timeline.ts
+++ b/meteor/server/publications/timeline.ts
@@ -41,13 +41,13 @@ meteorPublish(PubSub.timeline, async function (selector, token) {
 	}
 	return null
 })
-meteorPublish(PubSub.timelineDatastore, function (selector, token) {
-	if (!selector) throw new Meteor.Error(400, 'selector argument missing')
+meteorPublish(PubSub.timelineDatastore, async function (studioId, token) {
+	if (!studioId) throw new Meteor.Error(400, 'selector argument missing')
 	const modifier: FindOptions<TimelineDatastoreEntry> = {
 		fields: {},
 	}
-	if (StudioReadAccess.studioContent(selector, { userId: this.userId, token })) {
-		return TimelineDatastore.find(selector, modifier)
+	if (await StudioReadAccess.studioContent(studioId, { userId: this.userId, token })) {
+		return TimelineDatastore.find({ studioId }, modifier)
 	}
 	return null
 })
@@ -68,24 +68,22 @@ meteorCustomPublish(
 		}
 	}
 )
-meteorCustomPublishArray<TimelineDatastoreEntry>(
-	PubSub.timelineDatastoreForDevice,
-	'studioTimelineDatastore',
-	function (pub, deviceId: PeripheralDeviceId, token) {
-		if (
-			PeripheralDeviceReadAccess.peripheralDeviceContent({ deviceId: deviceId }, { userId: this.userId, token })
-		) {
-			const peripheralDevice = PeripheralDevices.findOne(deviceId)
+meteorPublish(PubSub.timelineDatastoreForDevice, async function (deviceId, token) {
+	if (await PeripheralDeviceReadAccess.peripheralDeviceContent(deviceId, { userId: this.userId, token })) {
+		const peripheralDevice = PeripheralDevices.findOne(deviceId)
 
-			if (!peripheralDevice) throw new Meteor.Error('PeripheralDevice "' + deviceId + '" not found')
+		if (!peripheralDevice) throw new Meteor.Error('PeripheralDevice "' + deviceId + '" not found')
 
-			const studioId = peripheralDevice.studioId
-			if (!studioId) return []
-
-			createObserverForTimelineDatastorePublication(pub, PubSub.timelineDatastoreForDevice, studioId)
+		const studioId = peripheralDevice.studioId
+		if (!studioId) return null
+		const modifier: FindOptions<TimelineDatastoreEntry> = {
+			fields: {},
 		}
+
+		return TimelineDatastore.find({ studioId }, modifier)
 	}
-)
+	return null
+})
 
 meteorCustomPublish(
 	PubSub.timelineForStudio,
@@ -246,46 +244,4 @@ async function createObserverForTimelinePublication(pub: CustomPublish<RoutedTim
 		pub,
 		0 // ms
 	)
-}
-function createObserverForTimelineDatastorePublication(
-	pub: CustomPublishArray<TimelineDatastoreEntry>,
-	observerId: PubSub,
-	studioId: StudioId
-) {
-	const observer = setUpOptimizedObserver<TimelineDatastoreEntry[], { studioId: StudioId | undefined }>(
-		`pub_${observerId}_${studioId}`,
-		(triggerUpdate) => {
-			// Set up observers:
-			return [
-				TimelineDatastore.find({ studioId }).observe({
-					added: () => triggerUpdate({ studioId: studioId }),
-					changed: () => triggerUpdate({ studioId: studioId }),
-					removed: () => triggerUpdate({ studioId: undefined }),
-				}),
-			]
-		},
-		() => {
-			// Initialize data
-			return {
-				studioId: studioId,
-			}
-		},
-		(newData: { studioId: StudioId | undefined }) => {
-			// Prepare data for publication:
-
-			if (!newData.studioId) {
-				return []
-			} else {
-				const datastore = TimelineDatastore.find({ studioId }).fetch()
-
-				return datastore
-			}
-		},
-		(newData) => {
-			pub.updatedDocs(newData)
-		}
-	)
-	pub.onStop(() => {
-		observer.stop()
-	})
 }

--- a/meteor/server/security/collections.ts
+++ b/meteor/server/security/collections.ts
@@ -205,11 +205,11 @@ Timeline.allow({
 	},
 })
 TimelineDatastore.allow({
-	insert(userId, doc): boolean {
-		return studioContentAllowWrite(userId, doc)
+	insert(_userId, _doc): boolean {
+		return false
 	},
-	update(userId, doc, fields, _modifier) {
-		return studioContentAllowWrite(userId, doc) && rejectFields(doc, fields, ['_id'])
+	update(_userId, _doc, _fields, _modifier) {
+		return false
 	},
 	remove(_userId, _doc) {
 		return false

--- a/meteor/server/security/collections.ts
+++ b/meteor/server/security/collections.ts
@@ -40,6 +40,7 @@ import { Buckets } from '../../lib/collections/Buckets'
 import { StudioContentWriteAccess } from './studio'
 import { TriggeredActions } from '../../lib/collections/TriggeredActions'
 import { resolveCredentials } from './lib/credentials'
+import { TimelineDatastore } from '../../lib/collections/TimelineDatastore'
 
 // Set up direct collection write access
 
@@ -198,6 +199,17 @@ Timeline.allow({
 	},
 	update(_userId, _doc, _fields, _modifier) {
 		return false
+	},
+	remove(_userId, _doc) {
+		return false
+	},
+})
+TimelineDatastore.allow({
+	insert(userId, doc): boolean {
+		return studioContentAllowWrite(userId, doc)
+	},
+	update(userId, doc, fields, _modifier) {
+		return studioContentAllowWrite(userId, doc) && rejectFields(doc, fields, ['_id'])
 	},
 	remove(_userId, _doc) {
 		return false

--- a/meteor/server/security/studio.ts
+++ b/meteor/server/security/studio.ts
@@ -83,6 +83,9 @@ export namespace StudioContentWriteAccess {
 		return anyContent(cred0, studioId)
 	}
 
+	export function timelineDatastore(cred0: Credentials, studioId: StudioId) {
+		return anyContent(cred0, studioId)
+	}
 	/** Check for permission to update the studio baseline */
 	export async function baseline(cred0: Credentials, studioId: StudioId): Promise<StudioContentAccess> {
 		return anyContent(cred0, studioId)

--- a/meteor/server/security/studio.ts
+++ b/meteor/server/security/studio.ts
@@ -83,7 +83,7 @@ export namespace StudioContentWriteAccess {
 		return anyContent(cred0, studioId)
 	}
 
-	export function timelineDatastore(cred0: Credentials, studioId: StudioId) {
+	export async function timelineDatastore(cred0: Credentials, studioId: StudioId) {
 		return anyContent(cred0, studioId)
 	}
 	/** Check for permission to update the studio baseline */

--- a/packages/blueprints-integration/src/action.ts
+++ b/packages/blueprints-integration/src/action.ts
@@ -104,6 +104,8 @@ export interface IBlueprintActionManifest {
 	/** Optional ways of executing this action. The default option is computed from the display properties */
 	triggerModes?: IBlueprintActionTriggerMode[]
 
+	// supportsDataStoreFastRoute?: boolean
+
 	/** Array of items expected to be played out. This is used by playout-devices to preload stuff.
 	 * @deprecated replaced by .expectedPackages
 	 */

--- a/packages/blueprints-integration/src/action.ts
+++ b/packages/blueprints-integration/src/action.ts
@@ -104,8 +104,6 @@ export interface IBlueprintActionManifest {
 	/** Optional ways of executing this action. The default option is computed from the display properties */
 	triggerModes?: IBlueprintActionTriggerMode[]
 
-	// supportsDataStoreFastRoute?: boolean
-
 	/** Array of items expected to be played out. This is used by playout-devices to preload stuff.
 	 * @deprecated replaced by .expectedPackages
 	 */

--- a/packages/blueprints-integration/src/api.ts
+++ b/packages/blueprints-integration/src/api.ts
@@ -16,6 +16,7 @@ import {
 	IRundownTimingEventContext,
 	IStudioBaselineContext,
 	IGetRundownContext,
+	IDataStoreActionExecutionContext,
 } from './context'
 import { IngestAdlib, ExtendedIngestRundown, IngestSegment } from './ingest'
 import { IBlueprintExternalMessageQueueObj } from './message'
@@ -162,6 +163,14 @@ export interface ShowStyleBlueprintManifest extends BlueprintManifestBase {
 
 		playoutStatus: 'previous' | 'current' | 'next'
 	) => void
+
+	/** Execute an action defined by an IBlueprintActionManifest */
+	executeDataStoreAction?: (
+		context: IDataStoreActionExecutionContext,
+		actionId: string,
+		userData: ActionUserData,
+		triggerMode?: string
+	) => Promise<void>
 
 	/** Execute an action defined by an IBlueprintActionManifest */
 	executeAction?: (

--- a/packages/blueprints-integration/src/common.ts
+++ b/packages/blueprints-integration/src/common.ts
@@ -1,4 +1,5 @@
 export { Time } from '@sofie-automation/shared-lib/dist/lib/lib'
+export { DatastorePersistenceMode } from '@sofie-automation/shared-lib/dist/core/model/TimelineDatastore'
 
 export interface IBlueprintConfig {
 	[key: string]: ConfigItemValue

--- a/packages/blueprints-integration/src/context.ts
+++ b/packages/blueprints-integration/src/context.ts
@@ -209,6 +209,9 @@ export interface IActionExecutionContext extends IShowStyleUserContext, IEventCo
 	/** Inform core that a take out of the current partinstance should be blocked until the specified time */
 	blockTakeUntil(time: Time | null): Promise<void>
 
+	setTimelineDatastoreValue(key: string, value: any, mode: 'temporary' | 'infinite'): Promise<void>
+	removeTimelineDatastoreValue(key: string): Promise<void>
+
 	/** Misc actions */
 	// updateAction(newManifest: Pick<IBlueprintAdLibActionManifest, 'description' | 'payload'>): void // only updates itself. to allow for the next one to do something different
 	// executePeripheralDeviceAction(deviceId: string, functionName: string, args: any[]): Promise<any>

--- a/packages/blueprints-integration/src/context.ts
+++ b/packages/blueprints-integration/src/context.ts
@@ -148,7 +148,15 @@ export interface ISegmentUserContext extends IUserNotesContext, IRundownContext,
 }
 
 /** Actions */
-export interface IActionExecutionContext extends IShowStyleUserContext, IEventContext {
+export interface IDataStoreActionExecutionContext extends IShowStyleUserContext, IEventContext {
+	setTimelineDatastoreValue(key: string, value: any, mode: 'temporary' | 'indefinite'): Promise<void>
+	removeTimelineDatastoreValue(key: string): Promise<void>
+}
+
+export interface IActionExecutionContext
+	extends IShowStyleUserContext,
+		IEventContext,
+		IDataStoreActionExecutionContext {
 	/** Data fetching */
 	// getIngestRundown(): IngestRundown // TODO - for which part?
 	/** Get a PartInstance which can be modified */
@@ -208,9 +216,6 @@ export interface IActionExecutionContext extends IShowStyleUserContext, IEventCo
 	takeAfterExecuteAction(take: boolean): Promise<boolean>
 	/** Inform core that a take out of the current partinstance should be blocked until the specified time */
 	blockTakeUntil(time: Time | null): Promise<void>
-
-	setTimelineDatastoreValue(key: string, value: any, mode: 'temporary' | 'infinite'): Promise<void>
-	removeTimelineDatastoreValue(key: string): Promise<void>
 
 	/** Misc actions */
 	// updateAction(newManifest: Pick<IBlueprintAdLibActionManifest, 'description' | 'payload'>): void // only updates itself. to allow for the next one to do something different

--- a/packages/blueprints-integration/src/context.ts
+++ b/packages/blueprints-integration/src/context.ts
@@ -1,4 +1,4 @@
-import { Time } from './common'
+import { DatastorePersistenceMode, Time } from './common'
 import { IBlueprintExternalMessageQueueObj } from './message'
 import { PackageInfo } from './packageInfo'
 import {
@@ -149,7 +149,14 @@ export interface ISegmentUserContext extends IUserNotesContext, IRundownContext,
 
 /** Actions */
 export interface IDataStoreActionExecutionContext extends IShowStyleUserContext, IEventContext {
-	setTimelineDatastoreValue(key: string, value: any, mode: 'temporary' | 'indefinite'): Promise<void>
+	/**
+	 * Setting a value in the datastore allows us to overwrite parts of a timeline content object with that value
+	 * @param key Key to use when referencing from the timeline object
+	 * @param value Value to overwrite the timeline object's content with
+	 * @param mode In temporary mode the value may be removed when the key is no longer on the timeline
+	 */
+	setTimelineDatastoreValue(key: string, value: any, mode: DatastorePersistenceMode): Promise<void>
+	/** Deletes a previously set value from the datastore */
 	removeTimelineDatastoreValue(key: string): Promise<void>
 }
 

--- a/packages/corelib/src/dataModel/Collections.ts
+++ b/packages/corelib/src/dataModel/Collections.ts
@@ -39,6 +39,7 @@ export enum CollectionName {
 	Snapshots = 'snapshots',
 	Studios = 'studios',
 	Timelines = 'timeline',
+	TimelineDatastore = 'timelineDatastore',
 	TriggeredActions = 'triggeredActions',
 	TranslationsBundles = 'translationsBundles',
 	UserActionsLog = 'userActionsLog',

--- a/packages/corelib/src/dataModel/Ids.ts
+++ b/packages/corelib/src/dataModel/Ids.ts
@@ -105,4 +105,7 @@ export type WorkerId = ProtectedString<'WorkerId'>
 /** A string, identifying a WorkerThread */
 export type WorkerThreadId = ProtectedString<'WorkerThreadId'>
 
+/** A string, identifyinf a TimelineDatastore entry */
+export type TimelineDatastoreEntryId = ProtectedString<'TimelineDatastoreEntryId'>
+
 export * from '@sofie-automation/shared-lib/dist/core/model/Ids'

--- a/packages/corelib/src/dataModel/TimelineDatastore.ts
+++ b/packages/corelib/src/dataModel/TimelineDatastore.ts
@@ -8,6 +8,7 @@ export interface DBTimelineDatastoreEntry {
 	value: any
 
 	modified: number
+	mode: 'temporary' | 'infinite'
 
 	/** Todo: some sort of history for the UI? */
 }

--- a/packages/corelib/src/dataModel/TimelineDatastore.ts
+++ b/packages/corelib/src/dataModel/TimelineDatastore.ts
@@ -1,0 +1,13 @@
+import { TimelineDatastoreEntryId, StudioId } from './Ids'
+
+export interface DBTimelineDatastoreEntry {
+	_id: TimelineDatastoreEntryId
+	studioId: StudioId
+
+	key: string
+	value: any
+
+	modified: number
+
+	/** Todo: some sort of history for the UI? */
+}

--- a/packages/corelib/src/dataModel/TimelineDatastore.ts
+++ b/packages/corelib/src/dataModel/TimelineDatastore.ts
@@ -1,14 +1,25 @@
+import { Time } from '@sofie-automation/blueprints-integration'
 import { TimelineDatastoreEntryId, StudioId } from './Ids'
+import { DatastorePersistenceMode } from '@sofie-automation/shared-lib/dist/core/model/TimelineDatastore'
 
 export interface DBTimelineDatastoreEntry {
 	_id: TimelineDatastoreEntryId
 	studioId: StudioId
 
+	/**
+	 * The key is used to refer from timeline objects $reference object
+	 */
 	key: string
+	/**
+	 * A value with which a part of the content of the timeline object will be overwritten
+	 */
 	value: any
 
-	modified: number
-	mode: 'temporary' | 'indefinite'
+	modified: Time
+	/**
+	 * Mode temporary may be removed when there are no more references to this key/value from the timeline
+	 */
+	mode: DatastorePersistenceMode
 
 	/** Todo: some sort of history for the UI? */
 }

--- a/packages/corelib/src/dataModel/TimelineDatastore.ts
+++ b/packages/corelib/src/dataModel/TimelineDatastore.ts
@@ -8,7 +8,7 @@ export interface DBTimelineDatastoreEntry {
 	value: any
 
 	modified: number
-	mode: 'temporary' | 'infinite'
+	mode: 'temporary' | 'indefinite'
 
 	/** Todo: some sort of history for the UI? */
 }

--- a/packages/documentation/docs/for-developers/for-blueprint-developers/timeline-datastore.md
+++ b/packages/documentation/docs/for-developers/for-blueprint-developers/timeline-datastore.md
@@ -1,0 +1,85 @@
+# Timeline Datastore
+
+The timeline datastore is a key-value store that can be used in conjuction with the timeline. The benefit of modifying values in the datastore is that the timings in the timeline are not modified so we can skip a lot of complicated calculations which reduces the system response time. An example usecase of the datastore feature is a fastpath for cutting cameras.
+
+## API
+
+In order to use the timeline datastore feature 2 API's are to be used. The timeline object has to contain a reference to a key in the datastore and the blueprints have to add a value for that key to the datastore. These references are added on the content field.
+
+### Timeline API
+
+```ts
+/**
+ * An object containing references to the datastore
+ */
+export interface TimelineDatastoreReferences {
+	/**
+	 * localPath is the path to the property in the content object to override
+	 */
+	[localPath: string]: {
+		/** Reference to the Datastore key where to fetch the value */
+		datastoreKey: string
+		/**
+		 * If true, the referenced value in the Datastore is only applied after the timeline-object has started (ie a later-started timeline-object will not be affected)
+		 */
+		overwrite: boolean
+	}
+}
+```
+
+### Timeline API example
+
+```ts
+const tlObj = {
+	id: 'obj0',
+	enable: { start: 1000 },
+	layer: 'layer0',
+	content: {
+		deviceType: DeviceType.Atem,
+		type: TimelineObjectAtem.MixEffect,
+
+		$references: {
+			'me.input': {
+				datastoreKey: 'camInput',
+				overwrite: true,
+			},
+		},
+
+		me: {
+			input: 1,
+			transition: TransitionType.Cut,
+		},
+	},
+}
+```
+
+### Blueprints API
+
+Values can be added and removed from the datastore through the adlib actions API.
+
+```ts
+interface DatastoreActionExecutionContext {
+	setTimelineDatastoreValue(key: string, value: unknown, mode: DatastorePersistenceMode): Promise<void>
+	removeTimelineDatastoreValue(key: string): Promise<void>
+}
+
+enum DatastorePersistenceMode {
+	Temporary = 'temporary',
+	indefinite = 'indefinite',
+}
+```
+
+The data persistence mode work as follows:
+
+- Temporary: this key-value pair may be cleaned up if it is no longer referenced to from the timeline, in practice this will currently only happen during deactivation of a rundown
+- This key-value pair may _not_ be automatically removed (it can still be removed by the blueprints)
+
+The above context methods may be used from the usual adlib actions context but there is also a special path where none of the usual cached data is available, as loading the caches may take some time. The `executeDataStoreAction` method is executed just before the `executeAction` method.
+
+## Example use case: camera cutting fast path
+
+Assuming a set of blueprints where we can cut camera's a on a vision mixer's mix effect by using adlib pieces, we want to add a fast path where the camera input is changed through the datastore first and then afterwards we add the piece for correctness.
+
+1.  If you haven't yet, convert the current camera adlibs to adlib actions by exporting the `IBlueprintActionManifest` as part of your `getRundown` implementation and implementing an adlib action in your `executeAction` handler that adds your camera piece.
+2.  Modify any camera pieces (including the one from your adlib action) to contain a reference to the datastore (See the timeline API example)
+3.  Implement an `executeDataStoreAction` handler as part of your blueprints, when this handler receives the action for your camera adlib it should call the `setTimelineDatastoreValue` method with the key you used in the timeline object (In the example it's `camInput`), the new input for the vision mixer and the `DatastorePersistenceMode.Temporary` persistence mode.

--- a/packages/job-worker/src/__mocks__/collection.ts
+++ b/packages/job-worker/src/__mocks__/collection.ts
@@ -21,6 +21,7 @@ import { DBSegment } from '@sofie-automation/corelib/dist/dataModel/Segment'
 import { DBShowStyleBase } from '@sofie-automation/corelib/dist/dataModel/ShowStyleBase'
 import { DBShowStyleVariant } from '@sofie-automation/corelib/dist/dataModel/ShowStyleVariant'
 import { DBStudio } from '@sofie-automation/corelib/dist/dataModel/Studio'
+import { DBTimelineDatastoreEntry } from '@sofie-automation/corelib/dist/dataModel/TimelineDatastore'
 import { TimelineComplete } from '@sofie-automation/corelib/dist/dataModel/Timeline'
 import { clone, literal } from '@sofie-automation/corelib/dist/lib'
 import {
@@ -294,6 +295,7 @@ export function getMockCollections(): Readonly<IDirectCollections> {
 			ShowStyleVariants: new MockMongoCollection<DBShowStyleVariant>(CollectionName.ShowStyleVariants),
 			Studios: new MockMongoCollection<DBStudio>(CollectionName.Studios),
 			Timelines: new MockMongoCollection<TimelineComplete>(CollectionName.Timelines),
+			TimelineDatastores: new MockMongoCollection<DBTimelineDatastoreEntry>(CollectionName.TimelineDatastore),
 
 			ExpectedPackages: new MockMongoCollection<ExpectedPackageDB>(CollectionName.ExpectedPackages),
 			PackageInfos: new MockMongoCollection(CollectionName.PackageInfos),

--- a/packages/job-worker/src/blueprints/context/adlibActions.ts
+++ b/packages/job-worker/src/blueprints/context/adlibActions.ts
@@ -78,7 +78,7 @@ export class DatastoreActionExecutionContext
 	constructor(
 		contextInfo: UserContextInfo,
 		context: JobContext,
-		showStyle: ReadonlyDeep<ShowStyleCompound>,
+		showStyle: ReadonlyDeep<ProcessedShowStyleCompound>,
 		watchedPackages: WatchedPackagesHelper
 	) {
 		super(contextInfo, context, showStyle, watchedPackages)

--- a/packages/job-worker/src/blueprints/context/adlibActions.ts
+++ b/packages/job-worker/src/blueprints/context/adlibActions.ts
@@ -560,6 +560,37 @@ export class ActionExecutionContext extends ShowStyleUserContext implements IAct
 		})
 	}
 
+	async setTimelineDatastoreValue(key: string, value: unknown, mode: 'temporary' | 'infinite'): Promise<void> {
+		const collection = this._context.directCollections.TimelineDatastores
+		const entry = await collection.findOne({ studioId: this._context.studioId, key })
+
+		if (!entry) {
+			await collection.insertOne({
+				_id: getRandomId(),
+				studioId: this._context.studioId,
+
+				key,
+				value,
+
+				modified: Date.now(),
+				mode,
+			})
+		} else {
+			await collection.update(entry._id, {
+				$set: {
+					value,
+					mode,
+					modified: Date.now(),
+				},
+			})
+		}
+	}
+
+	async removeTimelineDatastoreValue(key: string): Promise<void> {
+		const collection = this._context.directCollections.TimelineDatastores
+		await collection.remove({ studioId: this._context.studioId, key })
+	}
+
 	private _stopPiecesByRule(filter: (pieceInstance: PieceInstance) => boolean, timeOffset: number | undefined) {
 		if (!this._cache.Playlist.doc.currentPartInstanceId) {
 			return []

--- a/packages/job-worker/src/db/collections.ts
+++ b/packages/job-worker/src/db/collections.ts
@@ -33,6 +33,7 @@ import { DBShowStyleBase } from '@sofie-automation/corelib/dist/dataModel/ShowSt
 import { DBShowStyleVariant } from '@sofie-automation/corelib/dist/dataModel/ShowStyleVariant'
 import { DBStudio } from '@sofie-automation/corelib/dist/dataModel/Studio'
 import { TimelineComplete } from '@sofie-automation/corelib/dist/dataModel/Timeline'
+import { DBTimelineDatastoreEntry } from '@sofie-automation/corelib/dist/dataModel/TimelineDatastore'
 import { ExpectedPackageDB } from '@sofie-automation/corelib/dist/dataModel/ExpectedPackages'
 import { PackageInfoDB } from '@sofie-automation/corelib/dist/dataModel/PackageInfos'
 import { ProtectedString } from '@sofie-automation/corelib/dist/protectedString'
@@ -108,6 +109,7 @@ export interface IDirectCollections {
 	ShowStyleVariants: ICollection<DBShowStyleVariant>
 	Studios: ICollection<DBStudio>
 	Timelines: ICollection<TimelineComplete>
+	TimelineDatastores: ICollection<DBTimelineDatastoreEntry>
 
 	ExpectedPackages: ICollection<ExpectedPackageDB>
 	PackageInfos: ICollection<PackageInfoDB>
@@ -185,6 +187,10 @@ export function getMongoCollections(
 			),
 			Studios: wrapMongoCollection(database.collection(CollectionName.Studios), allowWatchers),
 			Timelines: wrapMongoCollection(database.collection(CollectionName.Timelines), allowWatchers),
+			TimelineDatastores: wrapMongoCollection(
+				database.collection(CollectionName.TimelineDatastore),
+				allowWatchers
+			),
 
 			ExpectedPackages: wrapMongoCollection(database.collection(CollectionName.ExpectedPackages), allowWatchers),
 			PackageInfos: wrapMongoCollection(database.collection(CollectionName.PackageInfos), allowWatchers),

--- a/packages/job-worker/src/playout/actions.ts
+++ b/packages/job-worker/src/playout/actions.ts
@@ -14,6 +14,7 @@ import { PeripheralDeviceType } from '@sofie-automation/corelib/dist/dataModel/P
 import { executePeripheralDeviceFunction } from '../peripheralDevice'
 import { EventsJobs } from '@sofie-automation/corelib/dist/worker/events'
 import { RundownPlaylistActivationId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { cleanTimelineDatastore } from './datastore'
 
 export async function activateRundownPlaylist(
 	context: JobContext,
@@ -133,6 +134,8 @@ export async function deactivateRundownPlaylist(context: JobContext, cache: Cach
 	const rundown = await deactivateRundownPlaylistInner(context, cache)
 
 	await updateStudioTimeline(context, cache)
+
+	await cleanTimelineDatastore(context, cache)
 
 	cache.defer(async () => {
 		if (rundown) {

--- a/packages/job-worker/src/playout/adlib.ts
+++ b/packages/job-worker/src/playout/adlib.ts
@@ -110,10 +110,29 @@ export async function takePieceAsAdlibNow(context: JobContext, data: TakePieceAs
 						)
 						break
 					case IBlueprintDirectPlayType.AdLibAction: {
+						const playlist = cache.PlaylistId
 						const executeProps = pieceToCopy.allowDirectPlay
+						const showStyle = await context.getShowStyleCompound(
+							rundown.showStyleVariantId,
+							rundown.showStyleBaseId
+						)
+						const blueprint = await context.getShowStyleBlueprint(showStyle._id)
+
+						const currentPartInstance = playlist.currentPartInstanceId
+							? await context.directCollections.PartInstances.findOne(playlist.currentPartInstanceId)
+							: undefined
+						if (!currentPartInstance)
+							throw new Error(
+								`Current PartInstance "${playlist.currentPartInstanceId}" could not be found.`
+							)
+
 						await executeActionInner(
 							context,
 							cache,
+							rundown,
+							showStyle,
+							blueprint,
+							currentPartInstance,
 							null, // TODO: should this be able to retrieve any watched packages?
 							async (actionContext, _rundown, _currentPartInstance, blueprint) => {
 								if (!blueprint.blueprint.executeAction)

--- a/packages/job-worker/src/playout/cache.ts
+++ b/packages/job-worker/src/playout/cache.ts
@@ -13,7 +13,6 @@ import { DBPart } from '@sofie-automation/corelib/dist/dataModel/Part'
 import { DBPartInstance } from '@sofie-automation/corelib/dist/dataModel/PartInstance'
 import { PieceInstance } from '@sofie-automation/corelib/dist/dataModel/PieceInstance'
 import { TimelineComplete } from '@sofie-automation/corelib/dist/dataModel/Timeline'
-import { DBTimelineDatastoreEntry } from '@sofie-automation/corelib/dist/dataModel/TimelineDatastore'
 import _ = require('underscore')
 import { RundownBaselineObj } from '@sofie-automation/corelib/dist/dataModel/RundownBaselineObj'
 import { cleanupRundownsForRemovedPlaylist } from '../rundownPlaylists'
@@ -126,7 +125,6 @@ export class CacheForPlayout extends CacheForPlayoutPreInit implements CacheForS
 	private toBeRemoved = false
 
 	public readonly Timeline: DbCacheWriteOptionalObject<TimelineComplete>
-	public readonly TimelineDatastore: DbCacheWriteCollection<DBTimelineDatastoreEntry>
 
 	public readonly Segments: DbCacheReadCollection<DBSegment>
 	public readonly Parts: DbCacheReadCollection<DBPart>
@@ -147,13 +145,11 @@ export class CacheForPlayout extends CacheForPlayoutPreInit implements CacheForS
 		partInstances: DbCacheWriteCollection<DBPartInstance>,
 		pieceInstances: DbCacheWriteCollection<PieceInstance>,
 		timeline: DbCacheWriteOptionalObject<TimelineComplete>,
-		timelineDatastore: DbCacheWriteCollection<DBTimelineDatastoreEntry>,
 		baselineObjects: DbCacheReadCollection<RundownBaselineObj>
 	) {
 		super(context, playlistLock, playlistId, peripheralDevices, playlist, rundowns)
 
 		this.Timeline = timeline
-		this.TimelineDatastore = timelineDatastore
 
 		this.Segments = segments
 		this.Parts = parts
@@ -252,7 +248,6 @@ export class CacheForPlayout extends CacheForPlayoutPreInit implements CacheForS
 			DbCacheWriteCollection<DBPartInstance>,
 			DbCacheWriteCollection<PieceInstance>,
 			DbCacheWriteOptionalObject<TimelineComplete>,
-			DbCacheWriteCollection<DBTimelineDatastoreEntry>,
 			DbCacheReadCollection<RundownBaselineObj>
 		]
 	> {
@@ -335,9 +330,6 @@ export class CacheForPlayout extends CacheForPlayoutPreInit implements CacheForS
 				context.directCollections.Timelines,
 				context.studioId
 			),
-			DbCacheWriteCollection.createFromDatabase(context, context.directCollections.TimelineDatastores, {
-				studioId: context.studioId,
-			}),
 		])
 
 		if (ingestCache) {

--- a/packages/job-worker/src/playout/cache.ts
+++ b/packages/job-worker/src/playout/cache.ts
@@ -13,6 +13,7 @@ import { DBPart } from '@sofie-automation/corelib/dist/dataModel/Part'
 import { DBPartInstance } from '@sofie-automation/corelib/dist/dataModel/PartInstance'
 import { PieceInstance } from '@sofie-automation/corelib/dist/dataModel/PieceInstance'
 import { TimelineComplete } from '@sofie-automation/corelib/dist/dataModel/Timeline'
+import { DBTimelineDatastoreEntry } from '@sofie-automation/corelib/dist/dataModel/TimelineDatastore'
 import _ = require('underscore')
 import { RundownBaselineObj } from '@sofie-automation/corelib/dist/dataModel/RundownBaselineObj'
 import { cleanupRundownsForRemovedPlaylist } from '../rundownPlaylists'
@@ -125,6 +126,7 @@ export class CacheForPlayout extends CacheForPlayoutPreInit implements CacheForS
 	private toBeRemoved = false
 
 	public readonly Timeline: DbCacheWriteOptionalObject<TimelineComplete>
+	public readonly TimelineDatastore: DbCacheWriteCollection<DBTimelineDatastoreEntry>
 
 	public readonly Segments: DbCacheReadCollection<DBSegment>
 	public readonly Parts: DbCacheReadCollection<DBPart>
@@ -145,11 +147,13 @@ export class CacheForPlayout extends CacheForPlayoutPreInit implements CacheForS
 		partInstances: DbCacheWriteCollection<DBPartInstance>,
 		pieceInstances: DbCacheWriteCollection<PieceInstance>,
 		timeline: DbCacheWriteOptionalObject<TimelineComplete>,
+		timelineDatastore: DbCacheWriteCollection<DBTimelineDatastoreEntry>,
 		baselineObjects: DbCacheReadCollection<RundownBaselineObj>
 	) {
 		super(context, playlistLock, playlistId, peripheralDevices, playlist, rundowns)
 
 		this.Timeline = timeline
+		this.TimelineDatastore = timelineDatastore
 
 		this.Segments = segments
 		this.Parts = parts
@@ -248,6 +252,7 @@ export class CacheForPlayout extends CacheForPlayoutPreInit implements CacheForS
 			DbCacheWriteCollection<DBPartInstance>,
 			DbCacheWriteCollection<PieceInstance>,
 			DbCacheWriteOptionalObject<TimelineComplete>,
+			DbCacheWriteCollection<DBTimelineDatastoreEntry>,
 			DbCacheReadCollection<RundownBaselineObj>
 		]
 	> {
@@ -330,6 +335,9 @@ export class CacheForPlayout extends CacheForPlayoutPreInit implements CacheForS
 				context.directCollections.Timelines,
 				context.studioId
 			),
+			DbCacheWriteCollection.createFromDatabase(context, context.directCollections.TimelineDatastores, {
+				studioId: context.studioId,
+			}),
 		])
 
 		if (ingestCache) {

--- a/packages/job-worker/src/playout/datastore.ts
+++ b/packages/job-worker/src/playout/datastore.ts
@@ -1,0 +1,21 @@
+import { deserializeTimelineBlob } from '@sofie-automation/corelib/dist/dataModel/Timeline'
+import { JobContext } from '../jobs'
+import { CacheForPlayout } from './cache'
+
+export async function cleanTimelineDatastore(_context: JobContext, cache: CacheForPlayout): Promise<void> {
+	const timeline = cache.Timeline.doc
+	const datastore = cache.TimelineDatastore.findFetch({})
+
+	if (!timeline) {
+		return
+	}
+
+	const timelineObjs = deserializeTimelineBlob(timeline.timelineBlob)
+
+	const timelineRefs = timelineObjs
+		.filter((o) => o.content.$references) // todo - update timeline types package
+		.flatMap((o) => Object.keys(o.content.$references))
+	const inactiveKeys = datastore.map((o) => o.key).filter((k) => !!timelineRefs.find((r) => r === k)) // todo - protect some values from being deleted?
+
+	cache.TimelineDatastore.remove({ key: { $in: inactiveKeys } })
+}

--- a/packages/playout-gateway/src/coreHandler.ts
+++ b/packages/playout-gateway/src/coreHandler.ts
@@ -146,6 +146,7 @@ export class CoreHandler {
 			this.core.autoSubscribe('studioOfDevice', this.core.deviceId),
 			this.core.autoSubscribe('mappingsForDevice', this.core.deviceId),
 			this.core.autoSubscribe('timelineForDevice', this.core.deviceId),
+			this.core.autoSubscribe('timelineDatastoreForDevice', this.core.deviceId),
 			this.core.autoSubscribe('peripheralDeviceCommands', this.core.deviceId),
 			this.core.autoSubscribe('rundownsForDevice', this.core.deviceId),
 		])

--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -1100,8 +1100,8 @@ export class TSRHandler {
 			studioId: peripheralDevice.studioId,
 		})
 		const datastore: Record<string, any> = {}
-		for (const obj of datastoreObjs) {
-			datastore[obj.key] = obj.value
+		for (const { key, value, modified } of datastoreObjs) {
+			datastore[key] = { value, modified }
 		}
 
 		this.logger.debug(datastore)

--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -353,6 +353,18 @@ export class TSRHandler {
 			this._triggerupdateExpectedPlayoutItems()
 		}
 		this._observers.push(expectedPlayoutItemsObserver)
+
+		const timelineDatastoreObserver = this._coreHandler.core.observe('studioTimelineDatastore')
+		timelineDatastoreObserver.added = () => {
+			this._triggerUpdateDatastore()
+		}
+		timelineDatastoreObserver.changed = () => {
+			this._triggerUpdateDatastore()
+		}
+		timelineDatastoreObserver.removed = () => {
+			this._triggerUpdateDatastore()
+		}
+		this._observers.push(timelineDatastoreObserver)
 	}
 	private resendStatuses(): void {
 		_.each(this._coreTsrHandlers, (tsrHandler) => {
@@ -1075,6 +1087,25 @@ export class TSRHandler {
 				}
 			})
 		)
+	}
+	private _triggerUpdateDatastore() {
+		if (!this._initialized) return
+		this._updateDatastore().catch((e) => this.logger.error('Error in _updateDatastore', e))
+	}
+	private async _updateDatastore() {
+		const datastoreCollection = this._coreHandler.core.getCollection('studioTimelineDatastore')
+		const peripheralDevice = this._getPeripheralDevice()
+
+		const datastoreObjs = datastoreCollection.find({
+			studioId: peripheralDevice.studioId,
+		})
+		const datastore: Record<string, any> = {}
+		for (const obj of datastoreObjs) {
+			datastore[obj.key] = obj.value
+		}
+
+		this.logger.debug(datastore)
+		this.tsr.setDatastore(datastore)
 	}
 	/**
 	 * Go through and transform timeline and generalize the Core-specific things

--- a/packages/shared-lib/src/core/model/TimelineDatastore.ts
+++ b/packages/shared-lib/src/core/model/TimelineDatastore.ts
@@ -1,0 +1,4 @@
+export enum DatastorePersistenceMode {
+	Temporary = 'temporary',
+	indefinite = 'indefinite',
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

* Implements the Datastore API from the timeline-state-resolver (https://github.com/nrkno/sofie-timeline-state-resolver/pull/219)
* Implements a new TimelinedataStore collection
* Implements a cleanup method and a debug view for said collection
* Implements a blueprint AdlibAction API for the datastore collection
* Splits the AdlibActionContext into 2 such that the blueprints can use a small, fast context for adlib actions utilising only the datastore

**Left todo**

- [x] Rebase on R47
- [ ] A round of reviews with some potential pair programming


**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
