### PR TITLE
docs(Package Manager): correct cd command in installation instructions

### DIFF
--- a/packages/documentation/docs/user-guide/installation/installing-package-manager.md
+++ b/packages/documentation/docs/user-guide/installation/installing-package-manager.md
@@ -28,7 +28,7 @@ Package Manager is a suite of standalone applications, separate from _Sofie&nbsp
 
 ```bash
 git clone https://github.com/nrkno/sofie-package-manager.git
-cd tv-automation-package-manager
+cd sofie-package-manager
 yarn install
 yarn build
 yarn start:single-app -- -- --basePath "C:\your\path\to\casparcg-server\media-folder (i.e. sofie-demo-media)"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

docs update

* **What is the current behavior?** (You can also link to an open issue here)

A `cd` command in the Package Manager installation instructions points to the wrong path.

* **What is the new behavior (if this is a feature change)?**

The command has been updated to point to the correct path.

* **Other information**:

N/A

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
