### PR TITLE
Chore: Allow node 14+ in published libs

### DIFF
--- a/packages/server-core-integration/package.json
+++ b/packages/server-core-integration/package.json
@@ -48,7 +48,7 @@
 		"license-validate": "yarn sofie-licensecheck"
 	},
 	"engines": {
-		"node": "^14.19 || ^16.14"
+		"node": ">=14.19"
 	},
 	"files": [
 		"/dist",

--- a/packages/shared-lib/package.json
+++ b/packages/shared-lib/package.json
@@ -30,7 +30,7 @@
 		"license-validate": "yarn sofie-licensecheck"
 	},
 	"engines": {
-		"node": "^14.19 || ^16.14"
+		"node": ">=14.19"
 	},
 	"files": [
 		"/dist",


### PR DESCRIPTION
This PR changes the allowed Node-versions in package.json files to allow all Node-versions above 14.19 (and not only allow 14 and 16).

This applies only to the libraries that are published and used by external apps.

My reasoning for this is that I think that we should not hold back other libraries by disallowing the use of newer versions of Node