### PR TITLE
feat: add studio frameRate to coreConfig

### DIFF
--- a/packages/blueprints-integration/src/api.ts
+++ b/packages/blueprints-integration/src/api.ts
@@ -354,6 +354,7 @@ export interface BlueprintResultRundownPlaylist {
 
 export interface BlueprintConfigCoreConfig {
 	hostUrl: string
+	frameRate: number
 }
 
 export interface IConfigMessage {

--- a/packages/job-worker/src/__mocks__/context.ts
+++ b/packages/job-worker/src/__mocks__/context.ts
@@ -199,7 +199,7 @@ export class MockJobContext implements JobContext {
 		}
 	}
 	getShowStyleBlueprintConfig(showStyle: ReadonlyDeep<ProcessedShowStyleCompound>): ProcessedShowStyleConfig {
-		return preprocessShowStyleConfig(showStyle, this.#showStyleBlueprint)
+		return preprocessShowStyleConfig(showStyle, this.#showStyleBlueprint, this.#studio.settings)
 	}
 
 	hackPublishTimelineToFastTrack(_newTimeline: TimelineComplete): void {

--- a/packages/job-worker/src/blueprints/__tests__/config.test.ts
+++ b/packages/job-worker/src/blueprints/__tests__/config.test.ts
@@ -56,6 +56,7 @@ describe('Test blueprint config', () => {
 		expect(res).toEqual({
 			core: {
 				hostUrl: 'https://sofie-in-jest:3000',
+				frameRate: 25,
 			},
 			studio: {
 				sdfsdf: 'one',

--- a/packages/job-worker/src/blueprints/config.ts
+++ b/packages/job-worker/src/blueprints/config.ts
@@ -12,7 +12,7 @@ import { getSofieHostUrl, objectPathGet, stringifyError } from '@sofie-automatio
 import _ = require('underscore')
 import { logger } from '../logging'
 import { CommonContext } from './context'
-import { DBStudio } from '@sofie-automation/corelib/dist/dataModel/Studio'
+import { DBStudio, IStudioSettings } from '@sofie-automation/corelib/dist/dataModel/Studio'
 import { protectString } from '@sofie-automation/corelib/dist/protectedString'
 import { ProcessedShowStyleCompound, StudioCacheContext } from '../jobs'
 import { applyAndValidateOverrides } from '@sofie-automation/corelib/dist/settings/objectWithOverrides'
@@ -101,9 +101,10 @@ export interface ProcessedStudioConfig {
  * Get the `BlueprintConfigCoreConfig`
  * This is a set of values provided to the blueprints about the environment, such as the url to access sofie ui
  */
-export function compileCoreConfigValues(): BlueprintConfigCoreConfig {
+export function compileCoreConfigValues(studioSettings: ReadonlyDeep<IStudioSettings>): BlueprintConfigCoreConfig {
 	return {
 		hostUrl: getSofieHostUrl(),
+		frameRate: studioSettings.frameRate,
 	}
 }
 
@@ -123,7 +124,7 @@ export function preprocessStudioConfig(
 				name: `preprocessStudioConfig`,
 				identifier: `studioId=${studio._id}`,
 			})
-			res = blueprint.preprocessConfig(context, res, compileCoreConfigValues())
+			res = blueprint.preprocessConfig(context, res, compileCoreConfigValues(studio.settings))
 		}
 	} catch (err) {
 		logger.error(`Error in studioBlueprint.preprocessConfig: ${stringifyError(err)}`)
@@ -138,7 +139,8 @@ export function preprocessStudioConfig(
  */
 export function preprocessShowStyleConfig(
 	showStyle: Pick<ReadonlyDeep<ProcessedShowStyleCompound>, '_id' | 'combinedBlueprintConfig' | 'showStyleVariantId'>,
-	blueprint: ReadonlyDeep<ShowStyleBlueprintManifest>
+	blueprint: ReadonlyDeep<ShowStyleBlueprintManifest>,
+	studioSettings: ReadonlyDeep<IStudioSettings>
 ): ProcessedShowStyleConfig {
 	let res: any = showStyle.combinedBlueprintConfig
 
@@ -148,7 +150,7 @@ export function preprocessShowStyleConfig(
 				name: `preprocessShowStyleConfig`,
 				identifier: `showStyleBaseId=${showStyle._id},showStyleVariantId=${showStyle.showStyleVariantId}`,
 			})
-			res = blueprint.preprocessConfig(context, res, compileCoreConfigValues())
+			res = blueprint.preprocessConfig(context, res, compileCoreConfigValues(studioSettings))
 		}
 	} catch (err) {
 		logger.error(`Error in showStyleBlueprint.preprocessConfig: ${stringifyError(err)}`)

--- a/packages/job-worker/src/playout/upgrade.ts
+++ b/packages/job-worker/src/playout/upgrade.ts
@@ -28,7 +28,7 @@ export async function handleBlueprintUpgradeForStudio(context: JobContext, _data
 	const result = blueprint.blueprint.applyConfig(
 		blueprintContext,
 		clone(rawBlueprintConfig),
-		compileCoreConfigValues()
+		compileCoreConfigValues(context.studio.settings)
 	)
 
 	await context.directCollections.Studios.update(context.studioId, {

--- a/packages/job-worker/src/workers/context.ts
+++ b/packages/job-worker/src/workers/context.ts
@@ -266,7 +266,9 @@ export class StudioCacheContextImpl implements StudioCacheContext {
 		if (!blueprint)
 			throw new Error(`Blueprint "${showStyle.blueprintId}" must be loaded before its config can be retrieved`)
 
-		const config = deepFreeze(clone(preprocessShowStyleConfig(showStyle, blueprint.blueprint)))
+		const config = deepFreeze(
+			clone(preprocessShowStyleConfig(showStyle, blueprint.blueprint, this.studio.settings))
+		)
 		this.cacheData.showStyleBlueprintConfig.set(showStyle.showStyleVariantId, config)
 
 		// Return the raw object, as it was frozen before being cached


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR adds the studio's current framerate to the `BlueprintConfigCoreConfig` interface, thereby making it available to blueprints.

* **What is the current behavior?** (You can also link to an open issue here)

The blueprints don't know the framerate of the studio.

* **What is the new behavior (if this is a feature change)?**

A `frameRate` property is available on the `coreConfig` argument provided to `preprocessConfig` and `applyConfig`.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
