### PR TITLE
fix: Removed clip filename and path from notification and hover pop-u…

### DIFF
--- a/meteor/lib/mediaObjects.ts
+++ b/meteor/lib/mediaObjects.ts
@@ -522,10 +522,7 @@ function checkPieceContentExpectedPackageStatus(
 					messages.push({
 						status: PieceStatusCode.SOURCE_MISSING,
 						message: generateTranslation(
-							`Clip "{{fileName}}" can't be played because it doesn't exist on the playout system`,
-							{
-								fileName: packageName,
-							}
+							`Clip can't be played because it doesn't exist on the playout system`,
 						),
 					})
 				} else if (

--- a/meteor/lib/mediaObjects.ts
+++ b/meteor/lib/mediaObjects.ts
@@ -521,9 +521,7 @@ function checkPieceContentExpectedPackageStatus(
 				) {
 					messages.push({
 						status: PieceStatusCode.SOURCE_MISSING,
-						message: generateTranslation(
-							`Clip can't be played because it doesn't exist on the playout system`,
-						),
+						message: generateTranslation(`Clip can't be played because it doesn't exist on the playout system`),
 					})
 				} else if (
 					packageOnPackageContainer.status.status ===

--- a/meteor/public/locales/nb/translations.json
+++ b/meteor/public/locales/nb/translations.json
@@ -932,7 +932,7 @@
     "Next Action": "Neste handling",
     "Run in": "Kjør i",
     "Stop": "Stopp",
-    "Clip \"{{fileName}}\" can't be played because it doesn't exist on the playout system": "Klippet \"{{fileName}}\" kan ikke spilles av fordi det ikke finnes på utspillingssystemet",
+    "Clip can't be played because it doesn't exist on the playout system": "Klippet kan ikke spilles av, det finnes ikke på utspillingssystemet",
     "{{sourceLayer}} is not yet ready on the playout system": "{{sourceLayer}} er ennå ikke klar til å spilles ut fra avviklingsserver",
     "{{sourceLayer}} is transferring to the the playout system": "{{sourceLayer}} overføres til avviklingsserver",
     "{{sourceLayer}} is transferring to the the playout system and cannot be played yet": "{{sourceLayer}} overføres til avviklingsserver og kan ikke spilles av ennå",

--- a/meteor/public/locales/nn/translations.json
+++ b/meteor/public/locales/nn/translations.json
@@ -931,7 +931,7 @@
     "Next Action": "Neste handling",
     "Run in": "Køyr i",
     "Stop": "Stopp",
-    "Clip \"{{fileName}}\" can't be played because it doesn't exist on the playout system": "Klippet \"{{fileName}}\" kan ikkje spelast av fordi det ikkje finnast på utspelingssystemet",
+    "Clip can't be played because it doesn't exist on the playout system": "Klippet kan ikkje spelast av, det finnast ikkje på utspelingssystemet",
     "{{sourceLayer}} is not yet ready on the playout system": "{{sourceLayer}} er enno ikkje klar til å spelast ut fra avviklingsserver",
     "{{sourceLayer}} is transferring to the the playout system": "{{sourceLayer}} overførast til avviklingsserver",
     "{{sourceLayer}} is transferring to the the playout system and cannot be played yet": "{{sourceLayer}} overførast til avviklingsserver og kan ikkje spelast av enno",


### PR DESCRIPTION
…p, since it was superfluous. Updated translations for nb and nn.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
The clip name and path was displayed multiple times in the hover pop-ups.


* **What is the new behavior (if this is a feature change)?**
Removed the clip name, it is still visible in another place in the same pop-up.


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
