### PR TITLE
fix: update ErrorBoundrary message to be more user-friendly

### DIFF
--- a/meteor/client/lib/ErrorBoundary.tsx
+++ b/meteor/client/lib/ErrorBoundary.tsx
@@ -1,194 +1,148 @@
 import * as React from 'react'
 
 interface IState {
-	hasError: boolean
-	error?: Error
-	info?: React.ErrorInfo
-	expandedStack?: boolean
-	expandedComponentStack?: boolean
+	error: {
+		error: Error
+		info: React.ErrorInfo
+	} | null
 }
 
 export class ErrorBoundary extends React.Component<{}, IState> {
-	static style = {
-		box: {
+	static style: { [key: string]: React.CSSProperties } = {
+		container: {
+			position: 'relative',
 			display: 'block',
-			position: 'static',
-			margin: '0',
+			margin: '10px',
 			padding: '10px',
-			fontSize: '10px',
-			lineHeight: '1.2em',
-			fontFamily: 'Roboto, sans-serif',
-			fontWeight: 300,
-			width: '100%',
+			// fontSize: '12px',
+			// lineHeight: '1.2em',
+
+			// fontWeight: 300,
+			textDecoration: 'none',
+			// width: '100%',
 			height: 'auto',
 			overflow: 'visible',
-			background: 'white',
-			textDecoration: 'none',
+			background: '#ffdddd',
+			color: 'black',
+			border: '2px solid red',
+
+			cursor: 'text',
+		},
+		h1: {
+			fontSize: '18px',
+			fontWeight: 'bold',
+
+			margin: '10px',
+			padding: '0',
+
 			color: 'red',
+		},
+		friendlyMessage: {
+			margin: '10px',
+			padding: '0',
+
+			fontWeight: 'bold',
+		},
+		errorDescription: {
+			padding: '10px',
+
 			border: '1px solid red',
-		} as React.CSSProperties,
-		header: {
-			display: 'block',
-			position: 'static',
-			margin: '0 0 10px 0',
-			padding: '0',
-			fontSize: '14px',
-			lineHeight: '1.2em',
-			fontFamily: 'Roboto, sans-serif',
-			fontWeight: 600,
-			width: '100%',
-			height: 'auto',
-			overflow: 'visible',
-			background: 'none',
-			textDecoration: 'none',
-			color: 'red',
-			border: 'none',
-		} as React.CSSProperties,
-		message: {
-			display: 'block',
-			position: 'static',
-			margin: '0 0 10px 0',
-			padding: '0',
-			fontSize: '10px',
-			lineHeight: '1.2em',
-			fontFamily: 'Roboto, sans-serif',
-			fontWeight: 300,
-			width: '100%',
-			height: 'auto',
-			overflow: 'visible',
-			background: 'white',
-			textDecoration: 'none',
-			color: 'red',
-			border: 'none',
-		} as React.CSSProperties,
+			boxShadow: '0px 0px 10px inset #e00',
+			backgroundColor: '#ebebeb',
+
+			overflow: 'auto',
+			minHeight: '5em',
+			fontSize: '12px',
+			fontFamily: 'monospace',
+		},
 		stack: {
 			display: 'block',
-			position: 'static',
-			margin: '0 0 10px 0',
-			padding: '0',
-			fontSize: '10px',
-			lineHeight: '1.2em',
-			fontFamily: 'Roboto, sans-serif',
-			fontWeight: 300,
-			width: '100%',
-			height: 'auto',
-			overflow: 'hidden',
-			textOverflow: 'ellipsis',
-			background: 'none',
-			textDecoration: 'none',
-			color: 'red',
-			border: 'none',
-			cursor: 'pointer',
-			whiteSpace: 'nowrap',
-		} as React.CSSProperties,
-		componentStack: {
-			display: 'block',
-			position: 'static',
-			margin: '0 0 10px 0',
-			padding: '0',
-			fontSize: '10px',
-			lineHeight: '1.2em',
-			fontFamily: 'Roboto, sans-serif',
-			fontWeight: 300,
-			width: '100%',
-			height: 'auto',
-			overflow: 'hidden',
-			textOverflow: 'ellipsis',
-			background: 'none',
-			textDecoration: 'none',
-			color: 'red',
-			border: 'none',
-			cursor: 'pointer',
-			whiteSpace: 'nowrap',
-		} as React.CSSProperties,
-		expandedStack: {
 			whiteSpace: 'pre',
-		} as React.CSSProperties,
+			margin: '0',
+			padding: '0',
+
+			fontFamily: 'monospace',
+		},
+		expandedStack: {
+			// whiteSpace: 'pre',
+		},
 		resetButton: {
 			display: 'block',
-			position: 'static',
-			margin: '0 0 0 0',
-			padding: '0',
-			fontSize: '10px',
-			lineHeight: '1.2em',
-			fontFamily: 'Roboto, sans-serif',
-			fontWeight: 600,
-			width: '100%',
-			height: 'auto',
-			overflow: 'visible',
-			background: 'white',
-			textDecoration: 'underline',
-			color: 'red',
-			border: 'none',
-			cursor: 'pointer',
-		} as React.CSSProperties,
+			margin: '10px 0',
+			fontWeight: 'normal',
+
+			// position: 'static',
+			// margin: '0 0 0 0',
+			// padding: '0',
+			// fontSize: '10px',
+			// lineHeight: '1.2em',
+			// fontFamily: 'Roboto, sans-serif',
+			// fontWeight: 600,
+			// width: '100%',
+			// height: 'auto',
+			// overflow: 'visible',
+			// background: 'white',
+			// textDecoration: 'underline',
+			// color: 'red',
+			// border: 'none',
+			// cursor: 'pointer',
+		},
 	}
 
 	constructor(props) {
 		super(props)
 		this.state = {
-			hasError: false,
+			error: null,
 		}
 	}
 
 	componentDidCatch(error: Error, info: React.ErrorInfo) {
 		this.setState({
-			hasError: true,
-			error: error,
-			info: info,
+			error: { error, info },
 		})
 	}
 
