### PR TITLE
fix(Prompter): Prompter doesn't scroll to the correct Part when using followtake

### DIFF
--- a/meteor/client/ui/Prompter/PrompterView.tsx
+++ b/meteor/client/ui/Prompter/PrompterView.tsx
@@ -290,13 +290,6 @@ export class PrompterViewInner extends MeteorReactComponent<Translated<IProps & 
 	componentDidUpdate(prevProps) {
 		this.triggerCheckCurrentTakeMarkers()
 		this.checkScrollToCurrent()
-
-		console.log(
-			'c:',
-			this.props.rundownPlaylist?.currentPartInstanceId,
-			prevProps.rundownPlaylist?.currentPartInstanceId
-		)
-		console.log('n:', this.props.rundownPlaylist?.nextPartInstanceId, prevProps.rundownPlaylist?.nextPartInstanceId)
 	}
 
 	private setDocumentTitle() {
@@ -341,7 +334,6 @@ export class PrompterViewInner extends MeteorReactComponent<Translated<IProps & 
 	scrollToPartInstance(partInstanceId: PartInstanceId) {
 		const scrollMargin = this.calculateScrollPosition()
 		const target = document.querySelector(`#partInstance_${partInstanceId}`)
-		console.log(target)
 
 		if (target) {
 			Velocity(document.body, 'finish')

--- a/meteor/client/ui/Prompter/PrompterView.tsx
+++ b/meteor/client/ui/Prompter/PrompterView.tsx
@@ -287,7 +287,7 @@ export class PrompterViewInner extends MeteorReactComponent<Translated<IProps & 
 		window.removeEventListener('scroll', this.onWindowScroll)
 	}
 
-	componentDidUpdate(prevProps) {
+	componentDidUpdate() {
 		this.triggerCheckCurrentTakeMarkers()
 		this.checkScrollToCurrent()
 	}

--- a/meteor/client/ui/Prompter/PrompterView.tsx
+++ b/meteor/client/ui/Prompter/PrompterView.tsx
@@ -287,9 +287,16 @@ export class PrompterViewInner extends MeteorReactComponent<Translated<IProps & 
 		window.removeEventListener('scroll', this.onWindowScroll)
 	}
 
-	componentDidUpdate() {
+	componentDidUpdate(prevProps) {
 		this.triggerCheckCurrentTakeMarkers()
 		this.checkScrollToCurrent()
+
+		console.log(
+			'c:',
+			this.props.rundownPlaylist?.currentPartInstanceId,
+			prevProps.rundownPlaylist?.currentPartInstanceId
+		)
+		console.log('n:', this.props.rundownPlaylist?.nextPartInstanceId, prevProps.rundownPlaylist?.nextPartInstanceId)
 	}
 
 	private setDocumentTitle() {
@@ -303,15 +310,13 @@ export class PrompterViewInner extends MeteorReactComponent<Translated<IProps & 
 			(this.props.rundownPlaylist && this.props.rundownPlaylist._id) || protectString('')
 		const playlist = RundownPlaylists.findOne(playlistId)
 
-		if (this.configOptions.followTake) {
-			if (playlist) {
-				if (playlist.currentPartInstanceId !== this.autoScrollPreviousPartInstanceId) {
-					this.autoScrollPreviousPartInstanceId = playlist.currentPartInstanceId
+		if (!this.configOptions.followTake) return
+		if (!playlist) return
+		if (playlist.currentPartInstanceId === this.autoScrollPreviousPartInstanceId) return
+		this.autoScrollPreviousPartInstanceId = playlist.currentPartInstanceId
+		if (playlist.currentPartInstanceId === null) return
 
-					this.scrollToLive()
-				}
-			}
-		}
+		this.scrollToPartInstance(playlist.currentPartInstanceId)
 	}
 	calculateScrollPosition() {
 		let pixelMargin = this.calculateMarginPosition()
@@ -332,6 +337,16 @@ export class PrompterViewInner extends MeteorReactComponent<Translated<IProps & 
 	calculateMarginPosition() {
 		// margin in pixels
 		return ((this.configOptions.margin || 0) * window.innerHeight) / 100
+	}
+	scrollToPartInstance(partInstanceId: PartInstanceId) {
+		const scrollMargin = this.calculateScrollPosition()
+		const target = document.querySelector(`#partInstance_${partInstanceId}`)
+		console.log(target)
+
+		if (target) {
+			Velocity(document.body, 'finish')
+			Velocity(target, 'scroll', { offset: -1 * scrollMargin, duration: 400, easing: 'ease-out' })
+		}
 	}
 	scrollToLive() {
 		const scrollMargin = this.calculateScrollPosition()
@@ -553,10 +568,18 @@ export const PrompterView = translateWithTracker<IProps, {}, ITrackedProps>((pro
 	const studioId = objectPathGet(props, 'match.params.studioId')
 	const studio = studioId ? Studios.findOne(studioId) : undefined
 
-	const rundownPlaylist = RundownPlaylists.findOne({
-		activationId: { $exists: true },
-		studioId: studioId,
-	})
+	const rundownPlaylist = RundownPlaylists.findOne(
+		{
+			activationId: { $exists: true },
+			studioId: studioId,
+		},
+		{
+			projection: {
+				trackedAbSessions: 0,
+				lastIncorrectPartPlaybackReported: 0,
+			},
+		}
+	) as Omit<RundownPlaylist, 'trackedAbSessions'> | undefined
 
 	return literal<ITrackedProps>({
 		rundownPlaylist,
@@ -777,13 +800,7 @@ export const Prompter = translateWithTracker<IPrompterProps, {}, IPrompterTracke
 						id={`segment_${segment.id}`}
 						data-obj-id={segment.id}
 						key={'segment_' + segment.id}
-						className={ClassNames(
-							'prompter-segment',
-							'scroll-anchor',
-							'segment-' + segment.id,
-							'part-' + firstPart.id,
-							firstPartStatus
-						)}
+						className={ClassNames('prompter-segment', 'scroll-anchor', firstPartStatus)}
 					>
 						{segment.title || 'N/A'}
 					</div>
@@ -792,15 +809,10 @@ export const Prompter = translateWithTracker<IPrompterProps, {}, IPrompterTracke
 				segment.parts.forEach((part) => {
 					lines.push(
 						<div
-							id={`part_${part.id}`}
+							id={`partInstance_${part.id}`}
 							data-obj-id={segment.id + '_' + part.id}
-							key={'part_' + part.id}
-							className={ClassNames(
-								'prompter-part',
-								'scroll-anchor',
-								'part-' + part.id,
-								this.getPartStatus(prompterData, part)
-							)}
+							key={'partInstance_' + part.id}
+							className={ClassNames('prompter-part', 'scroll-anchor', this.getPartStatus(prompterData, part))}
 						>
 							{part.title || 'N/A'}
 						</div>


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

The prompter can scroll to the wrong Part (it scrolls to the Part that _used to_ be the live Part instead of the new live Part.

This happens, because the refresh of the "inner" PrompterView may need to delay update to make sure that all the PieceInstances have streamed in.

* **What is the new behavior (if this is a feature change)?**

The scroll operation scrolls to the specific PartInstance, instead of relying on "live" class being present on the prompter's element.

* **Other information**:

The PrompterView needs to be rewritten to move away from it's legacy architecture.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
