### PR TITLE
Use default values from config manifest if no value has been configured

### DIFF
--- a/meteor/client/lib/EditAttribute.tsx
+++ b/meteor/client/lib/EditAttribute.tsx
@@ -229,7 +229,11 @@ const EditAttributeText = wrapEditAttribute(
 			this.handleEdit(event.target.value)
 		}
 		handleBlur(event) {
-			this.handleUpdate(event.target.value)
+			let value: string = event.target.value
+			if (value) {
+				value = value.trim()
+			}
+			this.handleUpdate(value)
 		}
 		handleEscape(event) {
 			const e = event as KeyboardEvent

--- a/meteor/client/ui/Settings/components/ConfigManifestEntryComponent.tsx
+++ b/meteor/client/ui/Settings/components/ConfigManifestEntryComponent.tsx
@@ -105,6 +105,12 @@ export const ConfigManifestEntryComponent = withTranslation()(
 						{t(configField.name)}
 						{this.renderEditAttribute(configField, obj, prefix)}
 						{configField.hint && <span className="text-s dimmed">{t(configField.hint)}</span>}
+						{configField.hint && configField && <span className="text-s dimmed"> - </span>}
+						{configField.defaultVal && (
+							<span className="text-s dimmed">
+								{t("Defaults to '{{defaultVal}}' if left empty", { defaultVal: configField.defaultVal })}
+							</span>
+						)}
 					</label>
 				</div>
 			)

--- a/packages/playout-gateway/src/configManifest.ts
+++ b/packages/playout-gateway/src/configManifest.ts
@@ -376,6 +376,7 @@ const PLAYOUT_SUBDEVICE_CONFIG: ImplementedSubDeviceConfig = {
 			id: 'options.playlistID',
 			name: '(Optional) Playlist ID',
 			type: ConfigManifestEntryType.STRING,
+			defaultVal: 'SOFIE',
 		},
 		{
 			id: 'options.preloadAllElements',


### PR DESCRIPTION

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug/Missing feature


* **What is the current behavior?** (You can also link to an open issue here)
In the config manifest there is an option to specify a default value for each configuration entry. This default value seems not to be used.


* **What is the new behavior (if this is a feature change)?**
When sending device options to each TSR device the default value from the config manifest will now be applied if there hasn't been configured any value. 
The configuration field in the UI displays a text "Defaults to '{defaultValue}' if left empty" if there is a default value specified in the config manifest.
The EditAttributeText now trims its value so strings like " " is no longer possible.


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
