### PR TITLE
fix(Timeline): infinites are rendered incorrectly when followed by another Piece

### DIFF
--- a/meteor/__mocks__/defaultCollectionObjects.ts
+++ b/meteor/__mocks__/defaultCollectionObjects.ts
@@ -1,6 +1,6 @@
 import { DBStudio, StudioId } from '../lib/collections/Studios'
-import { getCurrentTime, unprotectString } from '../lib/lib'
-import { DBRundownPlaylist, RundownPlaylistId } from '../lib/collections/RundownPlaylists'
+import { clone, getCurrentTime, unprotectString } from '../lib/lib'
+import { DBRundownPlaylist, RundownPlaylistActivationId, RundownPlaylistId } from '../lib/collections/RundownPlaylists'
 import { PeripheralDeviceId } from '../lib/collections/PeripheralDevices'
 import { ShowStyleBaseId } from '../lib/collections/ShowStyleBases'
 import { ShowStyleVariantId } from '../lib/collections/ShowStyleVariants'
@@ -11,6 +11,8 @@ import { IBlueprintPieceType, PieceLifespan } from '@sofie-automation/blueprints
 import { PieceId, Piece, PieceStatusCode, EmptyPieceTimelineObjectsBlob } from '../lib/collections/Pieces'
 import { AdLibPiece } from '../lib/collections/AdLibPieces'
 import { getRundownId } from '../server/api/ingest/lib'
