### PR TITLE
fix(PoGw): resolve issues with reporting context from TSR

### DIFF
--- a/packages/playout-gateway/src/coreHandler.ts
+++ b/packages/playout-gateway/src/coreHandler.ts
@@ -102,15 +102,15 @@ export class CoreHandler {
 
 		this.core.onConnected(() => {
 			this.logger.info('Core Connected!')
-			this.setupObserversAndSubscriptions().catch((e) => {
-				this.logger.error('Core Error during setupObserversAndSubscriptions:', e)
+			this.setupObserversAndSubscriptions().catch((e: any) => {
+				this.logger.error(`Core Error during setupObserversAndSubscriptions: ${e}`, { error: e })
 			})
 			if (this._onConnected) this._onConnected()
 		})
 		this.core.onDisconnected(() => {
 			this.logger.warn('Core Disconnected!')
 		})
-		this.core.onError((err) => {
+		this.core.onError((err: any) => {
 			this.logger.error('Core Error: ' + (typeof err === 'string' ? err : err.message || err.toString() || err))
 		})
 
@@ -261,10 +261,10 @@ export class CoreHandler {
 					.autoSubscribe('timeline', {
 						studioId: studioId,
 					})
-					.then((subscriptionId) => {
+					.then((subscriptionId: string | null) => {
 						this._timelineSubscription = subscriptionId
 					})
-					.catch((err) => {
+					.catch((err: any) => {
 						this.logger.error(err)
 					})
 
@@ -277,10 +277,10 @@ export class CoreHandler {
 					.autoSubscribe('expectedPlayoutItems', {
 						studioId: studioId,
 					})
-					.then((subscriptionId) => {
+					.then((subscriptionId: string | null) => {
 						this._expectedItemsSubscription = subscriptionId
 					})
-					.catch((err) => {
+					.catch((err: any) => {
 						this.logger.error(err)
 					})
 				this.logger.debug('VIZDEBUG: Subscription to expectedPlayoutItems done')
@@ -309,14 +309,17 @@ export class CoreHandler {
 			const cb = (err: any, res?: any) => {
 				// console.log('cb', err, res)
 				if (err) {
-					this.logger.error('executeFunction error', err, err.stack)
+					this.logger.error('executeFunction error', {
+						error: err,
+						stacktrace: err.stack,
+					})
 				}
 				fcnObject.core
 					.callMethod(PeripheralDeviceAPIMethods.functionReply, [cmd._id, err, res])
 					.then(() => {
 						// console.log('cb done')
 					})
-					.catch((error) => this.logger.error(error))
+					.catch((error: any) => this.logger.error(error))
 			}
 			// @ts-expect-error Untyped bunch of functions
 			// eslint-disable-next-line @typescript-eslint/ban-types
@@ -562,7 +565,7 @@ export class CoreTSRDeviceHandler {
 				this._device.deviceOptions.type
 			)
 		)
-		this.core.onError((err) => {
+		this.core.onError((err: any) => {
 			this._coreParentHandler.logger.error(
 				'Core Error: ' + ((_.isObject(err) && err.message) || err.toString() || err)
 			)
@@ -622,9 +625,12 @@ export class CoreTSRDeviceHandler {
 	sendStatus(): void {
 		if (!this.core) return // not initialized yet
 
-		this.core
-			.setStatus(this._deviceStatus)
-			.catch((e) => this._coreParentHandler.logger.error('Error when setting status: ', e, e.stack))
+		this.core.setStatus(this._deviceStatus).catch((e: any) =>
+			this._coreParentHandler.logger.error(`Error when setting status: ${e}`, {
+				error: e,
+				stacktrace: e.stack,
+			})
+		)
 	}
 	onCommandError(
 		errorMessage: string,
@@ -638,18 +644,31 @@ export class CoreTSRDeviceHandler {
 	): void {
 		this.core
 			.callMethodLowPrio(PeripheralDeviceAPIMethods.reportCommandError, [errorMessage, ref])
-			.catch((e) => this._coreParentHandler.logger.error('Error when callMethodLowPrio: ', e, e.stack))
+			.catch((e: any) =>
+				this._coreParentHandler.logger.error(`Error when callMethodLowPrio: ${e}`, {
+					error: e,
+					stacktrace: e.stack,
+				})
+			)
 	}
 	onUpdateMediaObject(collectionId: string, docId: string, doc: MediaObject | null): void {
 		this.core
 			.callMethodLowPrio(PeripheralDeviceAPIMethods.updateMediaObject, [collectionId, docId, doc])
-			.catch((e) => this._coreParentHandler.logger.error('Error when updating Media Object: ' + e, e.stack))
+			.catch((e: any) =>
+				this._coreParentHandler.logger.error(`Error when updating Media Object: ${e}`, {
+					error: e,
+					stacktrace: e.stack,
+				})
+			)
 	}
 	onClearMediaObjectCollection(collectionId: string): void {
 		this.core
 			.callMethodLowPrio(PeripheralDeviceAPIMethods.clearMediaObjectCollection, [collectionId])
-			.catch((e) =>
-				this._coreParentHandler.logger.error('Error when clearing Media Objects collection: ' + e, e.stack)
+			.catch((e: any) =>
+				this._coreParentHandler.logger.error(`Error when clearing Media Objects collection: ${e}`, {
+					error: e,
+					stacktrace: e.stack,
+				})
 			)
 	}
 

--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -851,7 +851,7 @@ export class TSRHandler {
 			}
 			const onCommandError = (error: any, context: any) => {
 				// todo: handle this better
-				this.logger.error(fixError(error), context)
+				this.logger.error(fixError(error), { context })
 			}
 			const onUpdateMediaObject = (collectionId: string, docId: string, doc: MediaObject | null) => {
 				coreTsrHandler.onUpdateMediaObject(collectionId, docId, doc)
@@ -869,6 +869,11 @@ export class TSRHandler {
 				if (_.isString(e)) e = name + ': ' + e
 
 				return e
+			}
+			const fixContext = (...context: any[]): any => {
+				return {
+					context,
+				}
 			}
 			await coreTsrHandler.init()
 
@@ -905,13 +910,13 @@ export class TSRHandler {
 			await device.device.on('clearMediaObjects', onClearMediaObjectCollection as () => void)
 
 			await device.device.on('info', ((e: any, ...args: any[]) => {
-				this.logger.info(fixError(e), ...args)
+				this.logger.info(fixError(e), fixContext(args))
 			}) as () => void)
 			await device.device.on('warning', ((e: any, ...args: any[]) => {
-				this.logger.warn(fixError(e), ...args)
+				this.logger.warn(fixError(e), fixContext(args))
 			}) as () => void)
 			await device.device.on('error', ((e: any, ...args: any[]) => {
-				this.logger.error(fixError(e), ...args)
+				this.logger.error(fixError(e), fixContext(args))
 			}) as () => void)
 
 			await device.device.on('debug', (...args: any[]) => {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Sometimes, when using JSON formatter, log context information is exploded from a string into an object, resulting in an entry looking like this:
```javascript
{0:"H", 1:"e", 2:"l", 3:"l", 4:"o", 5:" ", 6:"W", 7: "o", 8:"r", 9:"l", 10:"d"}
```

This is not good.

* **What is the new behavior (if this is a feature change)?**

Before forwarding context from TSR or attaching the context to the log, the context is sanitized so that it's always an object.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [x] The functionality has been tested by NRK
