### PR TITLE
Fix: viz purge rundown

### DIFF
--- a/meteor/client/ui/Status/SystemStatus.tsx
+++ b/meteor/client/ui/Status/SystemStatus.tsx
@@ -199,6 +199,40 @@ export const DeviceItem = reacti18next.withTranslation()(
 				},
 			})
 		}
+		onVizPurgeRundown(device: PeripheralDevice) {
+			const { t } = this.props
+
+			doModalDialog({
+				title: t('Purge Viz Rundown'),
+				message: t('Do you want to purge all elements from the viz-rundown?'),
+				onAccept: (event: any) => {
+					callPeripheralDeviceFunction(event, device._id, undefined, 'vizPurgeRundown')
+						.then(() => {
+							NotificationCenter.push(
+								new Notification(
+									undefined,
+									NoticeLevel.NOTIFICATION,
+									t('Purged all elements from rundown on Viz-device "{{deviceName}}"!', { deviceName: device.name }),
+									'SystemStatus'
+								)
+							)
+						})
+						.catch((err) => {
+							NotificationCenter.push(
+								new Notification(
+									undefined,
+									NoticeLevel.WARNING,
+									t('Purging failed: {{errorMessage}}', {
+										deviceName: device.name,
+										errorMessage: err + '',
+									}),
+									'SystemStatus'
+								)
+							)
+						})
+				},
+			})
+		}
 
 		render() {
 			const { t } = this.props
@@ -299,6 +333,22 @@ export const DeviceItem = reacti18next.withTranslation()(
 										}}
 									>
 										{t('Restart Quantel Gateway')}
+									</button>
+								</React.Fragment>
+							) : null}
+							{getAllowStudio() &&
+							this.props.device.type === PeripheralDeviceType.PLAYOUT &&
+							this.props.device.subType === TSR.DeviceType.VIZMSE ? (
+								<React.Fragment>
+									<button
+										className="btn btn-secondary"
+										onClick={(e) => {
+											e.preventDefault()
+											e.stopPropagation()
+											this.onVizPurgeRundown(this.props.device)
+										}}
+									>
+										{t('Purge Viz Rundown')}
 									</button>
 								</React.Fragment>
 							) : null}

--- a/meteor/yarn.lock
+++ b/meteor/yarn.lock
@@ -9832,10 +9832,10 @@ timecode@0.0.4:
   resolved "https://registry.yarnpkg.com/timecode/-/timecode-0.0.4.tgz#cdea9d2352009700e50da657cb7fb7c1720f5704"
   integrity sha512-xFVZlWnqls5eVphtUJo0UuXeJa0grBmxESSn5QPQB7CMsaVgTnLdP9PTZqb4KyFmLdrE+PUu3eEt42zHsMxCtw==
 
-timeline-state-resolver-types@7.5.0-release47.0:
-  version "7.5.0-release47.0"
-  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-7.5.0-release47.0.tgz#c9615f5cce493a361816577b003d4d81406087df"
-  integrity sha512-0YNAvKCRb0Og2DdMgXItWWu41F75yUd40mTb/F6JxXrMAe/KGNpUq2ImUXaMw2pIWJVI6PAVZUdgRUIS8gMGNQ==
+timeline-state-resolver-types@7.5.0-release47.1:
+  version "7.5.0-release47.1"
+  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-7.5.0-release47.1.tgz#1fe2bd43b038528fdd83678f4ead4c27c973c2e6"
+  integrity sha512-uhwdsvLwhB314iXYnxwfKpBc29JklNAmI1senu6kYOUsjdrYN9sI9ARcnjWxIvlSq/+4sk/HcMpw2vnLAYpW5w==
   dependencies:
     tslib "^2.3.1"
 

--- a/packages/blueprints-integration/package.json
+++ b/packages/blueprints-integration/package.json
@@ -39,7 +39,7 @@
 	],
 	"dependencies": {
 		"@sofie-automation/shared-lib": "link:../shared-lib",
-		"timeline-state-resolver-types": "7.5.0-release47.0",
+		"timeline-state-resolver-types": "7.5.0-release47.1",
 		"tslib": "^2.4.0",
 		"type-fest": "^2.19.0"
 	},

--- a/packages/blueprints-integration/package.json
+++ b/packages/blueprints-integration/package.json
@@ -39,7 +39,7 @@
 	],
 	"dependencies": {
 		"@sofie-automation/shared-lib": "link:../shared-lib",
-		"timeline-state-resolver-types": "7.5.0-release47.1",
+		"timeline-state-resolver-types": "7.5.0-release47.2",
 		"tslib": "^2.4.0",
 		"type-fest": "^2.19.0"
 	},

--- a/packages/playout-gateway/package.json
+++ b/packages/playout-gateway/package.json
@@ -62,7 +62,7 @@
 		"debug": "^4.3.3",
 		"fast-clone": "^1.5.13",
 		"influx": "^5.9.3",