+import { PartInstance, PartInstanceId, SegmentPlayoutId } from '../lib/collections/PartInstances'
+import { PieceInstance, PieceInstanceId } from '../lib/collections/PieceInstances'
 
 export function defaultRundownPlaylist(_id: RundownPlaylistId, studioId: StudioId): DBRundownPlaylist {
 	return {
@@ -154,5 +156,39 @@ export function defaultAdLibPiece(_id: PieceId, rundownId: RundownId, partId: Pa
 		outputLayerId: '',
 		content: {},
 		timelineObjectsString: EmptyPieceTimelineObjectsBlob,
+	}
+}
+export function defaultPartInstance(
+	_id: PartInstanceId,
+	playlistActivationId: RundownPlaylistActivationId,
+	segmentPlayoutId: SegmentPlayoutId,
+	part: DBPart
+): PartInstance {
+	return {
+		_id,
+		isTemporary: false,
+		part: clone(part),
+		playlistActivationId,
+		rehearsal: false,
+		rundownId: part.rundownId,
+		segmentId: part.segmentId,
+		takeCount: 0,
+		segmentPlayoutId,
+	}
+}
+export function defaultPieceInstance(
+	_id: PieceInstanceId,
+	playlistActivationId: RundownPlaylistActivationId,
+	rundownId: RundownId,
+	partInstanceId: PartInstanceId,
+	piece: Piece
+): PieceInstance {
+	return {
+		_id,
+		partInstanceId,
+		piece: clone(piece),
+		playlistActivationId,
+		rundownId,
+		isTemporary: false,
 	}
 }

--- a/meteor/client/lib/__tests__/__snapshots__/rundown.test.ts.snap
+++ b/meteor/client/lib/__tests__/__snapshots__/rundown.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`client/lib/rundown RundownUtils.getResolvedSegment 1`] = `
+exports[`client/lib/rundown RundownUtils.getResolvedSegment Basic Segment resolution 1`] = `
 Object {
   "autoNextPart": false,
   "currentLivePart": undefined,

--- a/meteor/client/lib/__tests__/rundown.test.ts
+++ b/meteor/client/lib/__tests__/rundown.test.ts
@@ -10,51 +10,371 @@ import {
 	RundownPlaylistId,
 	RundownPlaylistCollectionUtil,
 } from '../../../lib/collections/RundownPlaylists'
+import { Piece, Pieces } from '../../../lib/collections/Pieces'
+import { defaultPartInstance, defaultPiece, defaultPieceInstance } from '../../../__mocks__/defaultCollectionObjects'
+import { protectString } from '@sofie-automation/corelib/dist/protectedString'
+import { PieceLifespan } from '@sofie-automation/blueprints-integration'
+import { PartInstance, PartInstances } from '../../../lib/collections/PartInstances'
+import { PieceInstance } from '@sofie-automation/corelib/dist/dataModel/PieceInstance'
+import { PieceInstances } from '../../../lib/collections/PieceInstances'
 
 describe('client/lib/rundown', () => {
 	let env: DefaultEnvironment
 	let playlistId: RundownPlaylistId
-	beforeAll(async () => {
+	beforeEach(async () => {
 		env = await setupDefaultStudioEnvironment()
 		playlistId = setupDefaultRundownPlaylist(env).playlistId
 	})
-	testInFiber('RundownUtils.getResolvedSegment', () => {
-		const showStyleBase = env.showStyleBase
-		const playlist = RundownPlaylists.findOne(playlistId)
-		if (!playlist) throw new Error('Rundown not found')
+	describe('RundownUtils.getResolvedSegment', () => {
+		testInFiber('Basic Segment resolution', () => {
+			const showStyleBase = env.showStyleBase
+			const playlist = RundownPlaylists.findOne(playlistId)
+			if (!playlist) throw new Error('Rundown not found')
 
-		const { currentPartInstance, nextPartInstance } =
-			RundownPlaylistCollectionUtil.getSelectedPartInstances(playlist)
+			const { currentPartInstance, nextPartInstance } =
+				RundownPlaylistCollectionUtil.getSelectedPartInstances(playlist)
 
-		const rundowns = RundownPlaylistCollectionUtil.getRundownsOrdered(playlist)
-		const { parts, segments } = RundownPlaylistCollectionUtil.getSegmentsAndPartsSync(playlist)
-		const rundown = rundowns[0]
-		const segment = segments[0]
+			const rundowns = RundownPlaylistCollectionUtil.getRundownsOrdered(playlist)
+			const { parts, segments } = RundownPlaylistCollectionUtil.getSegmentsAndPartsSync(playlist)
+			const rundown = rundowns[0]
+			const segment = segments[0]
 
-		const resolvedSegment = RundownUtils.getResolvedSegment(
-			showStyleBase,
-			playlist,
-			rundown,
-			segment,
-			new Set(segments.slice(0, 0).map((s) => s._id)),
-			[],
-			new Map(),
-			parts.map((part) => part._id),
-			currentPartInstance,
-			nextPartInstance
-		)
-		expect(resolvedSegment).toBeTruthy()
-		expect(resolvedSegment.parts).toHaveLength(2)
-		expect(resolvedSegment).toMatchObject({
-			isLiveSegment: false,
-			isNextSegment: false,
-			currentLivePart: undefined,
-			currentNextPart: undefined,
-			hasRemoteItems: false,
-			hasGuestItems: false,
-			hasAlreadyPlayed: false,
-			autoNextPart: false,
+			const resolvedSegment = RundownUtils.getResolvedSegment(
+				showStyleBase,
+				playlist,
+				rundown,
+				segment,
+				new Set(segments.slice(0, 0).map((s) => s._id)),
+				[],
+				new Map(),
+				parts.map((part) => part._id),
+				currentPartInstance,
+				nextPartInstance
+			)
+			expect(resolvedSegment).toBeTruthy()
+			expect(resolvedSegment.parts).toHaveLength(2)
+			expect(resolvedSegment).toMatchObject({
+				isLiveSegment: false,
+				isNextSegment: false,
+				currentLivePart: undefined,
+				currentNextPart: undefined,
+				hasRemoteItems: false,
+				hasGuestItems: false,
+				hasAlreadyPlayed: false,
+				autoNextPart: false,
+			})
+			expect(resolvedSegment).toMatchSnapshot()
 		})
-		expect(resolvedSegment).toMatchSnapshot()
+
+		testInFiber('Infinite Piece starting in first Part is populated across the Segment', () => {
+			const showStyleBase = env.showStyleBase
+			const playlist = RundownPlaylists.findOne(playlistId)
+			if (!playlist) throw new Error('Playlist not found')
+
+			const { currentPartInstance, nextPartInstance } =
+				RundownPlaylistCollectionUtil.getSelectedPartInstances(playlist)
+
+			const rundowns = RundownPlaylistCollectionUtil.getRundownsOrdered(playlist)
+			const { parts, segments } = RundownPlaylistCollectionUtil.getSegmentsAndPartsSync(playlist)
+			const rundown = rundowns[0]
+			const rundownId = rundown._id
+			const segment = segments[1]
+			const firstPart = parts.find((part) => part.segmentId === segment._id)
+
+			if (!firstPart) throw new Error('Mock Segment 1 not found')
+
+			const infinitePiece: Piece = {
+				...defaultPiece(protectString(rundownId + '_infinite_piece'), rundownId, segment._id, firstPart._id),
+				externalId: 'MOCK_INFINITE_PIECE',
+				name: 'Infinite',
+				sourceLayerId: env.showStyleBase.sourceLayers[0]._id,
+				outputLayerId: env.showStyleBase.outputLayers[0]._id,
+				enable: {
+					start: 1000,
+				},
+				lifespan: PieceLifespan.OutOnSegmentEnd,
+			}
+
+			Pieces.insert(infinitePiece)
+
+			const resolvedSegment = RundownUtils.getResolvedSegment(
+				showStyleBase,
+				playlist,
+				rundown,
+				segment,
+				new Set(segments.slice(0, 1).map((s) => s._id)),
+				[],
+				new Map(),
+				parts.map((part) => part._id),
+				currentPartInstance,
+				nextPartInstance
+			)
+			expect(resolvedSegment).toBeTruthy()
+			expect(resolvedSegment.parts).toHaveLength(3)
+			expect(resolvedSegment).toMatchObject({
+				isLiveSegment: false,
+				isNextSegment: false,
+				currentLivePart: undefined,
+				currentNextPart: undefined,
+				hasRemoteItems: false,
+				hasGuestItems: false,
+				hasAlreadyPlayed: false,
+				autoNextPart: false,
+			})
+			const resolvedInfinitePiece00 = resolvedSegment.parts[0].pieces.find(
+				(piece) => piece.instance.piece._id === infinitePiece._id
+			)
+			expect(resolvedInfinitePiece00).toBeDefined()
+			expect(resolvedInfinitePiece00?.renderedInPoint).toBe(1000)
+			expect(resolvedInfinitePiece00?.renderedDuration).toBe(null)
+			const resolvedInfinitePiece01 = resolvedSegment.parts[1].pieces.find(
+				(piece) => piece.instance.piece._id === infinitePiece._id
+			)
+			expect(resolvedInfinitePiece01).toBeDefined()
+			expect(resolvedInfinitePiece01?.renderedInPoint).toBe(0)
+			expect(resolvedInfinitePiece01?.renderedDuration).toBe(null)
+		})
+
+		testInFiber('Infinite Piece starting in first Part is cropped by another Piece', () => {
+			const showStyleBase = env.showStyleBase
+			const playlist = RundownPlaylists.findOne(playlistId)
+			if (!playlist) throw new Error('Playlist not found')
+
+			const { currentPartInstance, nextPartInstance } =
+				RundownPlaylistCollectionUtil.getSelectedPartInstances(playlist)
+
+			const rundowns = RundownPlaylistCollectionUtil.getRundownsOrdered(playlist)
+			const { parts, segments } = RundownPlaylistCollectionUtil.getSegmentsAndPartsSync(playlist)
+			const rundown = rundowns[0]
+			const rundownId = rundown._id
+			const segment = segments[1]
+			const firstPart = parts.find((part) => part.segmentId === segment._id)
+
+			if (!firstPart) throw new Error('Mock Segment 1 not found')
+
+			const infinitePiece: Piece = {
+				...defaultPiece(protectString(rundownId + '_infinite_piece'), rundownId, segment._id, firstPart._id),
+				externalId: 'MOCK_INFINITE_PIECE',
+				name: 'Infinite',
+				sourceLayerId: env.showStyleBase.sourceLayers[0]._id,
+				outputLayerId: env.showStyleBase.outputLayers[0]._id,
+				enable: {
+					start: 1000,
+				},
+				lifespan: PieceLifespan.OutOnSegmentChange,
+			}
+			Pieces.insert(infinitePiece)
+
+			const croppingPiece: Piece = {
+				...defaultPiece(protectString(rundownId + '_cropping_piece'), rundownId, segment._id, firstPart._id),
+				externalId: 'MOCK_CROPPING_PIECE',
+				name: 'Cropping',
+				sourceLayerId: env.showStyleBase.sourceLayers[0]._id,
+				outputLayerId: env.showStyleBase.outputLayers[0]._id,
+				enable: {
+					start: 4000,
+					duration: 1000,
+				},
+				lifespan: PieceLifespan.WithinPart,
+			}
+			Pieces.insert(croppingPiece)
+
+			const resolvedSegment = RundownUtils.getResolvedSegment(
+				showStyleBase,
+				playlist,
+				rundown,
+				segment,
+				new Set(segments.slice(0, 1).map((s) => s._id)),
+				[],
+				new Map(),
+				parts.map((part) => part._id),
+				currentPartInstance,
+				nextPartInstance
+			)
+			expect(resolvedSegment).toBeTruthy()
+			expect(resolvedSegment.parts).toHaveLength(3)
+			expect(resolvedSegment).toMatchObject({
+				isLiveSegment: false,
+				isNextSegment: false,
+				currentLivePart: undefined,
+				currentNextPart: undefined,
+				hasRemoteItems: false,
+				hasGuestItems: false,
+				hasAlreadyPlayed: false,
+				autoNextPart: false,
+			})
+
+			expect(resolvedSegment.parts[0].pieces).toHaveLength(2)
+
+			const resolvedInfinitePiece00 = resolvedSegment.parts[0].pieces.find(
+				(piece) => piece.instance.piece._id === infinitePiece._id
+			)
+			expect(resolvedInfinitePiece00).toBeDefined()
+			expect(resolvedInfinitePiece00?.renderedInPoint).toBe(1000)
+			expect(resolvedInfinitePiece00?.renderedDuration).toBe(3000)
+
+			const resolvedCroppingPiece00 = resolvedSegment.parts[0].pieces.find(
+				(piece) => piece.instance.piece._id === croppingPiece._id
+			)
+			expect(resolvedCroppingPiece00).toBeDefined()
+			expect(resolvedCroppingPiece00?.renderedInPoint).toBe(4000)
+			expect(resolvedCroppingPiece00?.renderedDuration).toBe(1000)
+
+			expect(resolvedSegment.parts[1].pieces).toHaveLength(0)
+		})
+
+		testInFiber(
+			"User-Stopped Infinite Piece starting in first Part maintains it's length when followed by another Piece",
+			() => {
+				const showStyleBase = env.showStyleBase
+
+				const playlistActivationId = protectString('mock_activation_0')
+				RundownPlaylists.update(playlistId, {
+					$set: {
+						activationId: playlistActivationId,
+					},
+				})
+
+				let playlist = RundownPlaylists.findOne(playlistId)
+				if (!playlist) throw new Error('Playlist not found')
+
+				const rundowns = RundownPlaylistCollectionUtil.getRundownsOrdered(playlist)
+				const { parts, segments } = RundownPlaylistCollectionUtil.getSegmentsAndPartsSync(playlist)
+				const rundown = rundowns[0]
+				const rundownId = rundown._id
+				const segment = segments[1]
+				const firstPart = parts.find((part) => part.segmentId === segment._id)
+
+				if (!firstPart) throw new Error('Mock Segment 1 not found')
+
+				const infinitePiece: Piece = {
+					...defaultPiece(
+						protectString(rundownId + '_infinite_piece'),
+						rundownId,
+						segment._id,
+						firstPart._id
+					),
+					externalId: 'MOCK_INFINITE_PIECE',
+					name: 'Infinite',
+					sourceLayerId: env.showStyleBase.sourceLayers[0]._id,
+					outputLayerId: env.showStyleBase.outputLayers[0]._id,
+					enable: {
+						start: 1000,
+					},
+					lifespan: PieceLifespan.OutOnSegmentChange,
+				}
+				Pieces.insert(infinitePiece)
+
+				const followingPiece: Piece = {
+					...defaultPiece(
+						protectString(rundownId + '_cropping_piece'),
+						rundownId,
+						segment._id,
+						firstPart._id
+					),
+					externalId: 'MOCK_CROPPING_PIECE',
+					name: 'Cropping',
+					sourceLayerId: env.showStyleBase.sourceLayers[0]._id,
+					outputLayerId: env.showStyleBase.outputLayers[0]._id,
+					enable: {
+						start: 4000,
+						duration: 1000,
+					},
+					lifespan: PieceLifespan.WithinPart,
+				}
+				Pieces.insert(followingPiece)
+
+				const segmentPlayoutId = protectString('mock_segment_playout_0')
+				const mockCurrentPartInstance: PartInstance = {
+					...defaultPartInstance(
+						protectString(rundownId + '_partInstance_0'),
+						playlistActivationId,
+						segmentPlayoutId,
+						firstPart
+					),
+				}
+
+				PartInstances.insert(mockCurrentPartInstance)
+
+				const infinitePieceInstance: PieceInstance = {
+					...defaultPieceInstance(
+						protectString('instance_' + infinitePiece._id),
+						playlistActivationId,
+						rundown._id,
+						mockCurrentPartInstance._id,
+						infinitePiece
+					),
+					userDuration: {
+						end: 2000,
+					},
+				}
+
+				PieceInstances.insert(infinitePieceInstance)
+
+				const followingPieceInstance: PieceInstance = {
+					...defaultPieceInstance(
+						protectString('instance_' + followingPiece._id),
+						playlistActivationId,
+						rundown._id,
+						mockCurrentPartInstance._id,
+						followingPiece
+					),
+				}
+
+				PieceInstances.insert(followingPieceInstance)
+
+				RundownPlaylists.update(playlistId, {
+					$set: {
+						currentPartInstanceId: mockCurrentPartInstance._id,
+					},
+				})
+
+				playlist = RundownPlaylists.findOne(playlistId)
+				if (!playlist) throw new Error('Playlist not found')
+				const { currentPartInstance, nextPartInstance } =
+					RundownPlaylistCollectionUtil.getSelectedPartInstances(playlist)
+
+				const resolvedSegment = RundownUtils.getResolvedSegment(
+					showStyleBase,
+					playlist,
+					rundown,
+					segment,
+					new Set(segments.slice(0, 1).map((s) => s._id)),
+					[],
+					new Map(),
+					parts.map((part) => part._id),
+					currentPartInstance,
+					nextPartInstance
+				)
+				expect(resolvedSegment).toBeTruthy()
+				expect(resolvedSegment.parts).toHaveLength(3)
+				expect(resolvedSegment).toMatchObject({
+					isLiveSegment: true,
+					isNextSegment: false,
+					currentNextPart: undefined,
+					hasRemoteItems: false,
+					hasGuestItems: false,
+					autoNextPart: false,
+				})
+
+				expect(resolvedSegment.parts[0].pieces).toHaveLength(2)
+
+				const resolvedInfinitePiece00 = resolvedSegment.parts[0].pieces.find(
+					(piece) => piece.instance._id === infinitePieceInstance._id
+				)
+				expect(resolvedInfinitePiece00).toBeDefined()
+				expect(resolvedInfinitePiece00?.renderedInPoint).toBe(1000)
+				expect(resolvedInfinitePiece00?.renderedDuration).toBe(1000)
+
+				const resolvedCroppingPiece00 = resolvedSegment.parts[0].pieces.find(
+					(piece) => piece.instance._id === followingPieceInstance._id
+				)
+				expect(resolvedCroppingPiece00).toBeDefined()
+				expect(resolvedCroppingPiece00?.renderedInPoint).toBe(4000)
+				expect(resolvedCroppingPiece00?.renderedDuration).toBe(1000)
+
+				expect(resolvedSegment.parts[1].pieces).toHaveLength(0)
+			}
+		)
 	})
 })

--- a/meteor/client/lib/rundown.ts
+++ b/meteor/client/lib/rundown.ts
@@ -708,19 +708,23 @@ export namespace RundownUtils {
 								previousItem.renderedDuration !== undefined &&
 								currentItem.renderedDuration !== undefined
 							) {
+								// if previousItem is infinite, currentItem caps it within the current part
+								if (previousItem.instance.infinite) {
+									previousItem.instance.piece.lifespan = PieceLifespan.WithinPart
+									delete previousItem.instance.infinite
+								}
+
 								if (
-									previousItem.instance.infinite ||
+									// previousItem spans beyond the currentItem renderedInPoint
 									(previousItem.renderedDuration !== null &&
 										previousItem.renderedInPoint + previousItem.renderedDuration >
-											currentItem.renderedInPoint)
+											currentItem.renderedInPoint) ||
+									// previousItem is infinite
+									previousItem.renderedDuration === null
 								) {
 									previousItem.renderedDuration =
 										currentItem.renderedInPoint - previousItem.renderedInPoint
 									previousItem.cropped = true
-									if (previousItem.instance.infinite) {
-										previousItem.instance.piece.lifespan = PieceLifespan.WithinPart
-										delete previousItem.instance.infinite
-									}
 								}
 
 								previousItem.maxLabelWidth = currentItem.renderedInPoint - previousItem.renderedInPoint


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

If a user-stopped Infinite Piece is followed by any other Piece, it's renderedDuration will be set to the difference between it's inPoint and next Pieces inPoint, even if it ended before the next Piece.

* **What is the new behavior (if this is a feature change)?**

The user-stopped Infinite Piece maintains it's duration in the timeline.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
