### PR TITLE
fix: indicate which layers/mappings have overrides

### DIFF
--- a/meteor/client/ui/Settings/ShowStyle/OutputLayer.tsx
+++ b/meteor/client/ui/Settings/ShowStyle/OutputLayer.tsx
@@ -204,6 +204,26 @@ function OutputLayerEntry({ item, isExpanded, toggleExpanded, overrideHelper }: 
 			),
 		})
 	}, [t, item.id, item.computed.name, overrideHelper])
+	const confirmReset = useCallback(() => {
+		doModalDialog({
+			title: t('Reset this item?'),
+			yes: t('Reset'),
+			no: t('Cancel'),
+			onAccept: () => {
+				overrideHelper.resetItem(item.id)
+			},
+			message: (
+				<React.Fragment>
+					<p>
+						{t('Are you sure you want to reset all overrides for the output layer "{{outputLayerId}}"?', {
+							outputLayerId: item.computed.name,
+						})}
+					</p>
+					<p>{t('Please note: This action is irreversible!')}</p>
+				</React.Fragment>
+			),
+		})
+	}, [t, item.id, overrideHelper])
 
 	return (
 		<>
@@ -224,10 +244,20 @@ function OutputLayerEntry({ item, isExpanded, toggleExpanded, overrideHelper }: 
 					</div>
 				</td>
 				<td className="settings-studio-output-table__actions table-item-actions c3">
-					<button className="action-btn" onClick={toggleEditItem}>
+					{!item.defaults && (
+						<button className="action-btn" disabled>
+							<FontAwesomeIcon icon={faSync} title={t('Source layer cannot be reset as it has no default values')} />
+						</button>
+					)}
+					{item.defaults && item.overrideOps.length > 0 && (
+						<button className="action-btn" onClick={confirmReset} title={t('Reset source layer to default values')}>
+							<FontAwesomeIcon icon={faSync} />
+						</button>
+					)}
+					<button className="action-btn" onClick={toggleEditItem} title={t('Edit output layer')}>
 						<FontAwesomeIcon icon={faPencilAlt} />
 					</button>
-					<button className="action-btn" onClick={confirmDelete}>
+					<button className="action-btn" onClick={confirmDelete} title={t('Delete output layer')}>
 						<FontAwesomeIcon icon={faTrash} />
 					</button>
 				</td>

--- a/meteor/client/ui/Settings/ShowStyle/SourceLayer.tsx
+++ b/meteor/client/ui/Settings/ShowStyle/SourceLayer.tsx
@@ -233,6 +233,26 @@ function SourceLayerEntry({ item, isExpanded, toggleExpanded, overrideHelper }: 
 			),
 		})
 	}, [t, item.id, item.computed.name, overrideHelper])
+	const confirmReset = useCallback(() => {
+		doModalDialog({
+			title: t('Reset this item?'),
+			yes: t('Reset'),
+			no: t('Cancel'),
+			onAccept: () => {
+				overrideHelper.resetItem(item.id)
+			},
+			message: (
+				<React.Fragment>
+					<p>
+						{t('Are you sure you want to reset all overrides for the source layer "{{sourceLayerId}}"?', {
+							sourceLayerId: item.computed.name,
+						})}
+					</p>
+					<p>{t('Please note: This action is irreversible!')}</p>
+				</React.Fragment>
+			),
+		})
+	}, [t, item.id, overrideHelper])
 
 	return (
 		<>
@@ -247,10 +267,20 @@ function SourceLayerEntry({ item, isExpanded, toggleExpanded, overrideHelper }: 
 					{sourceLayerString(t, Number.parseInt(item.computed.type.toString(), 10) as SourceLayerType)}
 				</td>
 				<td className="settings-studio-source-table__actions table-item-actions c3">
-					<button className="action-btn" onClick={toggleEditItem}>
+					{!item.defaults && (
+						<button className="action-btn" disabled>
+							<FontAwesomeIcon icon={faSync} title={t('Source layer cannot be reset as it has no default values')} />
+						</button>
+					)}
+					{item.defaults && item.overrideOps.length > 0 && (
+						<button className="action-btn" onClick={confirmReset} title={t('Reset source layer to default values')}>
+							<FontAwesomeIcon icon={faSync} />
+						</button>
+					)}
+					<button className="action-btn" onClick={toggleEditItem} title={t('Edit source layer')}>
 						<FontAwesomeIcon icon={faPencilAlt} />
 					</button>
-					<button className="action-btn" onClick={confirmDelete}>
+					<button className="action-btn" onClick={confirmDelete} title={t('Delete source layer')}>
 						<FontAwesomeIcon icon={faTrash} />
 					</button>
 				</td>

--- a/meteor/client/ui/Settings/Studio/Mappings.tsx
+++ b/meteor/client/ui/Settings/Studio/Mappings.tsx
@@ -234,6 +234,26 @@ function StudioMappingsEntry({
 			),
 		})
 	}, [t, item.id, overrideHelper])
+	const confirmReset = useCallback(() => {
+		doModalDialog({
+			title: t('Reset this mapping?'),
+			yes: t('Reset'),
+			no: t('Cancel'),
+			onAccept: () => {
+				overrideHelper.resetItem(item.id)
+			},
+			message: (
+				<React.Fragment>
+					<p>
+						{t('Are you sure you want to reset all overrides for the mapping for layer "{{mappingId}}"?', {
+							mappingId: item.id,
+						})}
+					</p>
+					<p>{t('Please note: This action is irreversible!')}</p>
+				</React.Fragment>
+			),
+		})
+	}, [t, item.id, overrideHelper])
 
 	const doChangeItemId = useCallback(
 		(newItemId: string) => {
@@ -271,10 +291,20 @@ function StudioMappingsEntry({
 				</td>
 
 				<td className="settings-studio-device__actions table-item-actions c3">
-					<button className="action-btn" onClick={toggleEditItem}>
+					{!item.defaults && (
+						<button className="action-btn" disabled>
+							<FontAwesomeIcon icon={faSync} title={t('Mapping cannot be reset as it has no default values')} />
+						</button>
+					)}
+					{item.defaults && item.overrideOps.length > 0 && (
+						<button className="action-btn" onClick={confirmReset} title={t('Reset mapping to default values')}>
+							<FontAwesomeIcon icon={faSync} />
+						</button>
+					)}
+					<button className="action-btn" onClick={toggleEditItem} title={t('Edit mapping')}>
 						<FontAwesomeIcon icon={faPencilAlt} />
 					</button>
-					<button className="action-btn" onClick={confirmDelete}>
+					<button className="action-btn" onClick={confirmDelete} title={t('Delete mapping')}>
 						<FontAwesomeIcon icon={faTrash} />
 					</button>
 				</td>


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix

* **What is the current behavior?** (You can also link to an open issue here)

While adding various overrides to mappings to work in my local environment I realised that it wasn't possible to easily check where I had made changes without expanding a lot of mappings.

* **What is the new behavior (if this is a feature change)?**

This adds a button to clear the overrides, as a way of indicating that there are overrides. Clicking it will clear the overrides.
For any mappings/layers which were created in the ui and have no blueprint backing, it is shown as disabled, as an indication that it is an override, but it can't be cleared in this way

![image](https://user-images.githubusercontent.com/1327476/219108810-0662bcb7-888d-48e0-a211-161c19aea617.png)


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
