### PR TITLE
fix: refactor playout-gateway types into shared-lib

### DIFF
--- a/meteor/__mocks__/helpers/database.ts
+++ b/meteor/__mocks__/helpers/database.ts
@@ -85,6 +85,7 @@ import {
 	ShowStyleBaseId,
 	ShowStyleVariantId,
 } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { TSR_VERSION } from '@sofie-automation/shared-lib/dist/tsr'
 
 export enum LAYER_IDS {
 	SOURCE_CAM0 = 'cam0',
@@ -97,15 +98,6 @@ export enum LAYER_IDS {
 function getBlueprintDependencyVersions(): { TSR_VERSION: string; INTEGRATION_VERSION: string } {
 	const INTEGRATION_VERSION =
 		require('../../node_modules/@sofie-automation/blueprints-integration/package.json').version
-
-	let TSR_VERSION = ''
-	try {
-		// eslint-disable-next-line node/no-missing-require
-		TSR_VERSION = require('../../node_modules/timeline-state-resolver-types/package.json').version
-	} catch (e) {
-		TSR_VERSION =
-			require('../../node_modules/@sofie-automation/blueprints-integration/node_modules/timeline-state-resolver-types/package.json').version
-	}
 
 	return {
 		INTEGRATION_VERSION,

--- a/meteor/lib/collections/Studios.ts
+++ b/meteor/lib/collections/Studios.ts
@@ -5,20 +5,19 @@ import { Meteor } from 'meteor/meteor'
 import { ObserveChangesForHash, createMongoCollection } from './lib'
 import { registerIndex } from '../database'
 import { ExpectedPackageDB } from './ExpectedPackages'
-import { StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { CollectionName } from '@sofie-automation/corelib/dist/dataModel/Collections'
 
 import {
 	ResultingMappingRoutes,
 	DBStudio,
 	MappingExt,
-	MappingsHash,
 	StudioRouteType,
 	MappingsExt,
 	StudioRouteSet,
 } from '@sofie-automation/corelib/dist/dataModel/Studio'
 import { ReadonlyDeep } from 'type-fest'
 export * from '@sofie-automation/corelib/dist/dataModel/Studio'
+export { RoutedMappings } from '@sofie-automation/shared-lib/dist/core/model/Timeline'
 
 export function getActiveRoutes(routeSets: ReadonlyDeep<Record<string, StudioRouteSet>>): ResultingMappingRoutes {
 	const routes: ResultingMappingRoutes = {
@@ -137,12 +136,6 @@ export function routeExpectedPackages(
 	// Route the mappings
 	const routes = getActiveRoutes(studio.routeSets)
 	return getRoutedMappings(mappingsWithPackages, routes)
-}
-
-export interface RoutedMappings {
-	_id: StudioId
-	mappingsHash: MappingsHash | undefined
-	mappings: MappingsExt
 }
 
 export type Studio = DBStudio

--- a/meteor/lib/collections/Timeline.ts
+++ b/meteor/lib/collections/Timeline.ts
@@ -1,15 +1,14 @@
 import { createMongoCollection } from './lib'
-import { DBStudio, ResultingMappingRoutes } from './Studios'
-import { StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { ResultingMappingRoutes } from './Studios'
 import { CollectionName } from '@sofie-automation/corelib/dist/dataModel/Collections'
 
 import {
 	TimelineComplete,
 	TimelineObjGeneric,
 	updateLookaheadLayer,
-	TimelineBlob,
 } from '@sofie-automation/corelib/dist/dataModel/Timeline'
 export * from '@sofie-automation/corelib/dist/dataModel/Timeline'
+export { RoutedTimeline } from '@sofie-automation/shared-lib/dist/core/model/Timeline'
 
 export function getRoutedTimeline(
 	inputTimelineObjs: TimelineObjGeneric[],
@@ -54,20 +53,6 @@ export function getRoutedTimeline(
 		}
 	}
 	return outputTimelineObjs
-}
-
-/** This is the data-object published from Core */
-export interface RoutedTimeline {
-	_id: StudioId
-	/** Hash of the studio mappings */
-	mappingsHash: DBStudio['mappingsHash']
-
-	/** Hash of the Timeline */
-	timelineHash: TimelineComplete['timelineHash']
-
-	/** serialized JSON Array containing all timeline-objects */
-	timelineBlob: TimelineBlob
-	generated: TimelineComplete['generated']
 }
 
 export const Timeline = createMongoCollection<TimelineComplete>(CollectionName.Timelines)

--- a/packages/blueprints-integration/package.json
+++ b/packages/blueprints-integration/package.json
@@ -39,7 +39,6 @@
 	],
 	"dependencies": {
 		"@sofie-automation/shared-lib": "link:../shared-lib",
-		"timeline-state-resolver-types": "8.0.0-release48.0",
 		"tslib": "^2.4.0",
 		"type-fest": "^2.19.0"
 	},

--- a/packages/blueprints-integration/src/api.ts
+++ b/packages/blueprints-integration/src/api.ts
@@ -1,5 +1,3 @@
-import { TSRTimelineContent, TSRTimelineObj } from 'timeline-state-resolver-types'
-
 import { ActionUserData, IBlueprintActionManifest } from './action'
 import { ConfigManifestEntry } from './config'
 import {
@@ -37,7 +35,7 @@ import {
 	ExpectedPlayoutItemGeneric,
 } from './rundown'
 import { IBlueprintShowStyleBase, IBlueprintShowStyleVariant, IOutputLayer, ISourceLayer } from './showStyle'
-import { OnGenerateTimelineObj } from './timeline'
+import { TSR, OnGenerateTimelineObj } from './timeline'
 import { IBlueprintConfig } from './common'
 import { ExpectedPackage } from './package'
 import { ReadonlyDeep } from 'type-fest'
@@ -252,7 +250,7 @@ export interface ShowStyleBlueprintManifest<TRawConfig = IBlueprintConfig, TProc
 	/** Called after the timeline has been generated, used to manipulate the timeline */
 	onTimelineGenerate?: (
 		context: ITimelineEventContext,
-		timeline: OnGenerateTimelineObj<TSRTimelineContent>[],
+		timeline: OnGenerateTimelineObj<TSR.TSRTimelineContent>[],
 		previousPersistentState: TimelinePersistentState | undefined,
 		previousPartEndState: PartEndState | undefined,
 		resolvedPieces: IBlueprintResolvedPieceInstance[]
@@ -283,11 +281,11 @@ export type PartEndState = unknown
 export type TimelinePersistentState = unknown
 
 export interface BlueprintResultTimeline {
-	timeline: OnGenerateTimelineObj<TSRTimelineContent>[]
+	timeline: OnGenerateTimelineObj<TSR.TSRTimelineContent>[]
 	persistentState: TimelinePersistentState
 }
 export interface BlueprintResultBaseline {
-	timelineObjects: TSRTimelineObj<TSRTimelineContent>[]
+	timelineObjects: TSR.TSRTimelineObj<TSR.TSRTimelineContent>[]
 	/** @deprecated */
 	expectedPlayoutItems?: ExpectedPlayoutItemGeneric[]
 	expectedPackages?: ExpectedPackage.Any[]

--- a/packages/blueprints-integration/src/config.ts
+++ b/packages/blueprints-integration/src/config.ts
@@ -1,6 +1,6 @@
-import { DeviceType } from 'timeline-state-resolver-types'
 import { BasicConfigItemValue } from './common'
 import { SourceLayerType } from './content'
+import { TSR } from './timeline'
 
 export enum ConfigManifestEntryType {
 	STRING = 'string',
@@ -112,6 +112,6 @@ export interface ConfigManifestEntryLayerMappings<Multiple extends boolean>
 	extends ConfigManifestEntrySelectBase<Multiple> {
 	type: ConfigManifestEntryType.LAYER_MAPPINGS
 	filters?: {
-		deviceTypes?: DeviceType[]
+		deviceTypes?: TSR.DeviceType[]
 	}
 }

--- a/packages/blueprints-integration/src/content.ts
+++ b/packages/blueprints-integration/src/content.ts
@@ -1,6 +1,5 @@
-import { TSRTimelineContent } from 'timeline-state-resolver-types'
 import { Time } from './common'
-import { TimelineObjectCoreExt } from './timeline'
+import { TSR, TimelineObjectCoreExt } from './timeline'
 
 /** The type of the source layer, used to enable specific functions for special-type layers */
 export enum SourceLayerType {
@@ -31,7 +30,7 @@ export enum SourceLayerType {
 }
 
 export type WithTimeline<T extends BaseContent> = T & {
-	timelineObjects: TimelineObjectCoreExt<TSRTimelineContent>[]
+	timelineObjects: TimelineObjectCoreExt<TSR.TSRTimelineContent>[]
 }
 
 export interface BaseContent {

--- a/packages/blueprints-integration/src/context.ts
+++ b/packages/blueprints-integration/src/context.ts
@@ -1,4 +1,3 @@
-import { TSRTimelineContent } from 'timeline-state-resolver-types'
 import { DatastorePersistenceMode, Time } from './common'
 import { IBlueprintExternalMessageQueueObj } from './message'
 import { PackageInfo } from './packageInfo'
@@ -15,7 +14,7 @@ import {
 	IBlueprintSegmentRundown,
 } from './rundown'
 import { BlueprintMappings } from './studio'
-import { OnGenerateTimelineObj } from './timeline'
+import { TSR, OnGenerateTimelineObj } from './timeline'
 
 /** Common */
 
@@ -290,7 +289,7 @@ export interface ITimelineEventContext extends IEventContext, IRundownContext {
 	 * sessionName should also be used in calls to getPieceABSessionId for the owning piece
 	 */
 	getTimelineObjectAbSessionId(
-		obj: OnGenerateTimelineObj<TSRTimelineContent, any, any>,
+		obj: OnGenerateTimelineObj<TSR.TSRTimelineContent, any, any>,
 		sessionName: string
 	): string | undefined
 }

--- a/packages/blueprints-integration/src/migrations.ts
+++ b/packages/blueprints-integration/src/migrations.ts
@@ -1,9 +1,9 @@
-import { DeviceOptionsAny } from 'timeline-state-resolver-types'
 import { ConfigItemValue } from './common'
 import { OmitId } from './lib'
 import { IBlueprintShowStyleVariant, IOutputLayer, ISourceLayer } from './showStyle'
 import { IBlueprintTriggeredActions } from './triggers'
 import { BlueprintMapping } from './studio'
+import { TSR } from './timeline'
 
 export interface MigrationStepInput {
 	stepId?: string // automatically filled in later
@@ -65,9 +65,9 @@ export interface MigrationContextStudio {
 	setConfig: (configId: string, value: ConfigItemValue) => void
 	removeConfig: (configId: string) => void
 
-	getDevice: (deviceId: string) => DeviceOptionsAny | undefined
-	insertDevice: (deviceId: string, device: DeviceOptionsAny) => string | null
-	updateDevice: (deviceId: string, device: Partial<DeviceOptionsAny>) => void
+	getDevice: (deviceId: string) => TSR.DeviceOptionsAny | undefined
+	insertDevice: (deviceId: string, device: TSR.DeviceOptionsAny) => string | null
+	updateDevice: (deviceId: string, device: Partial<TSR.DeviceOptionsAny>) => void
 	removeDevice: (deviceId: string) => void
 }
 

--- a/packages/blueprints-integration/src/rundown.ts
+++ b/packages/blueprints-integration/src/rundown.ts
@@ -1,10 +1,10 @@
-import { DeviceType as TSR_DeviceType, ExpectedPlayoutItemContent } from 'timeline-state-resolver-types'
 import { ActionUserData } from './action'
 import { PartEndState } from './api'
 import { Time } from './common'
 import { SomeContent, WithTimeline } from './content'
 import { NoteSeverity } from './lib'
 import { ExpectedPackage } from './package'
+import { TSR } from './timeline'
 import { ITranslatableMessage } from './translations'
 
 /** Playlist, as generated from Blueprints */
@@ -446,12 +446,14 @@ export interface IBlueprintPieceGeneric<TMetadata = unknown> {
 /** @deprecated */
 export interface ExpectedPlayoutItemGeneric {
 	/** What type of playout device this item should be handled by */
-	deviceSubType: TSR_DeviceType // subset of PeripheralDeviceAPI.DeviceSubType
+	deviceSubType: TSR.DeviceType // subset of PeripheralDeviceAPI.DeviceSubType
 	/** Which playout device this item should be handled by */
 	// deviceId: string // Todo: implement deviceId support (later)
 	/** Content of the expectedPlayoutItem */
-	content: ExpectedPlayoutItemContent
+	content: TSR.ExpectedPlayoutItemContent
 }
+
+type ExpectedPlayoutItemContent = TSR.ExpectedPlayoutItemContent
 export { ExpectedPlayoutItemContent }
 
 /** Special types of pieces. Some are not always used in all circumstances */

--- a/packages/blueprints-integration/src/studio.ts
+++ b/packages/blueprints-integration/src/studio.ts
@@ -1,20 +1,5 @@
-import { Mapping, Mappings } from 'timeline-state-resolver-types'
-
-export enum LookaheadMode {
-	NONE = 0,
-	PRELOAD = 1,
-	// RETAIN = 2, // Removed due to complexity and it being possible to emulate with WHEN_CLEAR and infinites
-	WHEN_CLEAR = 3,
-}
-
-export interface BlueprintMappings extends Mappings {
-	[layerName: string]: BlueprintMapping
-}
-export interface BlueprintMapping extends Mapping {
-	/** What method core should use to create lookahead objects for this layer */
-	lookahead: LookaheadMode
-	/** How many lookahead objects to create for this layer. Default = 1 */
-	lookaheadDepth?: number
-	/** Maximum distance to search for lookahead. Default = 10 */
-	lookaheadMaxSearchDistance?: number
-}
+export {
+	LookaheadMode,
+	BlueprintMappings,
+	BlueprintMapping,
+} from '@sofie-automation/shared-lib/dist/core/model/Timeline'

--- a/packages/blueprints-integration/src/timeline.ts
+++ b/packages/blueprints-integration/src/timeline.ts
@@ -1,42 +1,19 @@
-import * as TSR from 'timeline-state-resolver-types'
+import { TimelineObjectCoreExt } from '@sofie-automation/shared-lib/dist/core/model/Timeline'
+import { TSR } from '@sofie-automation/shared-lib/dist/tsr'
+
 export { TSR }
 
-export { Timeline } from 'timeline-state-resolver-types'
+export {
+	TimelineObjHoldMode,
+	TimelineObjectCoreExt,
+	TimelineKeyframeCoreExt,
+} from '@sofie-automation/shared-lib/dist/core/model/Timeline'
 
 export enum TimelineObjClassesCore {
 	RundownRehearsal = 'rundown_rehersal',
 	RundownActive = 'rundown_active',
 	BeforeFirstPart = 'before_first_part',
 	NoNextPart = 'last_part',
-}
-
-export enum TimelineObjHoldMode {
-	/** Default: The object is played as usual (behaviour is not affected by Hold)  */
-	NORMAL = 0,
-	/** The object is played ONLY when doing a Hold */
-	ONLY = 1,
-	/** The object is played when NOT doing a Hold */
-	EXCEPT = 2,
-}
-
-export interface TimelineObjectCoreExt<
-	TContent extends { deviceType: TSR.DeviceType },
-	TMetadata = unknown,
-	TKeyframeMetadata = unknown
-> extends TSR.TSRTimelineObj<TContent> {
-	/** Restrict object usage according to whether we are currently in a hold */
-	holdMode?: TimelineObjHoldMode
-	/** Arbitrary data storage for plugins */
-	metaData?: TMetadata
-	/** Keyframes: Arbitrary data storage for plugins */
-	keyframes?: Array<TimelineKeyframeCoreExt<TContent, TKeyframeMetadata>>
-}
-
-export interface TimelineKeyframeCoreExt<TContent extends { deviceType: TSR.DeviceType }, TKeyframeMetadata = unknown>
-	extends TSR.Timeline.TimelineKeyframe<TContent> {
-	metaData?: TKeyframeMetadata
-	/** Whether to keep this keyframe when the object is copied for lookahead. By default all keyframes are removed */
-	preserveForLookahead?: boolean
 }
 
 /** TimelineObject extension for additional fields needed by onTimelineGenerate */

--- a/packages/blueprints-integration/src/util.ts
+++ b/packages/blueprints-integration/src/util.ts
@@ -1,8 +1,8 @@
 // tslint:disable-next-line:no-submodule-imports
-import * as tsrPkgInfo from 'timeline-state-resolver-types/package.json'
+import { TSR_VERSION } from '@sofie-automation/shared-lib/dist/tsr'
 
 /** @deprecated This is temporary and should be removed ASAP. Can we do it better? */
-export const TMP_TSR_VERSION: string = tsrPkgInfo.version
+export const TMP_TSR_VERSION: string = TSR_VERSION
 
 export enum iterateDeeplyEnum {
 	CONTINUE = '$continue',

--- a/packages/corelib/src/dataModel/Studio.ts
+++ b/packages/corelib/src/dataModel/Studio.ts
@@ -1,15 +1,10 @@
 import { BlueprintMapping, IBlueprintConfig, PackageContainer, TSR } from '@sofie-automation/blueprints-integration'
 import { ObjectWithOverrides } from '../settings/objectWithOverrides'
-import { ProtectedString } from '../protectedString'
-import { StudioId, OrganizationId, BlueprintId, ShowStyleBaseId, PeripheralDeviceId } from './Ids'
+import { StudioId, OrganizationId, BlueprintId, ShowStyleBaseId, MappingsHash } from './Ids'
 import { LastBlueprintConfig } from './Blueprint'
+import { MappingsExt, MappingExt } from '@sofie-automation/shared-lib/dist/core/model/Timeline'
 
-export interface MappingsExt {
-	[layerName: string]: MappingExt
-}
-export interface MappingExt extends Omit<BlueprintMapping, 'deviceId'> {
-	deviceId: PeripheralDeviceId
-}
+export { MappingsExt, MappingExt, MappingsHash }
 
 export interface IStudioSettings {
 	/** The framerate (frames per second) used to convert internal timing information (in milliseconds)
@@ -49,7 +44,6 @@ export interface IStudioSettings {
 	/** Preserve unsynced segments psoition in the rundown, relative to the other segments */
 	preserveOrphanedSegmentPositionInRundown?: boolean
 }
-export type MappingsHash = ProtectedString<'MappingsHash'>
 
 export type StudioLight = Omit<DBStudio, 'mappingsWithOverrides' | 'blueprintConfigWithOverrides'>
 

--- a/packages/corelib/src/dataModel/Timeline.ts
+++ b/packages/corelib/src/dataModel/Timeline.ts
@@ -1,4 +1,5 @@
-import { TSR, OnGenerateTimelineObj, TimelineObjectCoreExt, Time } from '@sofie-automation/blueprints-integration'
+import { TSR, OnGenerateTimelineObj, Time } from '@sofie-automation/blueprints-integration'
+import { TimelineObjGeneric, TimelineObjType } from '@sofie-automation/shared-lib/dist/core/model/Timeline'
 import { SetRequired } from 'type-fest'
 import { ProtectedString, protectString, unprotectString } from '../protectedString'
 import { PartInstanceId, PieceInstanceInfiniteId, BlueprintId, StudioId } from './Ids'
@@ -17,6 +18,8 @@ import {
 } from '@sofie-automation/shared-lib/dist/peripheralDevice/peripheralDeviceAPI'
 export { PartPlaybackCallbackData, PiecePlaybackCallbackData }
 
+export { TimelineObjGeneric, TimelineObjType }
+
 export type TimelineEnableExt = TSR.Timeline.TimelineEnable & { setFromNow?: boolean }
 
 export interface OnGenerateTimelineObjExt<TMetadata = unknown, TKeyframeMetadata = unknown>
@@ -27,24 +30,6 @@ export interface OnGenerateTimelineObjExt<TMetadata = unknown, TKeyframeMetadata
 	infinitePieceInstanceId?: PieceInstanceInfiniteId
 }
 
-export interface TimelineObjGeneric extends TimelineObjectCoreExt<TSR.TSRTimelineContent> {
-	/** Unique within a timeline (ie within a studio) */
-	id: string
-	/** Set when the id of the object is prefixed */
-	originalId?: string
-
-	objectType: TimelineObjType
-
-	enable: TimelineEnableExt | TimelineEnableExt[]
-
-	/** The id of the group object this object is in  */
-	inGroup?: string
-}
-
-export enum TimelineObjType {
-	/** Objects played in a rundown */
-	RUNDOWN = 'rundown',
-}
 export interface TimelineObjRundown extends TimelineObjGeneric {
 	objectType: TimelineObjType.RUNDOWN
 }

--- a/packages/corelib/src/dataModel/Timeline.ts
+++ b/packages/corelib/src/dataModel/Timeline.ts
@@ -1,16 +1,12 @@
 import { TSR, OnGenerateTimelineObj, Time } from '@sofie-automation/blueprints-integration'
 import { TimelineObjGeneric, TimelineObjType } from '@sofie-automation/shared-lib/dist/core/model/Timeline'
 import { SetRequired } from 'type-fest'
-import { ProtectedString, protectString, unprotectString } from '../protectedString'
 import { PartInstanceId, PieceInstanceInfiniteId, BlueprintId, StudioId } from './Ids'
+import { TimelineEnableExt } from '@sofie-automation/shared-lib/dist/core/model/Timeline'
 
-export enum TimelineContentTypeOther {
-	NOTHING = 'nothing',
-	GROUP = 'group',
-}
-
-import { TimelineHash } from '@sofie-automation/shared-lib/dist/core/model/Ids'
-export { TimelineHash }
+export { deserializeTimelineBlob, serializeTimelineBlob } from '@sofie-automation/shared-lib/dist/core/model/Timeline'
+import { TimelineHash, TimelineBlob } from '@sofie-automation/shared-lib/dist/core/model/Ids'
+export { TimelineHash, TimelineBlob }
 import {
 	PartPlaybackCallbackData,
 	PiecePlaybackCallbackData,
@@ -18,9 +14,12 @@ import {
 } from '@sofie-automation/shared-lib/dist/peripheralDevice/peripheralDeviceAPI'
 export { PartPlaybackCallbackData, PiecePlaybackCallbackData }
 
-export { TimelineObjGeneric, TimelineObjType }
+export { TimelineObjGeneric, TimelineObjType, TimelineEnableExt }
 
-export type TimelineEnableExt = TSR.Timeline.TimelineEnable & { setFromNow?: boolean }
+export enum TimelineContentTypeOther {
+	NOTHING = 'nothing',
+	GROUP = 'group',
+}
 
 export interface OnGenerateTimelineObjExt<TMetadata = unknown, TKeyframeMetadata = unknown>
 	extends SetRequired<OnGenerateTimelineObj<TSR.TSRTimelineContent, TMetadata, TKeyframeMetadata>, 'metaData'> {
@@ -96,13 +95,4 @@ export interface TimelineComplete {
 	timelineBlob: TimelineBlob
 	/** Version numbers of sofie at the time the timeline was generated */
 	generationVersions: TimelineCompleteGenerationVersions
-}
-
-export type TimelineBlob = ProtectedString<'TimelineBlob'>
-
-export function deserializeTimelineBlob(timelineBlob: TimelineBlob): TimelineObjGeneric[] {
-	return JSON.parse(unprotectString(timelineBlob)) as Array<TimelineObjGeneric>
-}
-export function serializeTimelineBlob(timeline: TimelineObjGeneric[]): TimelineBlob {
-	return protectString(JSON.stringify(timeline))
 }

--- a/packages/job-worker/package.json
+++ b/packages/job-worker/package.json
@@ -55,7 +55,7 @@
 		"superfly-timeline": "^8.3.1",
 		"threadedclass": "^1.1.2",
 		"tslib": "^2.4.0",
-		"type-fest": "^2.19.0",
+		"type-fest": "^3.1.0",
 		"underscore": "^1.13.4",
 		"vm2": "^3.9.11"
 	},

--- a/packages/job-worker/package.json
+++ b/packages/job-worker/package.json
@@ -55,7 +55,7 @@
 		"superfly-timeline": "^8.3.1",
 		"threadedclass": "^1.1.2",
 		"tslib": "^2.4.0",
-		"type-fest": "^3.1.0",
+		"type-fest": "^2.19.0",
 		"underscore": "^1.13.4",
 		"vm2": "^3.9.11"
 	},

--- a/packages/job-worker/src/playout/lookahead/findObjects.ts
+++ b/packages/job-worker/src/playout/lookahead/findObjects.ts
@@ -1,9 +1,4 @@
-import {
-	IBlueprintPieceType,
-	Timeline as TimelineTypes,
-	TimelineObjectCoreExt,
-	TSR,
-} from '@sofie-automation/blueprints-integration'
+import { IBlueprintPieceType, TimelineObjectCoreExt, TSR } from '@sofie-automation/blueprints-integration'
 import { PartInstanceId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { DBPart } from '@sofie-automation/corelib/dist/dataModel/Part'
 import { literal } from '@sofie-automation/corelib/dist/lib'
@@ -34,7 +29,7 @@ function tryActivateKeyframesForObject(
 ): TSR.TSRTimelineContent {
 	// Try and find a keyframe that is used when in a transition
 	if (hasTransition) {
-		let transitionKF: TimelineTypes.TimelineKeyframe | undefined
+		let transitionKF: TSR.Timeline.TimelineKeyframe | undefined
 		if (obj.keyframes) {
 			transitionKF = obj.keyframes.find((kf) => !Array.isArray(kf.enable) && kf.enable.while === '.is_transition')
 

--- a/packages/job-worker/src/playout/lookahead/index.ts
+++ b/packages/job-worker/src/playout/lookahead/index.ts
@@ -3,11 +3,7 @@ import { findLookaheadForLayer, LookaheadResult } from './findForLayer'
 import { CacheForPlayout, getRundownIDsFromCache } from '../cache'
 import { sortPieceInstancesByStart } from '../pieces'
 import { MappingExt } from '@sofie-automation/corelib/dist/dataModel/Studio'
-import {
-	Timeline as TimelineTypes,
-	LookaheadMode,
-	OnGenerateTimelineObj,
-} from '@sofie-automation/blueprints-integration'
+import { TSR, LookaheadMode, OnGenerateTimelineObj } from '@sofie-automation/blueprints-integration'
 import { SelectedPartInstancesTimelineInfo, SelectedPartInstanceTimelineInfo } from '../timeline/generate'
 import {
 	OnGenerateTimelineObjExt,
@@ -180,7 +176,7 @@ const getStartOfObjectRef = (obj: TimelineObjRundown & OnGenerateTimelineObj<any
 	`#${prefixSingleObjectId(obj, obj.pieceInstanceId ?? '')}.start`
 const calculateStartAfterPreviousObj = (
 	prevObj: TimelineObjRundown & OnGenerateTimelineObj<any>
-): TimelineTypes.TimelineEnable => {
+): TSR.Timeline.TimelineEnable => {
 	const prevHasDelayFlag = (prevObj.classes || []).indexOf('_lookahead_start_delay') !== -1
 
 	// Start with previous piece
@@ -226,7 +222,7 @@ function processResult(lookaheadObjs: LookaheadResult, mode: ValidLookaheadMode)
 
 	// Add the objects that have some timing info
 	lookaheadObjs.timed.forEach((obj, i) => {
-		let enable: TimelineTypes.TimelineEnable = {
+		let enable: TSR.Timeline.TimelineEnable = {
 			start: 1, // Absolute 0 without a group doesnt work
 		}
 		if (i !== 0) {

--- a/packages/playout-gateway/package.json
+++ b/packages/playout-gateway/package.json
@@ -59,7 +59,6 @@
 		"@sofie-automation/server-core-integration": "1.49.0-in-development",
 		"@sofie-automation/shared-lib": "1.49.0-in-development",
 		"debug": "^4.3.3",
-		"fast-clone": "^1.5.13",
 		"influx": "^5.9.3",
 		"timeline-state-resolver": "8.0.0-release48.0",
 		"tslib": "^2.4.0",

--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -38,9 +38,10 @@ import {
 	PeripheralDeviceStatusObject,
 } from '@sofie-automation/shared-lib/dist/peripheralDevice/peripheralDeviceAPI'
 import { assertNever } from '@sofie-automation/shared-lib/dist/lib/lib'
-import { protectString, unprotectObject } from '@sofie-automation/shared-lib/dist/lib/protectedString'
+import { protectString, unprotectObject, unprotectString } from '@sofie-automation/shared-lib/dist/lib/protectedString'
 import { StudioId, TimelineHash } from '@sofie-automation/shared-lib/dist/core/model/Ids'
 import {
+	deserializeTimelineBlob,
 	RoutedMappings,
 	RoutedTimeline,
 	TimelineObjGeneric,
@@ -396,11 +397,11 @@ export class TSRHandler {
 		}
 
 		const transformedTimeline = timeline.timelineBlob
-			? this._transformTimeline(JSON.parse(timeline.timelineBlob) as Array<TimelineObjGeneric>)
+			? this._transformTimeline(deserializeTimelineBlob(timeline.timelineBlob))
 			: timeline.timeline
 			? this._transformTimeline(clone(timeline.timeline))
 			: []
-		this.tsr.timelineHash = timeline.timelineHash
+		this.tsr.timelineHash = unprotectString(timeline.timelineHash)
 		this.tsr.setTimelineAndMappings(transformedTimeline, unprotectObject(mappingsObject.mappings))
 	}
 	private _getPeripheralDevice(): PeripheralDevicePublic {

--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -20,7 +20,6 @@ import {
 	StatusCode,
 } from 'timeline-state-resolver'
 import { CoreHandler, CoreTSRDeviceHandler } from './coreHandler'
-import clone = require('fast-clone')
 import * as crypto from 'crypto'
 import * as cp from 'child_process'
 
@@ -396,11 +395,7 @@ export class TSRHandler {
 			})
 		}
 
-		const transformedTimeline = timeline.timelineBlob
-			? this._transformTimeline(deserializeTimelineBlob(timeline.timelineBlob))
-			: timeline.timeline
-			? this._transformTimeline(clone(timeline.timeline))
-			: []
+		const transformedTimeline = this._transformTimeline(deserializeTimelineBlob(timeline.timelineBlob))
 		this.tsr.timelineHash = unprotectString(timeline.timelineHash)
 		this.tsr.setTimelineAndMappings(transformedTimeline, unprotectObject(mappingsObject.mappings))
 	}

--- a/packages/shared-lib/package.json
+++ b/packages/shared-lib/package.json
@@ -39,6 +39,7 @@
 		"/LICENSE"
 	],
 	"dependencies": {
+		"timeline-state-resolver-types": "8.0.0-release48.0",
 		"tslib": "^2.4.0",
 		"type-fest": "^2.19.0"
 	},

--- a/packages/shared-lib/src/core/model/Ids.ts
+++ b/packages/shared-lib/src/core/model/Ids.ts
@@ -35,3 +35,7 @@ export type ExpectedPackageWorkStatusId = ProtectedString<'ExpectedPackageStatus
 
 /** A string, identifying a TimelineDatastore entry */
 export type TimelineDatastoreEntryId = ProtectedString<'TimelineDatastoreEntryId'>
+
+export type MappingsHash = ProtectedString<'MappingsHash'>
+
+export type TimelineBlob = ProtectedString<'TimelineBlob'>

--- a/packages/shared-lib/src/core/model/Timeline.ts
+++ b/packages/shared-lib/src/core/model/Timeline.ts
@@ -63,9 +63,6 @@ export interface RoutedTimeline {
 	/** serialized JSON Array containing all timeline-objects */
 	timelineBlob: TimelineBlob
 	generated: number
-
-	// this is the old way of storing the timeline, kept for backwards-compatibility
-	timeline?: TimelineObjGeneric[]
 }
 
 export enum LookaheadMode {

--- a/packages/shared-lib/src/core/model/Timeline.ts
+++ b/packages/shared-lib/src/core/model/Timeline.ts
@@ -1,0 +1,99 @@
+import { TSR } from '../../tsr'
+import { PeripheralDeviceId, StudioId } from './Ids'
+
+export enum TimelineObjHoldMode {
+	/** Default: The object is played as usual (behaviour is not affected by Hold)  */
+	NORMAL = 0,
+	/** The object is played ONLY when doing a Hold */
+	ONLY = 1,
+	/** The object is played when NOT doing a Hold */
+	EXCEPT = 2,
+}
+
+export interface TimelineObjectCoreExt<
+	TContent extends { deviceType: TSR.DeviceType },
+	TMetadata = unknown,
+	TKeyframeMetadata = unknown
+> extends TSR.TSRTimelineObj<TContent> {
+	/** Restrict object usage according to whether we are currently in a hold */
+	holdMode?: TimelineObjHoldMode
+	/** Arbitrary data storage for plugins */
+	metaData?: TMetadata
+	/** Keyframes: Arbitrary data storage for plugins */
+	keyframes?: Array<TimelineKeyframeCoreExt<TContent, TKeyframeMetadata>>
+}
+
+export interface TimelineKeyframeCoreExt<TContent extends { deviceType: TSR.DeviceType }, TKeyframeMetadata = unknown>
+	extends TSR.Timeline.TimelineKeyframe<TContent> {
+	metaData?: TKeyframeMetadata
+	/** Whether to keep this keyframe when the object is copied for lookahead. By default all keyframes are removed */
+	preserveForLookahead?: boolean
+}
+
+export type TimelineEnableExt = TSR.Timeline.TimelineEnable & { setFromNow?: boolean }
+
+export enum TimelineObjType {
+	/** Objects played in a rundown */
+	RUNDOWN = 'rundown',
+}
+export interface TimelineObjGeneric extends TimelineObjectCoreExt<TSR.TSRTimelineContent> {
+	/** Unique within a timeline (ie within a studio) */
+	id: string
+	/** Set when the id of the object is prefixed */
+	originalId?: string
+
+	objectType: TimelineObjType
+
+	enable: TimelineEnableExt | TimelineEnableExt[]
+
+	/** The id of the group object this object is in  */
+	inGroup?: string
+}
+
+/** This is the data-object published from Core */
+export interface RoutedTimeline {
+	_id: StudioId
+	/** Hash of the studio mappings */
+	mappingsHash: string
+
+	/** Hash of the Timeline */
+	timelineHash: string
+
+	/** serialized JSON Array containing all timeline-objects */
+	timelineBlob: string
+	generated: number
+
+	// this is the old way of storing the timeline, kept for backwards-compatibility
+	timeline?: TimelineObjGeneric[]
+}
+
+export enum LookaheadMode {
+	NONE = 0,
+	PRELOAD = 1,
+	// RETAIN = 2, // Removed due to complexity and it being possible to emulate with WHEN_CLEAR and infinites
+	WHEN_CLEAR = 3,
+}
+
+export interface BlueprintMappings extends TSR.Mappings {
+	[layerName: string]: BlueprintMapping
+}
+export interface BlueprintMapping extends TSR.Mapping {
+	/** What method core should use to create lookahead objects for this layer */
+	lookahead: LookaheadMode
+	/** How many lookahead objects to create for this layer. Default = 1 */
+	lookaheadDepth?: number
+	/** Maximum distance to search for lookahead. Default = 10 */
+	lookaheadMaxSearchDistance?: number
+}
+
+export interface MappingsExt {
+	[layerName: string]: MappingExt
+}
+export interface MappingExt extends Omit<BlueprintMapping, 'deviceId'> {
+	deviceId: PeripheralDeviceId
+}
+export interface RoutedMappings {
+	_id: StudioId
+	mappingsHash: string | undefined
+	mappings: MappingsExt
+}

--- a/packages/shared-lib/src/core/model/Timeline.ts
+++ b/packages/shared-lib/src/core/model/Timeline.ts
@@ -1,5 +1,6 @@
+import { unprotectString, protectString } from '../../lib/protectedString'
 import { TSR } from '../../tsr'
-import { PeripheralDeviceId, StudioId } from './Ids'
+import { MappingsHash, PeripheralDeviceId, StudioId, TimelineBlob, TimelineHash } from './Ids'
 
 export enum TimelineObjHoldMode {
 	/** Default: The object is played as usual (behaviour is not affected by Hold)  */
@@ -54,13 +55,13 @@ export interface TimelineObjGeneric extends TimelineObjectCoreExt<TSR.TSRTimelin
 export interface RoutedTimeline {
 	_id: StudioId
 	/** Hash of the studio mappings */
-	mappingsHash: string
+	mappingsHash: MappingsHash | undefined
 
 	/** Hash of the Timeline */
-	timelineHash: string
+	timelineHash: TimelineHash
 
 	/** serialized JSON Array containing all timeline-objects */
-	timelineBlob: string
+	timelineBlob: TimelineBlob
 	generated: number
 
 	// this is the old way of storing the timeline, kept for backwards-compatibility
@@ -94,6 +95,13 @@ export interface MappingExt extends Omit<BlueprintMapping, 'deviceId'> {
 }
 export interface RoutedMappings {
 	_id: StudioId
-	mappingsHash: string | undefined
+	mappingsHash: MappingsHash | undefined
 	mappings: MappingsExt
+}
+
+export function deserializeTimelineBlob(timelineBlob: TimelineBlob): TimelineObjGeneric[] {
+	return JSON.parse(unprotectString(timelineBlob)) as Array<TimelineObjGeneric>
+}
+export function serializeTimelineBlob(timeline: TimelineObjGeneric[]): TimelineBlob {
+	return protectString(JSON.stringify(timeline))
 }

--- a/packages/shared-lib/src/tsr.ts
+++ b/packages/shared-lib/src/tsr.ts
@@ -1,0 +1,5 @@
+import * as TSR from 'timeline-state-resolver-types'
+export { TSR }
+
+import * as tsrPkgInfo from 'timeline-state-resolver-types/package.json'
+export const TSR_VERSION: string = tsrPkgInfo.version


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

Some types are copied between playout-gateway and corelib/meteor, as there is nowhere that they can be placed due to the dependency on tsr/tsr-types.

* **What is the new behavior (if this is a feature change)?**

The tsr-types dependency has been moved from blueprints-integration to shared-lib. While this does mean that some gateways (ingest/package-manager) will have the dependency unnecessarily, it is a small no-dependency library so has little impact on size.
This lets us move some more types into shared-lib, for better reuse across the sofie components.

* **Other information**:

While some changes were made to blueprints-integration typings, this has no impact to blueprints, as it is simply changing where tsr-types were imported from, and is keeping the existing re-export.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
