### PR TITLE
chore: prune docker images from ghcr

### DIFF
--- a/.github/workflows/prune-docker-images.yaml
+++ b/.github/workflows/prune-docker-images.yaml
@@ -1,0 +1,20 @@
+name: "Prune docker images"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '5 10 * * *'
+
+jobs:
+  prune-docker-images:
+    uses: nrkno/sofie-github-workflows/.github/workflows/prune-docker-images.yml@main
+    strategy:
+      max-parallel: 1
+      matrix:
+        repo: [ server-core, playout-gateway, mos-gateway ]
+    with:
+      dry-run: false
+      prune-untagged: true
+      package-name: sofie-core-${{ matrix.repo }}
+    secrets:
+      prune-token: ${{ secrets.GHCR_PRUNE_TOKEN }}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Prune docker images from GHCR using https://github.com/vlaurin/action-ghcr-prune. <s>I think that with this current configuration this workflow will delete **all untagged images**, but will not delete any tagged images. At least that has been my experience with testing using different combination of the available filters. 

What I would like to be able to do is delete all untagged images, keep all release images and keep 10 feature images. But so far I haven't been able to configure the action like that. If I specify a number of images to keep, untagged images are included in the count. </s>

**This workflow will** 
- Delete all untagged images.
- Keep tags that start with release and version number (v1.44.1 for instance). Also master, latest, nightly, main.
- Delete all tagged images that are older than 14 days.


**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
