### PR TITLE
Fix: Hack for slowness in release 44

### DIFF
--- a/meteor/server/lib/optimizedObserver.ts
+++ b/meteor/server/lib/optimizedObserver.ts
@@ -139,7 +139,7 @@ export async function setUpOptimizedObserver<
 
 							if (totalTime > SLOW_OBSERVE_TIME) {
 								logger.debug(
-									`Slow optimized observer ${identifier}. Total: ${totalTime}, manipulate: ${manipulateDuration}, publish: ${publishTime} (receivers: ${o.dataReceivers.length})`
+									`Slow optimized observer ${identifier}. Total: ${totalTime}ms, manipulate: ${manipulateDuration}ms, publish: ${publishTime}ms (receivers: ${o.dataReceivers.length}, count: ${result?.length})`
 								)
 							}
 						}

--- a/packages/job-worker/src/ingest/bucketAdlibs.ts
+++ b/packages/job-worker/src/ingest/bucketAdlibs.ts
@@ -254,7 +254,12 @@ export async function handleBucketItemImport(context: JobContext, data: BucketIt
 				ps.push(
 					context.directCollections.BucketAdLibPieces.replace(adlib),
 					updateExpectedMediaItemForBucketAdLibPiece(context, adlib),
-					updateExpectedPackagesForBucketAdLibPiece(context, adlib)
+					// HACK: Only generate a single expectedPackage for the adlibAction.
+					// This is to NOT generate expected packages for all of the showstyle-variants, just one.
+					// This will break the zebra-stripes in the GUI, and is only a temporary hack. / Johan 2023-01-13
+					isFirstShowStyleVariant
+						? updateExpectedPackagesForBucketAdLibPiece(context, adlib)
+						: Promise.resolve()
 				)
 
 				// Preserve this one
@@ -316,6 +321,8 @@ export async function handleBucketActionModify(context: JobContext, data: Bucket
 	const actionsToUpdate = await getGroupedAdlibActions(context, orgAction)
 
 	for (const action of actionsToUpdate) {
+		const isOrgAction = orgAction._id === action._id
+
 		const newAction = {
 			...action,
 			...newProps,
@@ -325,7 +332,10 @@ export async function handleBucketActionModify(context: JobContext, data: Bucket
 				$set: newProps,
 			}),
 			updateExpectedMediaItemForBucketAdLibAction(context, newAction),
-			updateExpectedPackagesForBucketAdLibAction(context, newAction),
+			// HACK: Only generate a single expectedPackage for the adlibAction.
+			// This is to NOT generate expected packages for all of the showstyle-variants, just one.
+			// This will break the zebra-stripes in the GUI, and is only a temporary hack. / Johan 2023-01-13
+			isOrgAction ? updateExpectedPackagesForBucketAdLibAction(context, newAction) : Promise.resolve(),
 		])
 	}
 }
@@ -341,6 +351,8 @@ export async function handleBucketPieceModify(context: JobContext, data: BucketP
 	const piecesToUpdate = await getGroupedAdlibs(context, orgPiece)
 
 	for (const piece of piecesToUpdate) {
+		const isOrgPiece = orgPiece._id === piece._id
+
 		await context.directCollections.BucketAdLibPieces.update(piece._id, {
 			$set: newProps,
 		})
@@ -352,7 +364,10 @@ export async function handleBucketPieceModify(context: JobContext, data: BucketP
 
 		await Promise.all([
 			updateExpectedMediaItemForBucketAdLibPiece(context, newPiece),
-			updateExpectedPackagesForBucketAdLibPiece(context, newPiece),
+			// HACK: Only generate a single expectedPackage for the adlibAction.
+			// This is to NOT generate expected packages for all of the showstyle-variants, just one.
+			// This will break the zebra-stripes in the GUI, and is only a temporary hack. / Johan 2023-01-13
+			isOrgPiece ? updateExpectedPackagesForBucketAdLibPiece(context, newPiece) : Promise.resolve(),
 		])
 	}
 }


### PR DESCRIPTION
This PR contains a hack to fix an issue we've seen where Core (paired with Package Manager and usage of Buckets) becomes very slow.

Currently, there is one adlib per showstyle-variant created per adlib, so if there are 20 variants, and 20 items in a bucket, there will be 400 adlibs (and 400 expectedPackages) created.

We believe that the 400 expectedPackages causes PM to send 800 PackageInfo updates (1 scan + 1 deepScan per package) to Core, and all of those are subscribed to by the web clients, causing both clients and server to become slow.


This PR adds a hack that only generates one (1) expectedPackage per _unique_ adlib-in-bucket. 

One consequence of this hack is that zebra-stripes are likely to show up in the GUI for the items in a bucket, that is something we'll have to address in a proper long-term fix later.
