### PR TITLE
fix: allow codecov upload to fail

### DIFF
--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -69,10 +69,7 @@ jobs:
         env:
           CI: true
       - name: Send coverage
-        uses: codecov/codecov-action@v2
-        with:
-          fail_ci_if_error: true
-          # name: codecov-umbrella
+        uses: codecov/codecov-action@v3
 
   build-core:
     # TODO - should this be dependant on tests or something passing if we are on a tag?
@@ -331,10 +328,7 @@ jobs:
           CI: true
       - name: Send coverage
         if: matrix.node-version == '16.x' || matrix.send-coverage == true
-        uses: codecov/codecov-action@v2
-        with:
-          fail_ci_if_error: true
-          # name: codecov-umbrella
+        uses: codecov/codecov-action@v3
 
   publish-docs:
     name: Publish Docs


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

fix

* **What is the current behavior?** (You can also link to an open issue here)

The codecov upload action often fails, causing the job to be reported as a failure

https://github.com/nrkno/sofie-core/actions/runs/3235435174/jobs/5299867326

* **What is the new behavior (if this is a feature change)?**

Don't fail if the upload fails  
This is the default behaviour of the action

Additionally, update the action to latest

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
