### PR TITLE
fix: missing package-manager methods

### DIFF
--- a/packages/shared-lib/src/peripheralDevice/methodsAPI.ts
+++ b/packages/shared-lib/src/peripheralDevice/methodsAPI.ts
@@ -38,6 +38,46 @@ import { MediaObject } from '../core/model/MediaObjects'
 import { MediaWorkFlow } from '../core/model/MediaWorkFlows'
 import { MediaWorkFlowStep } from '../core/model/MediaWorkFlowSteps'
 
+export type UpdateExpectedPackageWorkStatusesChanges =
+	| {
+			id: ExpectedPackageWorkStatusId
+			type: 'delete'
+	  }
+	| {
+			id: ExpectedPackageWorkStatusId
+			type: 'insert'
+			status: ExpectedPackageStatusAPI.WorkStatus
+	  }
+	| {
+			id: ExpectedPackageWorkStatusId
+			type: 'update'
+			status: Partial<ExpectedPackageStatusAPI.WorkStatus>
+	  }
+
+export type UpdatePackageContainerPackageStatusesChanges =
+	| {
+			containerId: string
+			packageId: string
+			type: 'delete'
+	  }
+	| {
+			containerId: string
+			packageId: string
+			type: 'update'
+			status: ExpectedPackageStatusAPI.PackageContainerPackageStatus
+	  }
+
+export type UpdatePackageContainerStatusesChanges =
+	| {
+			containerId: string
+			type: 'delete'
+	  }
+	| {
+			containerId: string
+			type: 'update'
+			status: ExpectedPackageStatusAPI.PackageContainerStatus
+	  }
+
 export interface NewPeripheralDeviceAPI {
 	functionReply(
 		deviceId: PeripheralDeviceId,
@@ -258,43 +298,23 @@ export interface NewPeripheralDeviceAPI {
 	updateExpectedPackageWorkStatuses(
 		deviceId: PeripheralDeviceId,
 		deviceToken: string,
-		changes: (
-			| {
-					id: ExpectedPackageWorkStatusId
-					type: 'delete'
-			  }
-			| {
-					id: ExpectedPackageWorkStatusId
-					type: 'insert'
-					status: ExpectedPackageStatusAPI.WorkStatus
-			  }
-			| {
-					id: ExpectedPackageWorkStatusId
-					type: 'update'
-					status: Partial<ExpectedPackageStatusAPI.WorkStatus>
-			  }
-		)[]
+		changes: UpdateExpectedPackageWorkStatusesChanges[]
 	): Promise<void>
 	removeAllExpectedPackageWorkStatusOfDevice(deviceId: PeripheralDeviceId, deviceToken: string): Promise<void>
 
 	updatePackageContainerPackageStatuses(
 		deviceId: PeripheralDeviceId,
 		deviceToken: string,
-		changes: (
-			| {
-					containerId: string
-					packageId: string
-					type: 'delete'
-			  }
-			| {
-					containerId: string
-					packageId: string
-					type: 'update'
-					status: ExpectedPackageStatusAPI.PackageContainerPackageStatus
-			  }
-		)[]
+		changes: UpdatePackageContainerPackageStatusesChanges[]
 	): Promise<void>
 	removeAllPackageContainerPackageStatusesOfDevice(deviceId: PeripheralDeviceId, deviceToken: string): Promise<void>
+
+	updatePackageContainerStatuses(
+		deviceId: PeripheralDeviceId,
+		deviceToken: string,
+		changes: UpdatePackageContainerStatusesChanges[]
+	): Promise<void>
+	removeAllPackageContainerStatusesOfDevice(deviceId: PeripheralDeviceId, deviceToken: string): Promise<void>
 
 	fetchPackageInfoMetadata(
 		deviceId: PeripheralDeviceId,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Package-manager is using r44 libraries which are not as strict on typings.
In r48 this changed with https://github.com/nrkno/sofie-core/pull/788, which exposes the methods in a 'typesafe' way.

A couple of methods were missing on the interface, causing them to not be exposed by server-core-integration

* **What is the new behavior (if this is a feature change)?**

The methods which are already implemented are now exposed in the interfaces, making them available for gateways

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
