### PR TITLE
fix(Action Triggers): A notification isn't shown when creating a Rundown Snapshot using a hotkey

### DIFF
--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -355,6 +355,7 @@ const RundownHeader = withTranslation()(
 			RundownViewEventBus.on(RundownViewEvents.RESYNC_RUNDOWN_PLAYLIST, this.eventResync)
 			RundownViewEventBus.on(RundownViewEvents.TAKE, this.eventTake)
 			RundownViewEventBus.on(RundownViewEvents.RESET_RUNDOWN_PLAYLIST, this.eventResetRundownPlaylist)
+			RundownViewEventBus.on(RundownViewEvents.CREATE_SNAPSHOT_FOR_DEBUG, this.eventCreateSnapshot)
 
 			reloadRundownPlaylistClick.set(this.reloadRundownPlaylist)
 		}
@@ -365,6 +366,7 @@ const RundownHeader = withTranslation()(
 			RundownViewEventBus.off(RundownViewEvents.RESYNC_RUNDOWN_PLAYLIST, this.eventResync)
 			RundownViewEventBus.off(RundownViewEvents.TAKE, this.eventTake)
 			RundownViewEventBus.off(RundownViewEvents.RESET_RUNDOWN_PLAYLIST, this.eventResetRundownPlaylist)
+			RundownViewEventBus.off(RundownViewEvents.CREATE_SNAPSHOT_FOR_DEBUG, this.eventCreateSnapshot)
 		}
 		eventActivate = (e: ActivateRundownPlaylistEvent) => {
 			if (e.rehearsal) {
@@ -384,6 +386,9 @@ const RundownHeader = withTranslation()(
 		}
 		eventResetRundownPlaylist = (e: IEventContext) => {
 			this.resetRundown(e.context)
+		}
+		eventCreateSnapshot = (e: IEventContext) => {
+			this.takeRundownSnapshot(e.context)
 		}
 
 		handleDisableNextPiece = (err: ClientAPI.ClientResponse<undefined>) => {

--- a/meteor/client/ui/RundownView/RundownViewEventBus.ts
+++ b/meteor/client/ui/RundownView/RundownViewEventBus.ts
@@ -39,6 +39,8 @@ export enum RundownViewEvents {
 	RENAME_BUCKET = 'renameBucket',
 	DELETE_BUCKET = 'deleteBucket',
 	CREATE_BUCKET = 'createBucket',
+
+	CREATE_SNAPSHOT_FOR_DEBUG = 'createSnapshotForDebug',
 }
 
 export interface IEventContext {
@@ -131,6 +133,7 @@ class RundownViewEventBus0 extends EventEmitter {
 	emit(event: RundownViewEvents.CREATE_BUCKET, e: IEventContext): boolean
 	emit(event: RundownViewEvents.DELETE_BUCKET_ADLIB, e: BucketAdLibEvent): boolean
 	emit(event: RundownViewEvents.RENAME_BUCKET_ADLIB, e: BucketAdLibEvent): boolean
+	emit(event: RundownViewEvents.CREATE_SNAPSHOT_FOR_DEBUG, e: BaseEvent): boolean
 	emit(event: string, ...args: any[]) {
 		return super.emit(event, ...args)
 	}
@@ -163,6 +166,7 @@ class RundownViewEventBus0 extends EventEmitter {
 	on(event: RundownViewEvents.CREATE_BUCKET, listener: (e: IEventContext) => void): this
 	on(event: RundownViewEvents.DELETE_BUCKET_ADLIB, listener: (e: BucketAdLibEvent) => void): this
 	on(event: RundownViewEvents.RENAME_BUCKET_ADLIB, listener: (e: BucketAdLibEvent) => void): this
+	on(event: RundownViewEvents.CREATE_SNAPSHOT_FOR_DEBUG, listener: (e: BaseEvent) => void): this
 	on(event: string, listener: (...args: any[]) => void) {
 		return super.on(event, listener)
 	}

--- a/meteor/lib/api/triggers/actionFactory.ts
+++ b/meteor/lib/api/triggers/actionFactory.ts
@@ -433,6 +433,17 @@ function createRundownPlaylistSoftResetRundownAction(_filterChain: IGUIContextFi
 	}
 }
 
+function createTakeRundownSnapshotAction(_filterChain: IGUIContextFilterLink[]): ExecutableAction {
+	return {
+		action: PlayoutActions.createSnapshotForDebug,
+		execute: (_t, e) => {
+			RundownViewEventBus.emit(RundownViewEvents.CREATE_SNAPSHOT_FOR_DEBUG, {
+				context: e,
+			})
+		},
+	}
+}
+
 /**
  * A utility method to create an ExecutableAction wrapping a simple UserAction call that takes some variables from
  * InternalActionContext as input
@@ -523,9 +534,13 @@ export function createAction(action: SomeAction, showStyleBase: ShowStyleBase): 
 				MeteorCall.userAction.disableNextPiece(e, ts, ctx.rundownPlaylistId.get(), !!action.undo)
 			)
 		case PlayoutActions.createSnapshotForDebug:
-			return createUserActionWithCtx(action, UserAction.CREATE_SNAPSHOT_FOR_DEBUG, async (e, ts, ctx) =>
-				MeteorCall.userAction.storeRundownSnapshot(e, ts, ctx.rundownPlaylistId.get(), `action`, false)
-			)
+			if (isActionTriggeredFromUiContext(action)) {
+				return createTakeRundownSnapshotAction(action.filterChain as IGUIContextFilterLink[])
+			} else {
+				return createUserActionWithCtx(action, UserAction.CREATE_SNAPSHOT_FOR_DEBUG, async (e, ts, ctx) =>
+					MeteorCall.userAction.storeRundownSnapshot(e, ts, ctx.rundownPlaylistId.get(), `action`, false)
+				)
+			}
 		case PlayoutActions.moveNext:
 			return createUserActionWithCtx(action, UserAction.MOVE_NEXT, async (e, ts, ctx) =>
 				MeteorCall.userAction.moveNext(


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

A notification isn't shown when creating a rundown snapshot using a hotkey

* **What is the new behavior (if this is a feature change)?**

The action is piped through the RundownViewEventBus when running in the UI, so that the custom handling for the response from the backend can kick in.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