-	toggleComponentStack = () => {
-		this.setState({ expandedComponentStack: !this.state.expandedComponentStack })
-	}
+	// toggleComponentStack = () => {
+	// 	this.setState({ expandedComponentStack: !this.state.expandedComponentStack })
+	// }
 
-	toggleStack = () => {
-		this.setState({ expandedStack: !this.state.expandedStack })
-	}
+	// toggleStack = () => {
+	// 	this.setState({ expandedStack: !this.state.expandedStack })
+	// }
 
 	resetComponent = () => {
-		this.setState({ hasError: false })
+		this.setState({ error: null })
 	}
 
 	render() {
-		if (this.state.hasError) {
+		if (this.state.error) {
+			const error = this.state.error.error
+			const info = this.state.error.info
 			return (
-				<div style={ErrorBoundary.style.box}>
-					{this.state.error && (
-						<React.Fragment>
-							<h5 style={ErrorBoundary.style.header}>{this.state.error.name}</h5>
-							{this.state.info && (
-								<p
-									style={{
-										...ErrorBoundary.style.componentStack,
-										...(this.state.expandedComponentStack ? ErrorBoundary.style.expandedStack : {}),
-									}}
-									onClick={this.toggleComponentStack}
-								>
-									{this.state.info.componentStack}
-								</p>
-							)}
-							<p style={ErrorBoundary.style.message}>{this.state.error.message}</p>
-							{this.state.error.stack && (
-								<p
-									style={{
-										...ErrorBoundary.style.stack,
-										...(this.state.expandedStack ? ErrorBoundary.style.expandedStack : {}),
-									}}
-									onClick={this.toggleStack}
-								>
-									{this.state.error.stack}
-								</p>
-							)}
-						</React.Fragment>
-					)}
-					<div style={ErrorBoundary.style.resetButton} onClick={this.resetComponent}>
-						Try to restart component
+				<div style={ErrorBoundary.style.container}>
+					<h1 style={ErrorBoundary.style.h1}>Whoops, something went wrong!</h1>
+
+					<div style={ErrorBoundary.style.friendlyMessage}>
+						There was an error in the Sofie GUI which caused it to crash.
+						<br />
+						Please copy the error description below and report it to your system administrator.
+						<br />
+						<button style={ErrorBoundary.style.resetButton} onClick={this.resetComponent}>
+							Click here to try to restart component
+						</button>
+					</div>
+
+					<div style={ErrorBoundary.style.errorDescription}>
+						<b>{error.name}</b>
+						<br />
+						<p style={ErrorBoundary.style.stack}>{error.message}</p>
+						<p style={ErrorBoundary.style.stack}>{error.stack ?? ''}</p>
+						<p style={ErrorBoundary.style.stack}>{info.componentStack}</p>
 					</div>
 				</div>
 			)
+		} else {
+			return this.props.children || null
 		}
-		return this.props.children || null
 	}
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR changes the visual appearance of the ErrorBoundrary, with the goal of being friendlier and more descriptive to the End-User.


* **What is the current behavior?** (You can also link to an open issue here)
Before:

![image](https://user-images.githubusercontent.com/15196563/198014125-82911b63-ff48-4e51-a5f8-3db2c039dd8c.png)


* **What is the new behavior (if this is a feature change)?**
After:

![image](https://user-images.githubusercontent.com/15196563/198013725-109aee1d-aa02-4cb9-9606-03639e2d8c5e.png)
