### PR TITLE
test: add setNextSegment tests

### DIFF
--- a/meteor/CHANGELOG.md
+++ b/meteor/CHANGELOG.md
@@ -2,6 +2,299 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.46.0-in-testing.0](https://github.com/nrkno/sofie-core/compare/v1.44.0...v1.46.0-in-testing.0) (2022-10-31)
+
+
+### Features
+
+* add CacheCollection.updateAll method ([89e3045](https://github.com/nrkno/sofie-core/commit/89e3045ce07f66461cc023af9dca56a078cb8763))
+* add state for rundownSegmentViewMode ([4c01c40](https://github.com/nrkno/sofie-core/commit/4c01c40e30bae1e119d18cb709fe7a4a7ab241d6))
+* change interaction model for PieceIndicatorMenu to be click + somewhat of a context menu ([c4b1348](https://github.com/nrkno/sofie-core/commit/c4b1348128972cce4c30c9c78b0e4442303c2059))
+* custom PieceIndicatorMenu ([9af8204](https://github.com/nrkno/sofie-core/commit/9af8204e7d8863cbcf1b30ffcaabc674222bf2de))
+* **List View:** open shelf and reveal AdLib when double clicking on column indicator ([de23d05](https://github.com/nrkno/sofie-core/commit/de23d05ed37b442ac93d0c99fb255c7741b5b35a))
+* PieceIndicatorMenu ([2e19ef8](https://github.com/nrkno/sofie-core/commit/2e19ef86d66744c5830cfe6d61aed819a35c312b))
+* refactor statusbar to be responsive ([309c164](https://github.com/nrkno/sofie-core/commit/309c16495f65f086ede0df5a54b12c7af47cfc8d))
+* remove data-store dependency from server-core-integration ([#738](https://github.com/nrkno/sofie-core/issues/738)) ([d715108](https://github.com/nrkno/sofie-core/commit/d7151084e1d96fdcf575864a439fe7a74087d740))
+* **RundownView:** add a button to switch view modes for entire Rundown ([28657b0](https://github.com/nrkno/sofie-core/commit/28657b0d572a571bb64f7c6d50883877d72b7cc6))
+* **SegmentList:** add Segment note icons to the segment header ([398bcd7](https://github.com/nrkno/sofie-core/commit/398bcd711ff587fc650eab257b3945be1191982d))
+* **SegmentList:** part identifiers ([ca2b6cc](https://github.com/nrkno/sofie-core/commit/ca2b6cc2583fe5d50c6feab0d7fbbbb9253f041b))
+* **SegmentList:** Piece status icons on indicators (WIP) ([56d0eb1](https://github.com/nrkno/sofie-core/commit/56d0eb12e54ef8604d1111fc555fdd25485fb14d))
+* **SegmentList:** Segment header sticking to viewport edge (WIP) ([005912c](https://github.com/nrkno/sofie-core/commit/005912c56565b56c3219690493a91fa85d22e965))
+* **SegmentList:** show state icons on Main pieces ([e259669](https://github.com/nrkno/sofie-core/commit/e259669146875aa3a4162b8e2c6d727f42f246df))
+* **SegmentList:** stick header to last Part ([791e823](https://github.com/nrkno/sofie-core/commit/791e823000b4e0e6c4c996d9da70512c02033559))
+* SOF-767 add option to hide default Start/Execute context menu options for adlibs ([8b8db6d](https://github.com/nrkno/sofie-core/commit/8b8db6d161c0b82e196e38fc23964aa324025cd9))
+* split ShowStyleBaseSettings into multiple tabs ([e1148d1](https://github.com/nrkno/sofie-core/commit/e1148d176ca8ac65b530855c7b86299fc39b5df7))
+* split studio settings into tabs ([23c969e](https://github.com/nrkno/sofie-core/commit/23c969e42f33cd59c1af30dc4a3c70c122779821))
+* support doubleclick in Indicator menu ([d11fd29](https://github.com/nrkno/sofie-core/commit/d11fd29f963e8eca8c2e01640580b634ef622e09))
+* syncIngestUpdateToPartInstance is called when a Part is orphaned, and allows for removing the PartInstance ([#750](https://github.com/nrkno/sofie-core/issues/750)) ([fae7d3f](https://github.com/nrkno/sofie-core/commit/fae7d3f61c497b8d8e3048a966912aaa2b21cacf))
+* this completely doesn't work ([8e3fe01](https://github.com/nrkno/sofie-core/commit/8e3fe01f89d86cc33c52f47190a2b351403b1315))
+
+
+### Bug Fixes
+
+* **ActionTriggers:** show a notification when creating a rundown snapshot ([b1b8cf3](https://github.com/nrkno/sofie-core/commit/b1b8cf34a0a557aada21e0fe705304e5525edd6f))
+* add feature flag confirmKeyCode, to allow for NOT using NumpadEnter in Modals ([549387a](https://github.com/nrkno/sofie-core/commit/549387a4cecd8efefe65c853d74040d38f43ea54))
+* adlibbed partinstance rank is wrong if there is an invalid part after the current ([4cad186](https://github.com/nrkno/sofie-core/commit/4cad186a94932e6416b26eb02e98d9a221fe449c))
+* allow codecov upload to fail ([#776](https://github.com/nrkno/sofie-core/issues/776)) ([e05e181](https://github.com/nrkno/sofie-core/commit/e05e181f20ed3312be314c1c62fb7944a6b6c29e))
+* clear all custom Segment View Modes, when changing rundownDefaultSegmentViewMode ([92517df](https://github.com/nrkno/sofie-core/commit/92517df0109c7ebbd3d6027791fc1fe81f22ce23))
+* complete implementation on R45 ([6a8e5b6](https://github.com/nrkno/sofie-core/commit/6a8e5b6e355d9a60f514b9b4e19f49067b50915d))
+* **Dashboard/Buckets:** LiveSpeak two-tone colouring is not visible with thumbnail present ([5c0ae6a](https://github.com/nrkno/sofie-core/commit/5c0ae6ad26d016e4ce3b163f6be65160bbdd7d32))
+* don't detach when only a single part ([8fa24b7](https://github.com/nrkno/sofie-core/commit/8fa24b760ad5e818ce00b73472e45c3de1b62a8f))
+* empty segment not being hidden ([78607c9](https://github.com/nrkno/sofie-core/commit/78607c92a9235fa06741d1123e47a72629fbee4c))
+* improve ideal-take-time layout ([977dc67](https://github.com/nrkno/sofie-core/commit/977dc67b88602fe33a2a3634ce726e9d80c84919))
+* limit nanoid to similar id output format as meteor ([18fe5f9](https://github.com/nrkno/sofie-core/commit/18fe5f91a1eb65e75f5e11051b107b87c5f5d9fe))
+* **LinePartTitle:** detecting if pixels are needed ([b5df3cb](https://github.com/nrkno/sofie-core/commit/b5df3cb48b729fd8637009b94bdb5d4ebbbb7ab6))
+* **List View:** freeze marker/countdown ([971a660](https://github.com/nrkno/sofie-core/commit/971a6604a1e162b82825ccbafd44cec6bdce5d22))
+* **List View:** OnAirIn/Duration is no longer a toggle ([f93a3df](https://github.com/nrkno/sofie-core/commit/f93a3df8ddaec9b395052ba3e17ab4880e2fcb89))
+* **List View:** right justify timeUntil label ([5689be1](https://github.com/nrkno/sofie-core/commit/5689be11dc462169ae7ac91177791833108bc096))
+* **List View:** show invalid reason on invalid Parts ([8b01b57](https://github.com/nrkno/sofie-core/commit/8b01b57dbdd0370dca6cc3d2b8cceb67369572a7))
+* **ListView:** show later Pieces in correct places ([8614f1a](https://github.com/nrkno/sofie-core/commit/8614f1ac2b334edfd5a9772876b185f08a5eec38))
+* **Local Source:** the channel color dot may be rendered incorrectly ([d9d7718](https://github.com/nrkno/sofie-core/commit/d9d77182d6af2ed7a54756efd715310adebe2e1c))
+* make header sticky on all pages ([eac9620](https://github.com/nrkno/sofie-core/commit/eac9620acb3d0ad45b332af6b06453c2e6e39ab2))
+* make overlay prop optional ([d18a8b1](https://github.com/nrkno/sofie-core/commit/d18a8b136080b0e57a59b5e04af12cbb988c95c1))
+* **PieceIndicatorMenu:** resolve an issue with "memory leak" warnings ([4c23022](https://github.com/nrkno/sofie-core/commit/4c23022339eb42a24aa3bd76f87466841c6360e9))
+* remove unused SourceLayerType.METADATA ([25dfc6d](https://github.com/nrkno/sofie-core/commit/25dfc6dd310ea07cfc933e8cc76cf5323b1d25d0))
+* **Segment List:** scroll to AdLib item ([d888d26](https://github.com/nrkno/sofie-core/commit/d888d26007088e590f8344ffc641b9af489444af))
+* **Segment List:** single click instead of double click ([fb50f71](https://github.com/nrkno/sofie-core/commit/fb50f71cbaf992d2f9654aac2a33d76cdd92c730))
+* **SegmentList:** only show tooltips on Part Title overflow ([b2c8c4a](https://github.com/nrkno/sofie-core/commit/b2c8c4a1f6efb96b5dd6ca44086619ab4db4d08f))
+* **SegmentList:** overtime shadow ([0523a4e](https://github.com/nrkno/sofie-core/commit/0523a4ee0a7a9b027b00ed5e5585f7219bb37300))
+* **SegmentList:** show Part headers with full color, instead of the arrow ([2221eb2](https://github.com/nrkno/sofie-core/commit/2221eb269181e7971bcfbd739b737640b7a33f29))
+* **setNextSegment:** next segment isn't selected when setNextSegment is called ([521ce15](https://github.com/nrkno/sofie-core/commit/521ce15ea209e647d6d26b7a786f60fc7d08151b))
+* SOF-1002 Now check for undefined before calling a potential undefined variable ([b0db998](https://github.com/nrkno/sofie-core/commit/b0db998889a4e6c31676d8de583d113493bed72b))
+* SOF-1031 Downgrade superfly-timeline to 8.2.1 ([018f898](https://github.com/nrkno/sofie-core/commit/018f898700d91678a6b0e5b7320b7886059a9040))
+* SOF-1106 degraded UI performance due to staggered updates not working ([e4df568](https://github.com/nrkno/sofie-core/commit/e4df56894c977b6d9bd6be8437aa14ee93b2922b))
+* **Storyboard:** VT/LiveSpeak Thumbnails can crash segment ([212378f](https://github.com/nrkno/sofie-core/commit/212378f92aa29b0c75f72182582362f8dba722b3))
+* **Timeline+Storyboard:** OnAirIn/Duration is no longer a toggle ([1ef35df](https://github.com/nrkno/sofie-core/commit/1ef35dfde0cfc769159e04207b0c4000a5ce2447))
+* update TSR dep ([145bb57](https://github.com/nrkno/sofie-core/commit/145bb572c76e404d6effd4b3d1424ecf9b11e417))
+
+### [42.0.7](https://github.com/nrkno/sofie-core/compare/v42.0.6-dev...v42.0.7) (2022-08-01)
+
+
+### Features
+
+* **SegmentList:** add flashing snowflake before freeze-frame ([2cf2447](https://github.com/nrkno/sofie-core/commit/2cf2447cb874d12d991a32216c8dfffabc70ff41))
+* **SegmentLIst:** add lines connecting time group members ([74bacb7](https://github.com/nrkno/sofie-core/commit/74bacb74a6ec0abaefe45f54e018e6cde6360a4c))
+* **SegmentList:** keep the ideal take line until a take is made ([132c73c](https://github.com/nrkno/sofie-core/commit/132c73c8e6c9bcef6e0118483c63154ef9f21bf6))
+* **SegmentList:** keep the label on Live pieces for the time being ([9af7bce](https://github.com/nrkno/sofie-core/commit/9af7bcec12ecd584b22519a7c978453a94a03541))
+* **SegmentList:** lines connecting infinites (WIP) ([bc9c9ce](https://github.com/nrkno/sofie-core/commit/bc9c9cecab053da1ad0072bf897f84869f293b88))
+* **SegmentList:** show tooltip to show entire name ([d919842](https://github.com/nrkno/sofie-core/commit/d9198420d8cc6b49dad2f0451834230c48239b46))
+* **SegmentList:** wider segment header ([366c10e](https://github.com/nrkno/sofie-core/commit/366c10e69441f81804750193ef99b6c4f1ecf0d0))
+
+
+### Bug Fixes
+
+* improve Line Part Piece Indicator display time-ordering ([8f3eaa5](https://github.com/nrkno/sofie-core/commit/8f3eaa528a33271a5917a38b78e15b37644c2f1b))
+* **SegmentList:** adlibbed pieces in parts ([64af977](https://github.com/nrkno/sofie-core/commit/64af977d912e0e61c4e518507ce887e7d2cd4209))
+* **SegmentList:** freeze frame countdown/too-short-main-piece ([cab84bf](https://github.com/nrkno/sofie-core/commit/cab84bfada4707f65fa88672fa7461fb6e384937))
+* **SegmentList:** Freeze overlay should only be limited to Piece width ([2ed5b2c](https://github.com/nrkno/sofie-core/commit/2ed5b2cf86a3b029494f0f3d809afc0549463bc5))
+* **SegmentList:** frozen overlay ([b755e25](https://github.com/nrkno/sofie-core/commit/b755e252a231871b8ae9d2509b434535818325ca))
+* **SegmentList:** offset ([da4794d](https://github.com/nrkno/sofie-core/commit/da4794d9961487e764287ac7d15ea24bfb6e9d14))
+* **SegmentList:** overtime counter can wrap ([fa1b55b](https://github.com/nrkno/sofie-core/commit/fa1b55b9559b551e1aa63c58e10a36587e2177cb))
+* **SegmentList:** Part name tooltip ([851d6c9](https://github.com/nrkno/sofie-core/commit/851d6c970b952c5019e1e57fdd75d8c1ad354e07))
+* **SegmentList:** show guest color ([360aa27](https://github.com/nrkno/sofie-core/commit/360aa27eed725e2bef12a23711702c7dc1362292))
+* **SegmentList:** show time on single Part in Segment ([4b4d4e4](https://github.com/nrkno/sofie-core/commit/4b4d4e4b3678ae56720e5cfd1e12ad962f6a31dc))
+* **SegmentList:** use better calculation for infinites connector ([a3d5939](https://github.com/nrkno/sofie-core/commit/a3d5939e655e8cb8783028b3e3a79c7c30ee5eda))
+* show anguilar next flag ([ebea031](https://github.com/nrkno/sofie-core/commit/ebea0310d59778dc45afd212a668684b9aec96f6))
+* SOF-1012 make `isolatedAutorunWithCleanup` independent from `currentComputation` ([7ef7d8a](https://github.com/nrkno/sofie-core/commit/7ef7d8ad050b567278c7d5bb7d6157601caa0cee))
+* SOF-1012 make `isolatedAutorunWithCleanup` independent from `currentComputation` ([#749](https://github.com/nrkno/sofie-core/issues/749)) ([e2b929d](https://github.com/nrkno/sofie-core/commit/e2b929ddb6fbd61ef4463a06efef535a70937904))
+* tooltip align object ([c8385d1](https://github.com/nrkno/sofie-core/commit/c8385d1f21124189249b7b4189fbd17bf7dfb324))
+
+### [42.0.6-dev](https://github.com/nrkno/sofie-core/compare/v1.41.1...v42.0.6-dev) (2022-07-22)
+
+
+### Features
+
+* add AUTO labels where we expect an auto-take to happen ([179ab43](https://github.com/nrkno/sofie-core/commit/179ab43ffe2777031dda86eb059162d2687d591b))
+* change some publications to not use mongo queries to better handle the ui state of a missing id ([b127778](https://github.com/nrkno/sofie-core/commit/b127778ce951e9c9703c65ca60e99e241cfe52a8))
+* improve viewMode switch ([33328d2](https://github.com/nrkno/sofie-core/commit/33328d2837e71a5f90eee338f9f56db934260592))
+* **List View:** show glow around live/next segment headers ([d1122af](https://github.com/nrkno/sofie-core/commit/d1122afdd8889eadde66246fe9ae6f8c56e5eea0))
+* **ListView:** add Script Mini Inspector ([cd0f735](https://github.com/nrkno/sofie-core/commit/cd0f735127a048b60fe727f6cc16a316ffadc3ad))
+* move piece labels right on Next parts ([28ac926](https://github.com/nrkno/sofie-core/commit/28ac9267250a4fe050baeff4acad8c7cd1f8e498))
+* **Segment List View:** double click on Pieces ([71de6d1](https://github.com/nrkno/sofie-core/commit/71de6d1aacd6d74e19d38720ca90b0f56d19bd4d))
+* **Segment List View:** show AdLibs as indicators on each Part ([c7aceec](https://github.com/nrkno/sofie-core/commit/c7aceece784c6857f688fba62e4e3f1f8f7f2359))
+* **Segment List:** hide instead of remove budget counter on past Segments ([76edf19](https://github.com/nrkno/sofie-core/commit/76edf199043ed66a6b7c95a1954c85471921ed32))
+* **Segment List:** rename One Part Per Line to SegmentList ([0e6b13e](https://github.com/nrkno/sofie-core/commit/0e6b13ef416029abda780633cf6f83ef6eeeef04))
+* **Segment List:** show multiple Pieces in Indicators as stacked ([a54fe16](https://github.com/nrkno/sofie-core/commit/a54fe164fe3f954761d2f682c04dc86a53158ce0))
+* **SegmentList:** enlarge Overlay Piece hit target ([00c6f89](https://github.com/nrkno/sofie-core/commit/00c6f89ebacc6c14cb923f38f96e5f795f505f70))
+* **SegmentList:** minWidth on segment title ([da305cf](https://github.com/nrkno/sofie-core/commit/da305cfcccf9f494de185ac738af6c215cd0b531))
+* show end of script (WIP) ([7f05fbf](https://github.com/nrkno/sofie-core/commit/7f05fbf147c76422dc785a20bc1a1ff76e8d476c))
+* strongly type meteorPublish ([608cae5](https://github.com/nrkno/sofie-core/commit/608cae567bf3ed1ee530fe00968fa30690f8dfc8))
+* strongly type meteorSubscribe ([6f281fa](https://github.com/nrkno/sofie-core/commit/6f281fa92014b5543fa7f865c5d02cd60d8a86ff))
+* support blueprints packaged with webpack5 ([2328939](https://github.com/nrkno/sofie-core/commit/23289396f4c1f7b8aa78a50a2403ea4a9e94c2eb))
+* Use React Tooltips for SwitchViewModeButton ([b83c3d3](https://github.com/nrkno/sofie-core/commit/b83c3d3b747239e25e7e667a5384ba97b13d5a7c))
+
+
+### Bug Fixes
+
+* add async wrapper for Picker (http router) ([9f337cc](https://github.com/nrkno/sofie-core/commit/9f337ccd0d39a1fa6c11935d761931ff0560f952))
+* alternate AutoFillSelector flow ([a3917e2](https://github.com/nrkno/sofie-core/commit/a3917e2ea96eb5b30f52dd76c0c634c0c590f6d2))
+* create rundownsForDevice publication for playout-gateway, as it needs to query on different criteria ([d80fdf8](https://github.com/nrkno/sofie-core/commit/d80fdf8dba7c500a22a93a0bb23dfd630deb99e5))
+* disable ui modification of rundown/rundownplaylist owned content ([efe80cc](https://github.com/nrkno/sofie-core/commit/efe80cc6aecea8dd37a6bb17eedeeed1ab1684ec))
+* ellipsis on script ([054cbe1](https://github.com/nrkno/sofie-core/commit/054cbe157fb312d630f5487588d4139f6075e91d))
+* invalid overlay over Pieces ([16e8223](https://github.com/nrkno/sofie-core/commit/16e8223dc891e7f17c3a5b49a5961910c6ce7d2e))
+* JSX-ify SVGs ([1aad6f1](https://github.com/nrkno/sofie-core/commit/1aad6f1447f9633ebc7281034c8f005b9e03eaef))
+* limit Part title to two lines ([1e09bdb](https://github.com/nrkno/sofie-core/commit/1e09bdb1cd0fe869b14cd5a9a9ff7efbb29e3ce1))
+* limit size of data loaded when verifying credentials ([0d08898](https://github.com/nrkno/sofie-core/commit/0d08898190344cc71bcca4a5bb427ab2d8ff3b6b))
+* **LinePartSecondaryPiece:** useCallback dependencies ([09fb69f](https://github.com/nrkno/sofie-core/commit/09fb69f4ae065d8b6d303b5273a320aa5030d9fe))
+* **List View:** move countdown to freeze-frame ([bc14bbf](https://github.com/nrkno/sofie-core/commit/bc14bbf776c5c8cfb5b9f54a15601db35aec7ef0))
+* **ListView:** Script MiniInspector position ([35e2dd0](https://github.com/nrkno/sofie-core/commit/35e2dd0741ed5ee5160c9a9dac5e248a39a3dc1e))
+* move switch mode button ([cee933a](https://github.com/nrkno/sofie-core/commit/cee933a5c1d200ffc608b4a9e55e6dd619fa7cfa))
+* onClick/onDoubleClick callbacks ([cadae5d](https://github.com/nrkno/sofie-core/commit/cadae5de47b24495c0c14fcd697dd76132e4ac66))
+* Part OnAir/Next indicators ([32b2ae2](https://github.com/nrkno/sofie-core/commit/32b2ae23822bf74f826099cbd441e84220e716b2))
+* publications not resolving ([d87710a](https://github.com/nrkno/sofie-core/commit/d87710aabd9ba0685b7465a99c560a05c4daee0b))
+* reduce mongo queries for clients calling peripheraldevice functions ([b599ced](https://github.com/nrkno/sofie-core/commit/b599ced76f7883e0e6b5c20f9d63745393709a98))
+* RundownView not loading PartInstances ([c837a9a](https://github.com/nrkno/sofie-core/commit/c837a9a47abf44c4ea78273634908389c3b1a97a))
+* **SegmentList:** change hit target area from ::before to ::after ([64b4d75](https://github.com/nrkno/sofie-core/commit/64b4d758983c8402ab0558bf893551dc860a818a))
+* **SegmentList:** freeze marker on untimed Parts ([5be8215](https://github.com/nrkno/sofie-core/commit/5be8215ffe877ccd17787f8a0d388d7a3acb3b09))
+* **SegmentList:** overflowing Pieces ([3f61d6d](https://github.com/nrkno/sofie-core/commit/3f61d6d804f1130e9bdddca78234bce94a118181))
+* **SegmentList:** overtime counter far to the righht ([70ad149](https://github.com/nrkno/sofie-core/commit/70ad14922c54a48308937ee38d47a6cb70ed908b))
+* **SegmentList:** Part context menu ([2e29f2a](https://github.com/nrkno/sofie-core/commit/2e29f2a677174128f9d0af5ac8340141be0347d6))
+* **SegmentList:** take line tweaks ([e27ac24](https://github.com/nrkno/sofie-core/commit/e27ac24fe12269855377d55119462cd14fe3b0d1))
+* show not present on AdLibs ([e65a8cc](https://github.com/nrkno/sofie-core/commit/e65a8cc524b2d7370f1ac1cc9c646beb2b8327a5))
+* SOF-769 make single tap toggle an adlib once ([64312ed](https://github.com/nrkno/sofie-core/commit/64312ed2a9011f7a1230c0e25f0b7a29a89c8006))
+* update imports ([522fe2c](https://github.com/nrkno/sofie-core/commit/522fe2c569035050b971eb9c6f2ce53ed9d10692))
+
+### [42.0.5-dev](https://github.com/nrkno/sofie-core/compare/v37.1.9...v42.0.5-dev) (2022-06-23)
+
+
+### Bug Fixes
+
+* SOF-944 make MiniShelf hotkeys work consistently ([cbd0c41](https://github.com/nrkno/sofie-core/commit/cbd0c411b6f34d768a70f495088e7eeb386e1127))
+
+### [37.1.9](https://github.com/nrkno/sofie-core/compare/v42.0.4-dev...v37.1.9) (2022-06-14)
+
+
+### Bug Fixes
+
+* **OPL:** overtime shadow animates even if at the end of the Part ([08fd0ee](https://github.com/nrkno/sofie-core/commit/08fd0eeb038a520dcfbd6cce01dca57f218c1a2a))
+* presenter screen added time after unrelated mos update ([#640](https://github.com/nrkno/sofie-core/issues/640)) ([9651a43](https://github.com/nrkno/sofie-core/commit/9651a4385631937af3ce3008a6786eda104c55ff))
+
+### [42.0.4-dev](https://github.com/nrkno/sofie-core/compare/v42.0.2-dev...v42.0.4-dev) (2022-06-10)
+
+
+### Features
+
+* alow to disable hover scrub on dashboard per-panel ([0670d63](https://github.com/nrkno/sofie-core/commit/0670d635c47323868e6414b2299a1208bc7687be))
+* **OPL:** enable hover inspector on Pieces ([988e9ef](https://github.com/nrkno/sofie-core/commit/988e9ef01bd63a36583b278a9513b20b5663f9ca))
+* **OPL:** Placeholder invalid Part display ([0418129](https://github.com/nrkno/sofie-core/commit/04181290602afab4bba288269e4180f6aca668a7))
+* some touchups ([a766660](https://github.com/nrkno/sofie-core/commit/a7666605d75bc61ddc5f25f16b361600c14910cf))
+* **Storyboard:** remove thumbnails ([a1efc4c](https://github.com/nrkno/sofie-core/commit/a1efc4c87021597f1ff512d245d1c46e1d590c2c))
+* **Storyboard:** remove thumbnails, shorten main Pieces ([ab40b8f](https://github.com/nrkno/sofie-core/commit/ab40b8f415da4e1bd73bb4647c7e6aa820377af8))
+
+
+### Bug Fixes
+
+* **OPL:** align stuff with other Segment view modes ([372f005](https://github.com/nrkno/sofie-core/commit/372f005bda2904cd040b6eb94e870a129c87703d))
+* **OPL:** Freeze frame indicator z-index ([096e3b8](https://github.com/nrkno/sofie-core/commit/096e3b8219f0f2967d90c6e998f8484d95298a0e))
+* **OPL:** issues after playing around with overtime shadow ([e73205e](https://github.com/nrkno/sofie-core/commit/e73205eedba8eca1c9e3034aabcf2841a0329aa7))
+* **OPL:** make segment title flush with other modes ([3c565b8](https://github.com/nrkno/sofie-core/commit/3c565b809aedfaa684bc7d49d47912b55ef2f20c))
+* **OPL:** very long Piece labels extend timeine size ([fe9daaa](https://github.com/nrkno/sofie-core/commit/fe9daaa51256cfccbb58e21226c294a88cd85960))
+* storyboard thumbnail for graphics ([5d10279](https://github.com/nrkno/sofie-core/commit/5d1027972ecfb42d2abb117fa2d3b1881dcbe97f))
+
+### [42.0.1-dev](https://github.com/nrkno/sofie-core/compare/v1.43.0-in-testing.0...v42.0.1-dev) (2022-06-03)
+
+
+### Features
+
+* add transition Pieces ([b88d15b](https://github.com/nrkno/sofie-core/commit/b88d15b75a76995e15cc7a6a7dcde652a93f97d6))
+* **OPL:** Piece Indicators ([a3f683f](https://github.com/nrkno/sofie-core/commit/a3f683fadf8d87228da6eb4ec48070de07a5fe82))
+* **OPL:** timed graphcis ([c13f562](https://github.com/nrkno/sofie-core/commit/c13f562329febaf3eb53c281bf1705d0e1c4947c))
+* part-level history shade ([96cd054](https://github.com/nrkno/sofie-core/commit/96cd05444644295575efd51acc2bd2d063ddfd3c))
+* prototype (WIP) ([01a2b8b](https://github.com/nrkno/sofie-core/commit/01a2b8bda9ad395f1a1bcdc2c246d16808240261))
+* Set log level from LOG_LEVEL env var. ([f4614d8](https://github.com/nrkno/sofie-core/commit/f4614d84dea41cb447cd5954d4510d7a32a705a5))
+* show freeze frame indicator ([d03cab1](https://github.com/nrkno/sofie-core/commit/d03cab1a6d8fbf559784e306fb38cebf2602a44a))
+* styling improvements ([cfc81ee](https://github.com/nrkno/sofie-core/commit/cfc81eef585877474cada8651fede896c4224e6a))
+
+
+### Bug Fixes
+
+* Add 'Use fallback' option for log level. ([e9dbd4f](https://github.com/nrkno/sofie-core/commit/e9dbd4f8261d0dd210f50fbff64ad9857c77f00c))
+* lowered logging level for a pair of log calls. ([9e6939d](https://github.com/nrkno/sofie-core/commit/9e6939de7acc2f656944db9a2d1240e9bd9f79a7))
+* offset secondary Pieces ([1a44bfd](https://github.com/nrkno/sofie-core/commit/1a44bfdc74f729942f19f52e7c4e02d926e65f1e))
+* **OPL:** Timed super position was incorrect ([649806a](https://github.com/nrkno/sofie-core/commit/649806a10595b2157797463dec65a4765015024d))
+* remove banned column name ([7656f8e](https://github.com/nrkno/sofie-core/commit/7656f8e8b555b96d86f1163e8848966ba70cc997))
+* SOF-767 enable context menu trigger in RundownViewShelf ([c1449b8](https://github.com/nrkno/sofie-core/commit/c1449b80e6bf75901ac9bfa53bb0b245dbedec7f))
+* SOF-767 hide bucket and inspector menu items when disabled ([c2b9b93](https://github.com/nrkno/sofie-core/commit/c2b9b93d1dfe9c10f7588084c6e64a667384e8a8))
+* SOF-954 make hackGetMediaObjectDuration return values ([e762b0d](https://github.com/nrkno/sofie-core/commit/e762b0da601489531b7fde01057a753926d37b95))
+* SOF-954 mediaObjects callbacks no longer cause crashes ([d78ca2d](https://github.com/nrkno/sofie-core/commit/d78ca2d5bf5dea7fead85dc76eeaea127390d4f4))
+* **TV 2:** SOF-767 show inspector if enabled ([63cf83f](https://github.com/nrkno/sofie-core/commit/63cf83f12f37c3024874b0b31e8ab1d5e01176ef))
+
+### [37.1.8](https://github.com/nrkno/sofie-core/compare/v42.0.0-dev...v37.1.8) (2022-05-10)
+
+
+### Bug Fixes
+
+* Bumped Sorensen for fixing preventDefaultDown not respecting global. ([acb6e85](https://github.com/nrkno/sofie-core/commit/acb6e85d0df093c3ab6424309b8ffbc2d404d9af))
+* made a custom funtion to find piece with script ([a762962](https://github.com/nrkno/sofie-core/commit/a762962db5dd943708d0412cdeff12b94bb2be38))
+* Use AnyEnter instead of Enter for modals. ([7c77e95](https://github.com/nrkno/sofie-core/commit/7c77e9597fcec699b3a0846abda05f820598a62e))
+
+## [42.0.0-dev](https://github.com/nrkno/sofie-core/compare/v1.42.5...v42.0.0-dev) (2022-05-03)
+
+### [1.42.5](https://github.com/nrkno/sofie-core/compare/v1.42.4...v1.42.5) (2022-05-03)
+
+### [1.42.4](https://github.com/nrkno/sofie-core/compare/v1.39.0...v1.42.4) (2022-05-03)
+
+### [37.1.7](https://github.com/nrkno/sofie-core/compare/v37.1.4...v37.1.7) (2022-04-26)
+
+
+### Bug Fixes
+
+* Bumped Sorensen and using preventDefaultDown option. ([1b75715](https://github.com/nrkno/sofie-core/commit/1b7571566106e37940c3fa9528f958373cc6ca7a))
+* RundownView now use TriggersHandler with shelfOnly. ([1278b1d](https://github.com/nrkno/sofie-core/commit/1278b1d620a7ae002b946810e0e23299220e4f8e))
+* scroll when component mounts, also when next=current ([47e1551](https://github.com/nrkno/sofie-core/commit/47e15515d2eab9745b9a41a5d3da230ba0aa6bc4))
+* SOF-858 filter out hidden segments ([b5364de](https://github.com/nrkno/sofie-core/commit/b5364de8d6a5cfeb06b8c8c7065ab6f8250a5b3a))
+* Using Settings with defaults included for poisonKey. ([70004ca](https://github.com/nrkno/sofie-core/commit/70004cac8826cd056746d48d56fdfb7e8283a291))
+
+### [37.1.4](https://github.com/nrkno/sofie-core/compare/v37.1.3...v37.1.4) (2022-04-06)
+
+
+### Bug Fixes
+
+* merge error ([4704de9](https://github.com/nrkno/sofie-core/commit/4704de920db2b2db0a6ebee1eac92d0b8a9269f8))
+
+### [37.1.3](https://github.com/nrkno/sofie-core/compare/v1.38.4...v37.1.3) (2022-04-06)
+
+
+### Bug Fixes
+
+* deactivating a rundown will now trigger an event allowing the ui to show a warning ([9a2269b](https://github.com/nrkno/sofie-core/commit/9a2269b80fa674bfbeb77f8a815c366023b3dbe7))
+* log the event when queueing minishelf adlibs ([43c2b3b](https://github.com/nrkno/sofie-core/commit/43c2b3b018f12fc58f65640cba3a17d3034d5cbc))
+* SOF-834 UI slow due to segments re-rendering too often ([9a3ae8d](https://github.com/nrkno/sofie-core/commit/9a3ae8dc36a95a6cebb07a8679a5130f2911dfc7))
+
+## [1.37.0-2](https://github.com/nrkno/sofie-core/compare/v1.38.2...v1.37.0-2) (2022-03-25)
+
+
+### Bug Fixes
+
+* cherry pick c2f96945379bb9052dcd7d8dfe82e641136fd4c5 to fix touch issue ([63273cb](https://github.com/nrkno/sofie-core/commit/63273cb844c790f3a7489f482eeb8d92d66377af))
+* make local copy of pointerId to avoid react throwing warning about event pooling ([0729c31](https://github.com/nrkno/sofie-core/commit/0729c3103b0d15b72aa8e40dc8d11a2a3187f8a6))
+* removed part of the commit that requires other code not merged to our branch yet ([d816de6](https://github.com/nrkno/sofie-core/commit/d816de621e316ed393783566102ae9bdbbe243ac))
+
+### [37.1.2](https://github.com/nrkno/sofie-core/compare/v37.1.1...v37.1.2) (2022-03-16)
+
+
+### Bug Fixes
+
+* Added poisonKey flag. ([dfe3781](https://github.com/nrkno/sofie-core/commit/dfe37817180c80465c5e810807d626e7a20ef0e9))
+* fixed failing test ([b1061fd](https://github.com/nrkno/sofie-core/commit/b1061fd9f9c4072d44d5e093604f38aea9f67d2d))
+* hidden segments disappearing forever ([e9ab481](https://github.com/nrkno/sofie-core/commit/e9ab481cb5b3f8e078da3c171be1755baf6f42fc))
+* segment countdown was only calculated for the first part in a segment ([0a8f9e7](https://github.com/nrkno/sofie-core/commit/0a8f9e70ee7017de7492aa0c13ebe5d8bace148f))
+* use time of when segment started playing when calculating remaining time of segment ([bde43f1](https://github.com/nrkno/sofie-core/commit/bde43f1dcbecd4e5211fc61031da628ed816f7cc))
+
+## [1.37.0-in-testing.32](https://github.com/nrkno/sofie-core/compare/v1.37.0-in-testing.31...v1.37.0-in-testing.32) (2022-01-10)
+
+
+### Bug Fixes
+
+* hidden segments disappearing forever ([0d7b945](https://github.com/nrkno/sofie-core/commit/0d7b9458aef78a68bcd038af6676f035af920527))
+
+## [1.37.0-in-testing.31](https://github.com/nrkno/sofie-core/compare/v1.37.1-in-testing.1...v1.37.0-in-testing.31) (2022-01-06)
+
+
+### Bug Fixes
+
+* fixed duplicated shoutcuts ([da344a6](https://github.com/nrkno/sofie-core/commit/da344a68d878ebe143523ace20536cf5aacd1ed1))
+
 ## [1.44.0](https://github.com/nrkno/sofie-core/compare/v1.44.0-in-testing.3...v1.44.0) (2022-10-24)
 
 ### [1.41.7](https://github.com/nrkno/sofie-core/compare/v1.41.6...v1.41.7) (2022-09-14)

--- a/meteor/Dockerfile
+++ b/meteor/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 # BUILD IMAGE
-FROM node:14.20
+FROM node:14
 RUN curl "https://install.meteor.com/?release=2.7.3" | sh
 
 # Temporary change the NODE_ENV env variable, so that all libraries are installed:

--- a/meteor/package.json
+++ b/meteor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "automation-core",
-	"version": "1.46.0-in-testing",
+	"version": "1.46.0-in-testing.0",
 	"private": true,
 	"engines": {
 		"node": ">=14.19.1"

--- a/meteor/server/api/blueprints/migrationContext.ts
+++ b/meteor/server/api/blueprints/migrationContext.ts
@@ -279,7 +279,7 @@ export class MigrationContextStudio implements IMigrationContextStudio {
 		}
 
 		const settings = parentDevice.settings as PlayoutDeviceSettings | undefined
-		if (settings && settings.devices[deviceId]) {
+		if (settings && settings.devices && settings.devices[deviceId]) {
 			throw new Meteor.Error(404, `Device "${deviceId}" cannot be inserted as it already exists`)
 		}
 

--- a/meteor/yarn.lock
+++ b/meteor/yarn.lock
@@ -9832,10 +9832,10 @@ timecode@0.0.4:
   resolved "https://registry.yarnpkg.com/timecode/-/timecode-0.0.4.tgz#cdea9d2352009700e50da657cb7fb7c1720f5704"
   integrity sha512-xFVZlWnqls5eVphtUJo0UuXeJa0grBmxESSn5QPQB7CMsaVgTnLdP9PTZqb4KyFmLdrE+PUu3eEt42zHsMxCtw==
 
-timeline-state-resolver-types@7.4.0-release46.1:
-  version "7.4.0-release46.1"
-  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-7.4.0-release46.1.tgz#e5c5e3959bc931d1b6adde72589b30e7c7681f20"
-  integrity sha512-PDzQdjiP6bSVm7O+QEqSZ7teYxU/1JfxkdLmvei+z23PldJ3yEBpG/uI/C+OfadeZMRQdKYErBRGQqn5VYSq0Q==
+timeline-state-resolver-types@7.4.0-release46.2:
+  version "7.4.0-release46.2"
+  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-7.4.0-release46.2.tgz#cb0fd08c7537504eca3531206bc20501612e33f0"
+  integrity sha512-1WYIyBiKS+JR1sBXB5gYGvcMB7JZhY4N++36i8YD44pP5B8a1j0g5LHcuv6Exo4DizlS6JuvvheSj218gKy6PQ==
   dependencies:
     tslib "^2.3.1"
 

--- a/packages/blueprints-integration/CHANGELOG.md
+++ b/packages/blueprints-integration/CHANGELOG.md
@@ -3,6 +3,39 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.46.0-in-testing.0](https://github.com/nrkno/tv-automation-server-core/compare/v1.44.0...v1.46.0-in-testing.0) (2022-10-31)
+
+
+### Bug Fixes
+
+* remove unused SourceLayerType.METADATA ([25dfc6d](https://github.com/nrkno/tv-automation-server-core/commit/25dfc6dd310ea07cfc933e8cc76cf5323b1d25d0))
+* SOF-954 make hackGetMediaObjectDuration return values ([e762b0d](https://github.com/nrkno/tv-automation-server-core/commit/e762b0da601489531b7fde01057a753926d37b95))
+* update TSR dep ([145bb57](https://github.com/nrkno/tv-automation-server-core/commit/145bb572c76e404d6effd4b3d1424ecf9b11e417))
+
+
+### Features
+
+* prototype (WIP) ([01a2b8b](https://github.com/nrkno/tv-automation-server-core/commit/01a2b8bda9ad395f1a1bcdc2c246d16808240261))
+* **Segment List View:** show AdLibs as indicators on each Part ([c7aceec](https://github.com/nrkno/tv-automation-server-core/commit/c7aceece784c6857f688fba62e4e3f1f8f7f2359))
+* **Segment List:** rename One Part Per Line to SegmentList ([0e6b13e](https://github.com/nrkno/tv-automation-server-core/commit/0e6b13ef416029abda780633cf6f83ef6eeeef04))
+* syncIngestUpdateToPartInstance is called when a Part is orphaned, and allows for removing the PartInstance ([#750](https://github.com/nrkno/tv-automation-server-core/issues/750)) ([fae7d3f](https://github.com/nrkno/tv-automation-server-core/commit/fae7d3f61c497b8d8e3048a966912aaa2b21cacf))
+
+
+
+## [1.42.5](https://github.com/nrkno/tv-automation-server-core/compare/v1.42.4...v1.42.5) (2022-05-03)
+
+
+
+## [1.42.4](https://github.com/nrkno/tv-automation-server-core/compare/v1.39.0...v1.42.4) (2022-05-03)
+
+
+
+## [37.1.2](https://github.com/nrkno/tv-automation-server-core/compare/v37.1.1...v37.1.2) (2022-03-16)
+
+
+
+
+
 # [1.44.0](https://github.com/nrkno/tv-automation-server-core/compare/v1.44.0-in-testing.3...v1.44.0) (2022-10-24)
 
 **Note:** Version bump only for package @sofie-automation/blueprints-integration

--- a/packages/blueprints-integration/package.json
+++ b/packages/blueprints-integration/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sofie-automation/blueprints-integration",
-	"version": "1.46.0-in-testing",
+	"version": "1.46.0-in-testing.0",
 	"description": "Library to define the interaction between core and the blueprints.",
 	"main": "dist/index.js",
 	"typings": "dist/index.d.ts",
@@ -39,7 +39,7 @@
 	],
 	"dependencies": {
 		"@sofie-automation/shared-lib": "link:../shared-lib",
-		"timeline-state-resolver-types": "7.4.0-release46.1",
+		"timeline-state-resolver-types": "7.4.0-release46.2",
 		"tslib": "^2.4.0",
 		"type-fest": "^2.19.0"
 	},

--- a/packages/corelib/package.json
+++ b/packages/corelib/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sofie-automation/corelib",
-	"version": "1.46.0-in-testing",
+	"version": "1.46.0-in-testing.0",
 	"private": true,
 	"description": "Internal library for some types shared by core and workers",
 	"main": "dist/index.js",

--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "sofie-documentation",
-	"version": "1.46.0-in-testing",
+	"version": "1.46.0-in-testing.0",
 	"private": true,
 	"scripts": {
 		"docusaurus": "docusaurus",

--- a/packages/job-worker/package.json
+++ b/packages/job-worker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sofie-automation/job-worker",
-	"version": "1.46.0-in-testing",
+	"version": "1.46.0-in-testing.0",
 	"description": "Worker for things",
 	"main": "dist/index.js",
 	"license": "MIT",

--- a/packages/job-worker/src/playout/adlib.ts
+++ b/packages/job-worker/src/playout/adlib.ts
@@ -528,13 +528,14 @@ export async function innerStartQueuedAdLib(
 	// Ensure it is labelled as dynamic
 	newPartInstance.orphaned = 'adlib-part'
 
+	// Find the following part, so we can pick a good rank
 	const followingPart = selectNextPart(
 		context,
 		cache.Playlist.doc,
 		currentPartInstance,
 		null,
 		getOrderedSegmentsAndPartsFromPlayoutCache(cache),
-		true
+		false // We want to insert it before any trailing invalid piece
 	)
 	newPartInstance.part._rank = getRank(
 		currentPartInstance.part,

--- a/packages/lerna.json
+++ b/packages/lerna.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.46.0-in-testing",
+	"version": "1.46.0-in-testing.0",
 	"npmClient": "yarn",
 	"useWorkspaces": true
 }

--- a/packages/mos-gateway/CHANGELOG.md
+++ b/packages/mos-gateway/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.46.0-in-testing.0](https://github.com/nrkno/tv-automation-server-core/compare/v1.44.0...v1.46.0-in-testing.0) (2022-10-31)
+
+
+### Features
+
+* remove data-store dependency from server-core-integration ([#738](https://github.com/nrkno/tv-automation-server-core/issues/738)) ([d715108](https://github.com/nrkno/tv-automation-server-core/commit/d7151084e1d96fdcf575864a439fe7a74087d740))
+
+
+
+
+
 # [1.44.0](https://github.com/nrkno/tv-automation-server-core/compare/v1.44.0-in-testing.3...v1.44.0) (2022-10-24)
 
 **Note:** Version bump only for package mos-gateway

--- a/packages/mos-gateway/Dockerfile
+++ b/packages/mos-gateway/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 # BUILD IMAGE
-FROM node:16.16
+FROM node:16
 WORKDIR /opt
 
 COPY package.json lerna.json yarn.lock tsconfig.json ./
@@ -13,7 +13,7 @@ RUN yarn build
 RUN yarn install --check-files --frozen-lockfile --production --force --ignore-scripts # purge dev-dependencies
 
 # DEPLOY IMAGE
-FROM node:16.16-alpine
+FROM node:16-alpine
 RUN apk add --no-cache tzdata
 
 COPY --from=0 /opt/package.json /opt/package.json

--- a/packages/mos-gateway/Dockerfile.circle
+++ b/packages/mos-gateway/Dockerfile.circle
@@ -1,4 +1,4 @@
-FROM node:16.16-alpine
+FROM node:16-alpine
 RUN apk add --no-cache tzdata
 
 COPY package.json /opt/

--- a/packages/mos-gateway/package.json
+++ b/packages/mos-gateway/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mos-gateway",
-	"version": "1.46.0-in-testing",
+	"version": "1.46.0-in-testing.0",
 	"private": true,
 	"description": "MOS-Gateway for the Sofie project",
 	"license": "MIT",
@@ -65,8 +65,8 @@
 		"production"
 	],
 	"dependencies": {
-		"@sofie-automation/server-core-integration": "1.46.0-in-testing",
-		"@sofie-automation/shared-lib": "1.46.0-in-testing",
+		"@sofie-automation/server-core-integration": "1.46.0-in-testing.0",
+		"@sofie-automation/shared-lib": "1.46.0-in-testing.0",
 		"mos-connection": "^2.0.1",
 		"tslib": "^2.4.0",
 		"underscore": "^1.13.4",

--- a/packages/playout-gateway/CHANGELOG.md
+++ b/packages/playout-gateway/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.46.0-in-testing.0](https://github.com/nrkno/tv-automation-server-core/compare/v1.44.0...v1.46.0-in-testing.0) (2022-10-31)
+
+
+### Bug Fixes
+
+* create rundownsForDevice publication for playout-gateway, as it needs to query on different criteria ([d80fdf8](https://github.com/nrkno/tv-automation-server-core/commit/d80fdf8dba7c500a22a93a0bb23dfd630deb99e5))
+* lowered logging level for a pair of log calls. ([9e6939d](https://github.com/nrkno/tv-automation-server-core/commit/9e6939de7acc2f656944db9a2d1240e9bd9f79a7))
+* SOF-1031 Downgrade superfly-timeline to 8.2.1 ([018f898](https://github.com/nrkno/tv-automation-server-core/commit/018f898700d91678a6b0e5b7320b7886059a9040))
+* update TSR dep ([145bb57](https://github.com/nrkno/tv-automation-server-core/commit/145bb572c76e404d6effd4b3d1424ecf9b11e417))
+
+
+### Features
+
+* remove data-store dependency from server-core-integration ([#738](https://github.com/nrkno/tv-automation-server-core/issues/738)) ([d715108](https://github.com/nrkno/tv-automation-server-core/commit/d7151084e1d96fdcf575864a439fe7a74087d740))
+
+
+
+
+
 # [1.44.0](https://github.com/nrkno/tv-automation-server-core/compare/v1.44.0-in-testing.3...v1.44.0) (2022-10-24)
 
 

--- a/packages/playout-gateway/Dockerfile
+++ b/packages/playout-gateway/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 # BUILD IMAGE
-FROM node:16.16
+FROM node:16
 WORKDIR /opt
 
 COPY package.json lerna.json yarn.lock tsconfig.json ./
@@ -14,7 +14,7 @@ RUN yarn build
 RUN yarn install --check-files --frozen-lockfile --production --force --ignore-scripts # purge dev-dependencies
 
 # DEPLOY IMAGE
-FROM node:16.16-alpine
+FROM node:16-alpine
 RUN apk add --no-cache tzdata
 
 COPY --from=0 /opt/package.json /opt/package.json

--- a/packages/playout-gateway/Dockerfile.circle
+++ b/packages/playout-gateway/Dockerfile.circle
@@ -1,4 +1,4 @@
-FROM node:16.16-alpine
+FROM node:16-alpine
 RUN apk add --no-cache tzdata
 
 COPY package.json /opt/

--- a/packages/playout-gateway/package.json
+++ b/packages/playout-gateway/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "playout-gateway",
-	"version": "1.46.0-in-testing",
+	"version": "1.46.0-in-testing.0",
 	"private": true,
 	"description": "Connect to Core, play stuff",
 	"license": "MIT",
@@ -56,13 +56,13 @@
 		"production"
 	],
 	"dependencies": {
-		"@sofie-automation/blueprints-integration": "1.46.0-in-testing",
-		"@sofie-automation/server-core-integration": "1.46.0-in-testing",
-		"@sofie-automation/shared-lib": "1.46.0-in-testing",
+		"@sofie-automation/blueprints-integration": "1.46.0-in-testing.0",
+		"@sofie-automation/server-core-integration": "1.46.0-in-testing.0",
+		"@sofie-automation/shared-lib": "1.46.0-in-testing.0",
 		"debug": "^4.3.3",
 		"fast-clone": "^1.5.13",
 		"influx": "^5.9.3",
-		"timeline-state-resolver": "7.4.0-release46.1",
+		"timeline-state-resolver": "7.4.0-release46.2",
 		"tslib": "^2.4.0",
 		"underscore": "^1.13.4",
 		"winston": "^3.8.2"

--- a/packages/server-core-integration/CHANGELOG.md
+++ b/packages/server-core-integration/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.46.0-in-testing.0](https://github.com/nrkno/tv-automation-server-core/compare/v1.44.0...v1.46.0-in-testing.0) (2022-10-31)
+
+
+### Features
+
+* remove data-store dependency from server-core-integration ([#738](https://github.com/nrkno/tv-automation-server-core/issues/738)) ([d715108](https://github.com/nrkno/tv-automation-server-core/commit/d7151084e1d96fdcf575864a439fe7a74087d740))
+
+
+
+
+
 # [1.44.0](https://github.com/nrkno/tv-automation-server-core/compare/v1.44.0-in-testing.3...v1.44.0) (2022-10-24)
 
 **Note:** Version bump only for package @sofie-automation/server-core-integration

--- a/packages/server-core-integration/package.json
+++ b/packages/server-core-integration/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sofie-automation/server-core-integration",
-	"version": "1.46.0-in-testing",
+	"version": "1.46.0-in-testing.0",
 	"description": "Library for connecting to Core",
 	"main": "dist/index.js",
 	"typings": "dist/index.d.ts",
@@ -70,7 +70,7 @@
 		"production"
 	],
 	"dependencies": {
-		"@sofie-automation/shared-lib": "1.46.0-in-testing",
+		"@sofie-automation/shared-lib": "1.46.0-in-testing.0",
 		"ejson": "^2.2.3",
 		"eventemitter3": "^4.0.7",
 		"faye-websocket": "^0.11.4",

--- a/packages/shared-lib/package.json
+++ b/packages/shared-lib/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sofie-automation/shared-lib",
-	"version": "1.46.0-in-testing",
+	"version": "1.46.0-in-testing.0",
 	"private": false,
 	"description": "Library for types & values shared by core, workers and gateways",
 	"main": "dist/index.js",

--- a/packages/yarn.lock
+++ b/packages/yarn.lock
@@ -3095,7 +3095,7 @@
   version "1.46.0-in-testing"
   dependencies:
     "@sofie-automation/shared-lib" "link:shared-lib"
-    timeline-state-resolver-types "7.4.0-release46.1"
+    timeline-state-resolver-types "7.4.0-release46.2"
     tslib "^2.4.0"
     type-fest "^2.19.0"
 
@@ -13917,7 +13917,7 @@ threadedclass@^0.8.0:
     is-running "^2.1.0"
     tslib "^1.13.0"
 
-threadedclass@^1.1.0:
+threadedclass@^1.1.0, threadedclass@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/threadedclass/-/threadedclass-1.1.1.tgz#6813b3c401b3d55264f6225c9d2c15516d7efa97"
   integrity sha512-HffBjerRZGOlhUBt9Ue8nYCuV6khK9er86w4svTvf1Xn6ibAyJok290o2MJ/qJ1vy0A4UphEo3DSsxFN5g+TBQ==
@@ -13962,17 +13962,17 @@ timecode@0.0.4:
   resolved "https://registry.yarnpkg.com/timecode/-/timecode-0.0.4.tgz#cdea9d2352009700e50da657cb7fb7c1720f5704"
   integrity sha512-xFVZlWnqls5eVphtUJo0UuXeJa0grBmxESSn5QPQB7CMsaVgTnLdP9PTZqb4KyFmLdrE+PUu3eEt42zHsMxCtw==
 
-timeline-state-resolver-types@7.4.0-release46.1:
-  version "7.4.0-release46.1"
-  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-7.4.0-release46.1.tgz#e5c5e3959bc931d1b6adde72589b30e7c7681f20"
-  integrity sha512-PDzQdjiP6bSVm7O+QEqSZ7teYxU/1JfxkdLmvei+z23PldJ3yEBpG/uI/C+OfadeZMRQdKYErBRGQqn5VYSq0Q==
+timeline-state-resolver-types@7.4.0-release46.2:
+  version "7.4.0-release46.2"
+  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-7.4.0-release46.2.tgz#cb0fd08c7537504eca3531206bc20501612e33f0"
+  integrity sha512-1WYIyBiKS+JR1sBXB5gYGvcMB7JZhY4N++36i8YD44pP5B8a1j0g5LHcuv6Exo4DizlS6JuvvheSj218gKy6PQ==
   dependencies:
     tslib "^2.3.1"
 
-timeline-state-resolver@7.4.0-release46.1:
-  version "7.4.0-release46.1"
-  resolved "https://registry.yarnpkg.com/timeline-state-resolver/-/timeline-state-resolver-7.4.0-release46.1.tgz#2538cb4938e4519e79eb846b67792d9a2c76aa96"
-  integrity sha512-qjnAkW2eGb9mQMrTHzij4167iKHV7Nz/HpGjuSHr38wabKHw6Vf5oYeZeFyK9jlL2E+204/5mrXSBDwlm/pbSg==
+timeline-state-resolver@7.4.0-release46.2:
+  version "7.4.0-release46.2"
+  resolved "https://registry.yarnpkg.com/timeline-state-resolver/-/timeline-state-resolver-7.4.0-release46.2.tgz#926de42c12f1409be040a58020523f03a12c88f3"
+  integrity sha512-sRcEIjCNwc30FbNurFvYM9wQfBRSLeo26nYCwo9OZ25XO2MCpBbLkfEYY3czKEDLGhdrgkDBYb/NM6TuvhkHPg==
   dependencies:
     "@tv2media/v-connection" "^6.0.2"
     atem-connection "2.4.0"
@@ -13993,8 +13993,8 @@ timeline-state-resolver@7.4.0-release46.1:
     request "^2.88.0"
     sprintf-js "^1.1.2"
     superfly-timeline "^8.2.8"
-    threadedclass "^1.1.0"
-    timeline-state-resolver-types "7.4.0-release46.1"
+    threadedclass "^1.1.1"
+    timeline-state-resolver-types "7.4.0-release46.2"
     tslib "^2.3.1"
     tv-automation-quantel-gateway-client "^2.0.5"
     underscore "^1.13.4"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds tests for a method called `setNextSegment` (in the GUI the feature known as _Queue segment_).


* **What is the current behavior?** (You can also link to an open issue here)

* **What is the new behavior (if this is a feature change)?**


* **Other information**:
Opening as a draft because currently the test fails on a special case that we [used to have](https://github.com/nrkno/sofie-core/blob/release37/meteor/server/api/userActions.ts#L185-L189) (when the next part instance is outside of the current segment, it should just set the first part of the chosen segment as next, instead of queuing), but I have yet to confirm if we want to bring it back.


**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
