### PR TITLE
fix: don't give out the same lookahead AB session ID to sessions with different names

### DIFF
--- a/packages/job-worker/src/blueprints/__tests__/context-events.test.ts
+++ b/packages/job-worker/src/blueprints/__tests__/context-events.test.ts
@@ -856,25 +856,36 @@ describe('Test blueprint api context', () => {
 
 			// existing 'distant' lookahead session
 			const obj2 = createTimelineObject(unprotectString(distantPartId), undefined, true)
-			expect(context.getTimelineObjectAbSessionId(obj2, 'name0')).toEqual('lookahead2')
+			expect(context.getTimelineObjectAbSessionId(obj2, 'name2')).toEqual('lookahead2')
 			expect(context.knownSessions).toHaveLength(1)
+
+			// new 'distant' lookahead session
+			const obj2a = createTimelineObject(unprotectString(distantPartId), undefined, true)
+			expect(context.getTimelineObjectAbSessionId(obj2a, 'name0')).toEqual(getSessionId(0))
+			expect(context.knownSessions).toHaveLength(2)
+			existingSessions.push({
+				id: getSessionId(0),
+				lookaheadForPartId: distantPartId,
+				name: 'name0',
+			})
 
 			// current partInstance session
 			const obj3 = createTimelineObject(currentPartInstance._id, undefined, true)
 			expect(context.getTimelineObjectAbSessionId(obj3, 'name1')).toEqual('current1')
-			expect(context.knownSessions).toHaveLength(2)
+			expect(context.knownSessions).toHaveLength(3)
 
 			// next partInstance session
 			const obj4 = createTimelineObject(nextPartInstance._id, undefined, true)
 			expect(context.getTimelineObjectAbSessionId(obj4, 'name0')).toEqual('next0')
-			expect(context.knownSessions).toHaveLength(3)
+			expect(context.knownSessions).toHaveLength(4)
 
 			// next partInstance new session
 			const obj5 = createTimelineObject(nextPartInstance._id, undefined, true)
-			expect(context.getTimelineObjectAbSessionId(obj5, 'name1')).toEqual(getSessionId(0))
-			expect(context.knownSessions).toHaveLength(4)
+			expect(context.getTimelineObjectAbSessionId(obj5, 'name1')).toEqual(getSessionId(1))
+			expect(context.knownSessions).toHaveLength(5)
+
 			existingSessions.push({
-				id: getSessionId(0),
+				id: getSessionId(1),
 				lookaheadForPartId: nextPartInstance.part._id,
 				name: 'name1',
 				partInstanceIds: [nextPartInstance._id],

--- a/packages/job-worker/src/blueprints/context/OnTimelineGenerateContext.ts
+++ b/packages/job-worker/src/blueprints/context/OnTimelineGenerateContext.ts
@@ -195,7 +195,9 @@ export class OnTimelineGenerateContext extends RundownContext implements ITimeli
 			const partInstance = this.partInstances.find((p) => p._id === partInstanceId)
 			if (partInstance) partId = partInstance.part._id
 
-			const lookaheadSession = this._knownSessions.find((s) => s.lookaheadForPartId === partId)
+			const lookaheadSession = this._knownSessions.find(
+				(s) => s.lookaheadForPartId === partId && s.name === sessionName
+			)
 			if (lookaheadSession) {
 				lookaheadSession.keep = true
 				if (partInstance) {


### PR DESCRIPTION
This PR is being opened on behalf of [TV 2 Norway](https://github.com/tv2norge).

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

If two or more lookahead sessions in the same AB pool are active for the same `lookaheadForPartId`, they will receive the same AB session ID even if they are for different sessions (as determined by `sessionName`).

* **What is the new behavior (if this is a feature change)?**

Now, `sessionName` is checked when attempting to find an existing `lookaheadSession`. This is in line with earlier bits in the same function which also check for existing sessions.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
