### PR TITLE
fix(EditAtribute): Number(0) isn't shown, because it's replaced with String("")

### DIFF
--- a/meteor/client/lib/EditAttribute.tsx
+++ b/meteor/client/lib/EditAttribute.tsx
@@ -244,7 +244,7 @@ const EditAttributeText = wrapEditAttribute(
 					disabled={this.props.disabled}
 					placeholder={this.props.label}
 					updateOnKey={this.props.updateOnKey}
-					value={this.getAttribute() || ''}
+					value={this.getAttribute() ?? ''}
 					handleUpdate={this.handleChange}
 				/>
 			)
@@ -294,7 +294,7 @@ const EditAttributeInt = wrapEditAttribute(
 					disabled={this.props.disabled}
 					placeholder={this.props.label}
 					updateOnKey={this.props.updateOnKey}
-					value={this.getAttribute() || ''}
+					value={this.getAttribute() ?? ''}
 					handleUpdate={this.handleChange}
 				/>
 			)
@@ -319,7 +319,7 @@ const EditAttributeFloat = wrapEditAttribute(
 					disabled={this.props.disabled}
 					placeholder={this.props.label}
 					updateOnKey={this.props.updateOnKey}
-					value={this.getAttribute() || ''}
+					value={this.getAttribute() ?? ''}
 					handleUpdate={this.handleChange}
 				/>
 			)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

It's impossible to see the value `0`, since it's being replaced by `""`.

* **What is the new behavior (if this is a feature change)?**

Instead of using `||` as fallback, the Int and Float inputs use a `??` operator, which allows the `0` value to show.

* **Other information**:

(cherry picked from commit 6616b7be6586654b8c9a913682f1b372cbbabd0c)

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