-		"timeline-state-resolver": "7.5.0-release47.0",
+		"timeline-state-resolver": "7.5.0-release47.1",
 		"tslib": "^2.4.0",
 		"underscore": "^1.13.4",
 		"winston": "^3.8.2"

--- a/packages/playout-gateway/package.json
+++ b/packages/playout-gateway/package.json
@@ -62,7 +62,7 @@
 		"debug": "^4.3.3",
 		"fast-clone": "^1.5.13",
 		"influx": "^5.9.3",
-		"timeline-state-resolver": "7.5.0-release47.1",
+		"timeline-state-resolver": "7.5.0-release47.2",
 		"tslib": "^2.4.0",
 		"underscore": "^1.13.4",
 		"winston": "^3.8.2"

--- a/packages/playout-gateway/src/coreHandler.ts
+++ b/packages/playout-gateway/src/coreHandler.ts
@@ -13,6 +13,7 @@ import {
 	QuantelDevice,
 	MediaObject,
 	DeviceOptionsAny,
+	VizMSEDevice,
 } from 'timeline-state-resolver'
 
 import * as _ from 'underscore'
@@ -478,6 +479,14 @@ export class CoreHandler {
 		if (!device) throw new Error(`TSR Device "${deviceId}" not found!`)
 
 		await device.formatDisks()
+	}
+	async vizPurgeRundown(deviceId: string): Promise<any> {
+		if (!this._tsrHandler) throw new Error('TSRHandler is not initialized')
+
+		const device = this._tsrHandler.tsr.getDevice(deviceId)?.device as ThreadedClass<VizMSEDevice>
+		if (!device) throw new Error(`TSR Device "${deviceId}" not found!`)
+
+		return device.purgeRundown(true)
 	}
 	async updateCoreStatus(): Promise<any> {
 		let statusCode = StatusCode.GOOD

--- a/packages/yarn.lock
+++ b/packages/yarn.lock
@@ -3095,7 +3095,7 @@
   version "1.47.0-in-testing.0"
   dependencies:
     "@sofie-automation/shared-lib" "link:shared-lib"
-    timeline-state-resolver-types "7.5.0-release47.1"
+    timeline-state-resolver-types "7.5.0-release47.2"
     tslib "^2.4.0"
     type-fest "^2.19.0"
 
@@ -13962,17 +13962,17 @@ timecode@0.0.4:
   resolved "https://registry.yarnpkg.com/timecode/-/timecode-0.0.4.tgz#cdea9d2352009700e50da657cb7fb7c1720f5704"
   integrity sha512-xFVZlWnqls5eVphtUJo0UuXeJa0grBmxESSn5QPQB7CMsaVgTnLdP9PTZqb4KyFmLdrE+PUu3eEt42zHsMxCtw==
 
-timeline-state-resolver-types@7.5.0-release47.1:
-  version "7.5.0-release47.1"
-  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-7.5.0-release47.1.tgz#1fe2bd43b038528fdd83678f4ead4c27c973c2e6"
-  integrity sha512-uhwdsvLwhB314iXYnxwfKpBc29JklNAmI1senu6kYOUsjdrYN9sI9ARcnjWxIvlSq/+4sk/HcMpw2vnLAYpW5w==
+timeline-state-resolver-types@7.5.0-release47.2:
+  version "7.5.0-release47.2"
+  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-7.5.0-release47.2.tgz#5247328c683219535224ee560390e38c924732af"
+  integrity sha512-8A8b8UnAKEY26FUa/GwX9Q4OOwNEoTkHVQik1HZyqBIIrQxoigrGT9/C/EG3K/+uFZlnHeHhPXBrMlf2vh2Brw==
   dependencies:
     tslib "^2.3.1"
 
-timeline-state-resolver@7.5.0-release47.1:
-  version "7.5.0-release47.1"
-  resolved "https://registry.yarnpkg.com/timeline-state-resolver/-/timeline-state-resolver-7.5.0-release47.1.tgz#6cce884a51e53aa1e823bb07c0ce9f42dc57ca45"
-  integrity sha512-5SSl4fpijCYuyUDBCzB5+2AAIINfhgCiujE7PYAvPtQUCIzUMNN1KKtNwBAb1DFgYIMOVSL9WxY/6DpcyOCqvQ==
+timeline-state-resolver@7.5.0-release47.2:
+  version "7.5.0-release47.2"
+  resolved "https://registry.yarnpkg.com/timeline-state-resolver/-/timeline-state-resolver-7.5.0-release47.2.tgz#17c90331e33c4d6eed9fdfded265ff5cb92a7167"
+  integrity sha512-ylTjtJhYNeA8KqLEqqipDhxvEPZ5YiRp+xqBBOc6z/eVey/46GdeaCXZmBqEB4e1UyElkU5RRfW2zRqXe/CDKQ==
   dependencies:
     "@tv2media/v-connection" "^6.0.3"
     atem-connection "2.4.0"
@@ -13994,7 +13994,7 @@ timeline-state-resolver@7.5.0-release47.1:
     sprintf-js "^1.1.2"
     superfly-timeline "^8.3.0"
     threadedclass "^1.1.1"
-    timeline-state-resolver-types "7.5.0-release47.1"
+    timeline-state-resolver-types "7.5.0-release47.2"
     tslib "^2.3.1"
     tv-automation-quantel-gateway-client "^2.0.5"
     underscore "^1.13.4"

--- a/packages/yarn.lock
+++ b/packages/yarn.lock
@@ -3092,10 +3092,10 @@
     webpack-sources "^3.2.2"
 
 "@sofie-automation/blueprints-integration@link:blueprints-integration":
-  version "1.47.0-in-development"
+  version "1.47.0-in-testing.0"
   dependencies:
     "@sofie-automation/shared-lib" "link:shared-lib"
-    timeline-state-resolver-types "7.5.0-release47.0"
+    timeline-state-resolver-types "7.5.0-release47.1"
     tslib "^2.4.0"
     type-fest "^2.19.0"
 
@@ -3120,7 +3120,7 @@
     shelljs "^0.8.5"
 
 "@sofie-automation/corelib@link:corelib":
-  version "1.47.0-in-development"
+  version "1.47.0-in-testing.0"
   dependencies:
     "@sofie-automation/blueprints-integration" "link:blueprints-integration"
     "@sofie-automation/shared-lib" "link:shared-lib"
@@ -3136,7 +3136,7 @@
     underscore "^1.13.4"
 
 "@sofie-automation/shared-lib@link:shared-lib":
-  version "1.47.0-in-development"
+  version "1.47.0-in-testing.0"
   dependencies:
     tslib "^2.4.0"
     type-fest "^2.19.0"
@@ -13962,17 +13962,17 @@ timecode@0.0.4:
   resolved "https://registry.yarnpkg.com/timecode/-/timecode-0.0.4.tgz#cdea9d2352009700e50da657cb7fb7c1720f5704"
   integrity sha512-xFVZlWnqls5eVphtUJo0UuXeJa0grBmxESSn5QPQB7CMsaVgTnLdP9PTZqb4KyFmLdrE+PUu3eEt42zHsMxCtw==
 
-timeline-state-resolver-types@7.5.0-release47.0:
-  version "7.5.0-release47.0"
-  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-7.5.0-release47.0.tgz#c9615f5cce493a361816577b003d4d81406087df"
-  integrity sha512-0YNAvKCRb0Og2DdMgXItWWu41F75yUd40mTb/F6JxXrMAe/KGNpUq2ImUXaMw2pIWJVI6PAVZUdgRUIS8gMGNQ==
+timeline-state-resolver-types@7.5.0-release47.1:
+  version "7.5.0-release47.1"
+  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-7.5.0-release47.1.tgz#1fe2bd43b038528fdd83678f4ead4c27c973c2e6"
+  integrity sha512-uhwdsvLwhB314iXYnxwfKpBc29JklNAmI1senu6kYOUsjdrYN9sI9ARcnjWxIvlSq/+4sk/HcMpw2vnLAYpW5w==
   dependencies:
     tslib "^2.3.1"
 
-timeline-state-resolver@7.5.0-release47.0:
-  version "7.5.0-release47.0"
-  resolved "https://registry.yarnpkg.com/timeline-state-resolver/-/timeline-state-resolver-7.5.0-release47.0.tgz#f20841aece2e2f233a5dd0efde40240c05268952"
-  integrity sha512-j2oYHT+/gta65cifrApFWvTnw/dm9d6OYCgXskkttqBNLslVL4MFz767V7ml4gwlbADYZcjpIBHzyFiNBd2J4g==
+timeline-state-resolver@7.5.0-release47.1:
+  version "7.5.0-release47.1"
+  resolved "https://registry.yarnpkg.com/timeline-state-resolver/-/timeline-state-resolver-7.5.0-release47.1.tgz#6cce884a51e53aa1e823bb07c0ce9f42dc57ca45"
+  integrity sha512-5SSl4fpijCYuyUDBCzB5+2AAIINfhgCiujE7PYAvPtQUCIzUMNN1KKtNwBAb1DFgYIMOVSL9WxY/6DpcyOCqvQ==
   dependencies:
     "@tv2media/v-connection" "^6.0.3"
     atem-connection "2.4.0"
@@ -13994,7 +13994,7 @@ timeline-state-resolver@7.5.0-release47.0:
     sprintf-js "^1.1.2"
     superfly-timeline "^8.3.0"
     threadedclass "^1.1.1"
-    timeline-state-resolver-types "7.5.0-release47.0"
+    timeline-state-resolver-types "7.5.0-release47.1"
     tslib "^2.3.1"
     tv-automation-quantel-gateway-client "^2.0.5"
     underscore "^1.13.4"


### PR DESCRIPTION
This PR adds a button on the Viz-device in system status page, which when clicked will trigger a purge of a viz-rundown.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
