### PR TITLE
fix: prevent blueprint migrations which inserted playout-gateway subdevices on a fresh install from failing

### DIFF
--- a/meteor/server/api/blueprints/migrationContext.ts
+++ b/meteor/server/api/blueprints/migrationContext.ts
@@ -279,7 +279,7 @@ export class MigrationContextStudio implements IMigrationContextStudio {
 		}
 
 		const settings = parentDevice.settings as PlayoutDeviceSettings | undefined
-		if (settings && settings.devices[deviceId]) {
+		if (settings && settings.devices && settings.devices[deviceId]) {
 			throw new Meteor.Error(404, `Device "${deviceId}" cannot be inserted as it already exists`)
 		}
 


### PR DESCRIPTION
Even though the typings state it shouldn't be undefined, `settings.devices` is undefined here on a fresh install until at least one subdevice has been added to the playout-gateway. Before this fix, it would have to be added manually via the settings page before any blueprint migrations which also tried to insert devices could run successfully.

It's possible that there is a better place for this fix, but after a couple hours of searching I couldn't find the root cause.