### PR TITLE
fix: in the event of multiple tags they should all have the correct name

### DIFF
--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -107,13 +107,25 @@ jobs:
         run: |
           echo "Enable build and push: ${{ env.SECRET_ACCESS != '' }}"
           echo "enable=${{ env.SECRET_ACCESS != '' }}" >> $GITHUB_OUTPUT
-      - name: Get the Docker tag
-        id: docker-tag
+      - name: Get the Docker tag for GHCR
+        id: ghcr-tag
         if: steps.check-build-and-push.outputs.enable == 'true'
         uses: docker/metadata-action@v4
         with:
           images: |
-            server-core
+            ghcr.io/${{ github.repository }}/server-core
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag
+            type=raw,value=latest,enable={{is_default_branch}}
+      - name: Get the Docker tag for DockerHub
+        id: dockerhub-tag
+        if: steps.check-build-and-push.outputs.enable == 'true'
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ secrets.DOCKERHUB_IMAGE_PREFIX }}server-core
           tags: |
             type=schedule
             type=ref,event=branch
@@ -172,8 +184,8 @@ jobs:
           context: .
           file: ./meteor/Dockerfile.circle
           push: true
-          labels: ${{ steps.docker-tag.outputs.labels }}
-          tags: "ghcr.io/${{ github.repository }}/${{ steps.docker-tag.outputs.tags }}"
+          labels: ${{ steps.ghcr-tag.outputs.labels }}
+          tags: "${{ steps.ghcr-tag.outputs.tags }}"
       - name: Build and push to DockerHub
         if: steps.check-build-and-push.outputs.enable == 'true' && steps.dockerhub.outputs.dockerhub-publish == '1'
         uses: docker/build-push-action@v3
@@ -181,8 +193,8 @@ jobs:
           context: .
           file: ./meteor/Dockerfile.circle
           push: true
-          labels: ${{ steps.docker-tag.outputs.labels }}
-          tags: "${{ secrets.DOCKERHUB_IMAGE_PREFIX }}${{ steps.docker-tag.outputs.tags }}"
+          labels: ${{ steps.dockerhub-tag.outputs.labels }}
+          tags: "${{ steps.dockerhub-tag.outputs.tags }}"
 
   build-gateways:
     # TODO - should this be dependant on tests or something passing if we are on a tag?
@@ -225,13 +237,25 @@ jobs:
         run: |
           echo "Enable build and push: ${{ env.SECRET_ACCESS != '' }}"
           echo "enable=${{ env.SECRET_ACCESS != '' }}" >> $GITHUB_OUTPUT
-      - name: Get the Docker tag
-        id: docker-tag
+      - name: Get the Docker tag for GHCR
+        id: ghcr-tag
         if: steps.check-build-and-push.outputs.enable == 'true'
         uses: docker/metadata-action@v4
         with:
           images: |
-            ${{ matrix.gateway-name }}
+            ghcr.io/${{ github.repository }}/${{ matrix.gateway-name }}
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag
+            type=raw,value=latest,enable={{is_default_branch}}
+      - name: Get the Docker tag for DockerHub
+        id: dockerhub-tag
+        if: steps.check-build-and-push.outputs.enable == 'true'
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ secrets.DOCKERHUB_IMAGE_PREFIX }}${{ matrix.gateway-name }}
           tags: |
             type=schedule
             type=ref,event=branch
@@ -272,8 +296,8 @@ jobs:
           context: ./packages
           file: ./packages/${{ matrix.gateway-name }}/Dockerfile.circle
           push: true
-          labels: ${{ steps.docker-tag.outputs.labels }}
-          tags: "ghcr.io/${{ github.repository }}/${{ steps.docker-tag.outputs.tags }}"
+          labels: ${{ steps.ghcr-tag.outputs.labels }}
+          tags: "${{ steps.ghcr-tag.outputs.tags }}"
       - name: Build and push to DockerHub
         if: steps.check-build-and-push.outputs.enable == 'true' && steps.dockerhub.outputs.dockerhub-publish == '1'
         uses: docker/build-push-action@v3
@@ -281,8 +305,8 @@ jobs:
           context: ./packages
           file: ./packages/${{ matrix.gateway-name }}/Dockerfile.circle
           push: true
-          labels: ${{ steps.docker-tag.outputs.labels }}
-          tags: "${{ secrets.DOCKERHUB_IMAGE_PREFIX }}${{ steps.docker-tag.outputs.tags }}"
+          labels: ${{ steps.dockerhub-tag.outputs.labels }}
+          tags: "${{ steps.dockerhub-tag.outputs.tags }}"
 
   lint-packages:
     name: Lint Package


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes the issue where if there are multiple tags, only the first image name is "fully qualified" and can be pushed to the correct repository.

* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
