### PR TITLE
fix: ensure keyframes have unique ids

### DIFF
--- a/packages/job-worker/src/playout/lib.ts
+++ b/packages/job-worker/src/playout/lib.ts
@@ -722,6 +722,13 @@ export function prefixAllObjectIds<T extends TimelineObjGeneric>(
 			obj.inGroup = idMap[obj.inGroup] || obj.inGroup
 		}
 
+		// make sure any keyframes are unique
+		if (obj.keyframes) {
+			for (const kf of obj.keyframes) {
+				kf.id = `${kf.id}_${obj.id}`
+			}
+		}
+
 		return obj
 	})
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bug fix

* **What is the current behavior?** (You can also link to an open issue here)

During a headline sequence, take a FULL, then STK, then recue the already played FULL.  
Attempting to take the FULL results in an 'internal server error'

* **What is the new behavior (if this is a feature change)?**

The sequence above is now playable

* **Other information**:

No task for this, it was found and fixed while testing other playout issues that required running this flow.

I think (but am not 100% sure) that this is safe, as I don't think we allow referencing keyframe ids anywhere else in the timeline. I don't think this will cause problems with length of the ids becoming too long, but I havent verified this

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
