### PR TITLE
Bug fix: change how to wait for other Fibers in collections.*Async

### DIFF
--- a/meteor/lib/__tests__/lib.test.ts
+++ b/meteor/lib/__tests__/lib.test.ts
@@ -1,3 +1,5 @@
+import '../../__mocks__/_extendJest'
+
 import { Meteor } from 'meteor/meteor'
 import { Mongo } from 'meteor/mongo'
 import { afterEachInFiber, testInFiber } from '../../__mocks__/helpers/jest'
@@ -14,6 +16,7 @@ import {
 	equalSets,
 	equivalentArrays,
 	LogLevel,
+	makePromise,
 } from '../lib'
 import { MeteorMock } from '../../__mocks__/meteor'
 
@@ -195,5 +198,38 @@ describe('lib/lib', () => {
 	testInFiber('equivalentArrays', () => {
 		expect(equivalentArrays(['a', 'b', 'c'], ['c', 'a', 'b'])).toBe(true)
 		expect(equivalentArrays(['a', 'b', 'c'], ['b', 'g', 'a'])).toBe(false)
+	})
+	testInFiber('makePromise', async () => {
+		let a = 0
+		// Check that they are executed in order:
+		expect(
+			await Promise.all([
+				makePromise(() => {
+					return a++
+				}),
+				makePromise(() => {
+					return a++
+				}),
+			])
+		).toStrictEqual([0, 1])
+
+		// Handle an instant throw:
+		await expect(
+			makePromise(() => {
+				throw new Error('asdf')
+			})
+		).rejects.toMatchToString(/asdf/)
+
+		// Handle a delayed throw:
+		const delayedThrow = Meteor.wrapAsync((callback) => {
+			setTimeout(() => {
+				callback(new Error('asdf'), null)
+			}, 10)
+		})
+		await expect(
+			makePromise(() => {
+				delayedThrow()
+			})
+		).rejects.toMatchToString(/asdf/)
 	})
 })

--- a/meteor/lib/collections/lib.ts
+++ b/meteor/lib/collections/lib.ts
@@ -6,7 +6,6 @@ import {
 	getHash,
 	ProtectedString,
 	makePromise,
-	sleep,
 	registerCollection,
 	stringifyError,
 	protectString,
@@ -291,12 +290,9 @@ class WrappedAsyncMongoCollection<DBInterface extends { _id: ProtectedString<any
 		options?: FindOptions<DBInterface>
 	): Promise<Array<DBInterface>> {
 		// Make the collection fethcing in another Fiber:
-		const p = makePromise(() => {
+		return makePromise(() => {
 			return this.find(selector as any, options).fetch()
 		})
-		// Pause the current Fiber briefly, in order to allow for the other Fiber to start executing:
-		await sleep(0)
-		return p
 	}
 
 	async findOneAsync(
@@ -308,12 +304,9 @@ class WrappedAsyncMongoCollection<DBInterface extends { _id: ProtectedString<any
 	}
 
 	async insertAsync(doc: DBInterface): Promise<DBInterface['_id']> {
-		const p = makePromise(() => {
+		return makePromise(() => {
 			return this.insert(doc)
 		})
-		// Pause the current Fiber briefly, in order to allow for the other Fiber to start executing:
-		await sleep(0)
-		return p
 	}
 
 	async insertManyAsync(docs: DBInterface[]): Promise<Array<DBInterface['_id']>> {
@@ -321,7 +314,7 @@ class WrappedAsyncMongoCollection<DBInterface extends { _id: ProtectedString<any
 	}
 
 	async insertIgnoreAsync(doc: DBInterface): Promise<DBInterface['_id']> {
-		const p = makePromise(() => {
+		return makePromise(() => {
 			return this.insert(doc)
 		}).catch((err) => {
 			if (err.toString().match(/duplicate key/i)) {
@@ -330,9 +323,6 @@ class WrappedAsyncMongoCollection<DBInterface extends { _id: ProtectedString<any
 				throw err
 			}
 		})
-		// Pause the current Fiber briefly, in order to allow for the other Fiber to start executing:
-		await sleep(0)
-		return p
 	}
 
 	async updateAsync(
@@ -340,12 +330,9 @@ class WrappedAsyncMongoCollection<DBInterface extends { _id: ProtectedString<any
 		modifier: MongoModifier<DBInterface>,
 		options?: UpdateOptions
 	): Promise<number> {
-		const p = makePromise(() => {
+		return makePromise(() => {
 			return this.update(selector, modifier, options)
 		})
-		// Pause the current Fiber briefly, in order to allow for the other Fiber to start executing:
-		await sleep(0)
-		return p
 	}
 
 	async upsertAsync(
@@ -353,12 +340,9 @@ class WrappedAsyncMongoCollection<DBInterface extends { _id: ProtectedString<any
 		modifier: MongoModifier<DBInterface>,
 		options?: UpsertOptions
 	): Promise<{ numberAffected?: number; insertedId?: DBInterface['_id'] }> {
-		const p = makePromise(() => {
+		return makePromise(() => {
 			return this.upsert(selector, modifier, options)
 		})
-		// Pause the current Fiber briefly, in order to allow for the other Fiber to start executing:
-		await sleep(0)
-		return p
 	}
 
 	async upsertManyAsync(docs: DBInterface[]): Promise<{ numberAffected: number; insertedIds: DBInterface['_id'][] }> {
@@ -381,12 +365,9 @@ class WrappedAsyncMongoCollection<DBInterface extends { _id: ProtectedString<any
 	}
 
 	async removeAsync(selector: MongoQuery<DBInterface> | DBInterface['_id']): Promise<number> {
-		const p = makePromise(() => {
+		return makePromise(() => {
 			return this.remove(selector)
 		})
-		// Pause the current Fiber briefly, in order to allow for the other Fiber to start executing:
-		await sleep(0)
-		return p
 	}
 
 	async bulkWriteAsync(ops: Array<AnyBulkWriteOperation<DBInterface>>): Promise<void> {


### PR DESCRIPTION

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
If for example `collection.findFetchAsync` throws instantly (like if providing an invalid argument) `makeReady` rejects right away. Since there is a `sleep(0)` in `collection.findFetchAsync`, the promise is therefore unhandled, thus causing Core to crash.


* **What is the new behavior (if this is a feature change)?**
I've moved the sleep into `makePromise` and ensured that the resulting promise is handled from the start.


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
