### PR TITLE
Fix: packageInfo removeDelay

### DIFF
--- a/meteor/lib/collections/PackageInfos.ts
+++ b/meteor/lib/collections/PackageInfos.ts
@@ -3,6 +3,7 @@ import { registerIndex } from '../database'
 import { CollectionName } from '@sofie-automation/corelib/dist/dataModel/Collections'
 
 import { PackageInfoDB } from '@sofie-automation/corelib/dist/dataModel/PackageInfos'
+import { getCurrentTime } from '../lib'
 export * from '@sofie-automation/corelib/dist/dataModel/PackageInfos'
 
 export const PackageInfos = createMongoCollection<PackageInfoDB>(CollectionName.PackageInfos)
@@ -11,3 +12,8 @@ registerIndex(PackageInfos, {
 	studioId: 1,
 	packageId: 1,
 })
+/** Returns a list of PackageInfos which are no longer valid */
+export async function getRemovedPackageInfos(): Promise<PackageInfoDB['_id'][]> {
+	const docs = await PackageInfos.findFetchAsync({ removeTime: { $lte: getCurrentTime() } }, { fields: { _id: 1 } })
+	return docs.map((p) => p._id)
+}

--- a/meteor/server/api/cleanup.ts
+++ b/meteor/server/api/cleanup.ts
@@ -39,7 +39,7 @@ import { getActiveRundownPlaylistsInStudioFromDb } from './studio/lib'
 import { ExpectedPackages } from '../../lib/collections/ExpectedPackages'
 import { ExpectedPackageWorkStatuses } from '../../lib/collections/ExpectedPackageWorkStatuses'
 import { PackageContainerPackageStatuses } from '../../lib/collections/PackageContainerPackageStatus'
-import { PackageInfos } from '../../lib/collections/PackageInfos'
+import { getRemovedPackageInfos, PackageInfos } from '../../lib/collections/PackageInfos'
 import { Settings } from '../../lib/Settings'
 import { TriggeredActions } from '../../lib/collections/TriggeredActions'
 import { AsyncMongoCollection } from '../../lib/collections/lib'
@@ -293,6 +293,14 @@ export async function cleanupOldDataInner(actuallyCleanup: boolean = false): Pro
 	{
 		ownedByStudioId(PackageInfos)
 		ownedByDeviceId(PackageInfos)
+
+		const removedPackageInfoIds = await getRemovedPackageInfos()
+		addToResult(CollectionName.PackageInfos, removedPackageInfoIds.length)
+		if (actuallyCleanup) {
+			PackageInfos.remove({
+				_id: { $in: removedPackageInfoIds },
+			})
+		}
 	}
 	// Parts
 	{

--- a/meteor/server/cronjobs.ts
+++ b/meteor/server/cronjobs.ts
@@ -20,6 +20,7 @@ import { Parts } from '../lib/collections/Parts'
 import { PartInstances } from '../lib/collections/PartInstances'
 import { PieceInstances } from '../lib/collections/PieceInstances'
 import { deferAsync } from '@sofie-automation/corelib/dist/lib'
+import { getRemovedPackageInfos, PackageInfos } from '../lib/collections/PackageInfos'
 
 const lowPrioFcn = (fcn: () => any) => {
 	// Do it at a random time in the future:
@@ -226,6 +227,22 @@ Meteor.startup(() => {
 					}
 				)
 			}
+		}
+		{
+			// Clean up removed PackageInfos:
+			deferAsync(
+				async () => {
+					const removedPackageInfoIds = await getRemovedPackageInfos()
+					if (removedPackageInfoIds.length) {
+						PackageInfos.remove({
+							_id: { $in: removedPackageInfoIds },
+						})
+					}
+				},
+				(e) => {
+					logger.error(`Cron: Cleanup PackageInfos error: ${e}`)
+				}
+			)
 		}
 	}
 	Meteor.setInterval(anyTimeCronjob, 30 * 60 * 1000) // every 30 minutes

--- a/packages/corelib/src/dataModel/PackageInfos.ts
+++ b/packages/corelib/src/dataModel/PackageInfos.ts
@@ -1,4 +1,4 @@
-import { PackageInfo } from '@sofie-automation/blueprints-integration'
+import { PackageInfo, Time } from '@sofie-automation/blueprints-integration'
 import { protectString } from '../protectedString'
 import { ExpectedPackageDB } from './ExpectedPackages'
 import { ExpectedPackageId, PackageInfoId, PeripheralDeviceId, StudioId } from './Ids'
@@ -26,6 +26,9 @@ export interface PackageInfoDB extends PackageInfo.Base {
 
 	type: PackageInfo.Type
 	payload: any
+
+	/** If set, the package is invalid and will be removed after this time (unix timestamp) */
+	removeTime?: Time | null
 }
 
 export function getPackageInfoId(packageId: ExpectedPackageId, type: string): PackageInfoId {

--- a/packages/shared-lib/src/peripheralDevice/methodsAPI.ts
+++ b/packages/shared-lib/src/peripheralDevice/methodsAPI.ts
@@ -315,7 +315,8 @@ export interface NewPeripheralDeviceAPI {
 		deviceId: PeripheralDeviceId,
 		deviceToken: string,
 		type: string,
-		packageId: ExpectedPackageId
+		packageId: ExpectedPackageId,
+		removeDelay?: number
 	): Promise<void>
 
 	determineDiffTime(): Promise<DiffTimeResult>


### PR DESCRIPTION
This PR adds the property `removeDelay` to PackageInfo, used to delay the removal of a PackageInfo, a feature used by Package Manager.
