### PR TITLE
chore: Added missing 'showoverunder' parameter

### DIFF
--- a/packages/documentation/docs/user-guide/features/prompter.md
+++ b/packages/documentation/docs/user-guide/features/prompter.md
@@ -28,6 +28,7 @@ The prompter UI can be configured using query parameters:
 | `showmarker`    | 0 / 1  | If the marker is not set to "hide", control if the marker is hidden or not                                                                                          | `1`     |
 | `showscroll`    | 0 / 1  | Whether the scroll bar should be shown                                                                                                                              | `1`     |
 | `followtake`    | 0 / 1  | Whether the prompter should automatically scroll to current segment when the operator TAKE:s it                                                                     | `1`     |
+| `showoverunder`    | 0 / 1  | The timer in the top-right of the prompter, showing the overtime/undertime of the current show.                                                                     | `1`     |
 | `debug`         | 0 / 1  | Whether to display a debug box showing controller input values and the calculated speed the prompter is currently scrolling at. Used to tweak speedMaps and ranges. | `0`     |
 
 Example: [http://127.0.0.1/prompter/studio0/?mode=mouse&followtake=0&fontsize=20](http://127.0.0.1/prompter/studio0/?mode=mouse&followtake=0&fontsize=20)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix, the "showoverunder" parameter was missing from the documentation.


* **Other information**:
Verified that the parameter works as expected by testing on Xpro1 running 1.44.2-0.
**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
