### PR TITLE
fix: Queued parts at the end of a playlist

### DIFF
--- a/meteor/client/ui/RundownView/RundownTiming/RundownTimingProvider.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming/RundownTimingProvider.tsx
@@ -138,6 +138,9 @@ export const RundownTimingProvider = withTracker<
 
 				if (insertBefore !== null) {
 					parts.splice(insertBefore, 0, partInstance.part)
+				} else if (foundSegment && partInstance.orphaned === 'adlib-part') {
+					// Part is right at the end of the rundown
+					parts.push(partInstance.part)
 				}
 			}
 		})


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**What is the current behavior?** (You can also link to an open issue here)
When queuing a Part at the end of a Playlist, timing information for this Part is not reported. This results in the UI drawing the queued Part and the Playhead incorrectly, in some cases resulting in a Part that is not visible to the user.


**What is the new behavior (if this is a feature change)?**
If a Part is marked as an `adlib-part` orphan and its parent Segment is found but it cannot otherwise be placed in the list of Parts, the Part is added to the end of the list.


**Other information**:
If R49 is closed for contributions then I will rebase onto R50 when a branch is available.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
