### PR TITLE
fix: lookahead loading skipped wipe for remainder of the part SOFIE-2168

### DIFF
--- a/packages/job-worker/src/playout/lookahead/__tests__/findForLayer.test.ts
+++ b/packages/job-worker/src/playout/lookahead/__tests__/findForLayer.test.ts
@@ -34,6 +34,7 @@ describe('findLookaheadForLayer', () => {
 			previousPart?.part.part,
 			{
 				part: partInstanceInfo.part.part,
+				usesInTransition: false,
 				pieces: partInstanceInfo.allPieces,
 			},
 			partInstanceInfo.part._id
@@ -60,18 +61,21 @@ describe('findLookaheadForLayer', () => {
 				allPieces: [createFakePiece('1'), createFakePiece('2'), createFakePiece('3')],
 				onTimeline: true,
 				nowInPart: 2000,
+				calculatedTimings: { inTransitionStart: null },
 			},
 			{
 				part: { _id: '2', part: '2p' },
 				allPieces: [createFakePiece('4'), createFakePiece('5'), createFakePiece('6')],
 				onTimeline: true,
 				nowInPart: 1000,
+				calculatedTimings: { inTransitionStart: null },
 			},
 			{
 				part: { _id: '3', part: '3p' },
 				allPieces: [createFakePiece('7'), createFakePiece('8'), createFakePiece('9')],
 				onTimeline: false,
 				nowInPart: 0,
+				calculatedTimings: { inTransitionStart: null },
 			},
 		] as any
 
@@ -148,6 +152,7 @@ describe('findLookaheadForLayer', () => {
 			{ _id: 'p5' },
 		].map((p) => ({
 			part: p as any,
+			usesInTransition: true,
 			pieces: [{ _id: p._id + '_p1' } as any],
 		}))
 

--- a/packages/job-worker/src/playout/lookahead/__tests__/findObjects.test.ts
+++ b/packages/job-worker/src/playout/lookahead/__tests__/findObjects.test.ts
@@ -302,6 +302,7 @@ describe('findLookaheadObjectsForPart', () => {
 		])
 
 		// No previous should still allow it
+		partInfo.usesInTransition = false
 		const objects3 = findLookaheadObjectsForPart(
 			context,
 			currentPartInstanceId,
@@ -313,7 +314,7 @@ describe('findLookaheadObjectsForPart', () => {
 		expect(stripObjectProperties(objects3, true)).toStrictEqual(stripObjectProperties(objects1, true))
 
 		// Previous disables transition
-		const blockedPreviousPart: DBPart = { disableNextInTransition: true, classesForNext: undefined } as any
+		const blockedPreviousPart: DBPart = { classesForNext: undefined } as any
 		const objects4 = findLookaheadObjectsForPart(
 			context,
 			currentPartInstanceId,
@@ -634,6 +635,7 @@ describe('findLookaheadObjectsForPart', () => {
 		])
 
 		// No previous should still allow it
+		partInfo.usesInTransition = false
 		const objects3 = findLookaheadObjectsForPart(
 			context,
 			currentPartInstanceId,
@@ -645,7 +647,7 @@ describe('findLookaheadObjectsForPart', () => {
 		expect(stripObjectProperties(objects3, true)).toStrictEqual(stripObjectProperties(objects1, true))
 
 		// Previous disables transition
-		const blockedPreviousPart: DBPart = { disableNextInTransition: true, classesForNext: undefined } as any
+		const blockedPreviousPart: DBPart = { classesForNext: undefined } as any
 		const objects4 = findLookaheadObjectsForPart(
 			context,
 			currentPartInstanceId,
@@ -787,6 +789,7 @@ describe('findLookaheadObjectsForPart', () => {
 		])
 
 		// No previous part
+		partInfo.usesInTransition = false
 		const objects3 = findLookaheadObjectsForPart(
 			context,
 			currentPartInstanceId,

--- a/packages/job-worker/src/playout/lookahead/__tests__/findObjects.test.ts
+++ b/packages/job-worker/src/playout/lookahead/__tests__/findObjects.test.ts
@@ -34,7 +34,7 @@ describe('findLookaheadObjectsForPart', () => {
 		const currentPartInstanceId: PartInstanceId | null = null
 		const rundownId: RundownId = protectString('rundown0')
 		const layerName = 'layer0'
-		const partInfo = { part: definePart(rundownId), pieces: [] }
+		const partInfo = { part: definePart(rundownId), usesInTransition: true, pieces: [] }
 		const objects = findLookaheadObjectsForPart(
 			context,
 			currentPartInstanceId,
@@ -75,6 +75,7 @@ describe('findLookaheadObjectsForPart', () => {
 
 		const partInfo = {
 			part: definePart(rundownId),
+			usesInTransition: true,
 			pieces: literal<PieceInstance[]>([
 				{
 					...defaultPieceInstanceProps,
@@ -112,6 +113,7 @@ describe('findLookaheadObjectsForPart', () => {
 
 		const partInfo = {
 			part: definePart(rundownId),
+			usesInTransition: true,
 			pieces: literal<PieceInstance[]>([
 				{
 					...defaultPieceInstanceProps,
@@ -195,6 +197,7 @@ describe('findLookaheadObjectsForPart', () => {
 
 		const partInfo = {
 			part: definePart(rundownId),
+			usesInTransition: true,
 			pieces: literal<PieceInstance[]>([
 				{
 					...defaultPieceInstanceProps,
@@ -330,6 +333,7 @@ describe('findLookaheadObjectsForPart', () => {
 
 		const partInfo = {
 			part: definePart(rundownId),
+			usesInTransition: true,
 			pieces: literal<PieceInstance[]>([
 				{
 					...defaultPieceInstanceProps,
@@ -468,6 +472,7 @@ describe('findLookaheadObjectsForPart', () => {
 
 		const partInfo = {
 			part: definePart(rundownId),
+			usesInTransition: true,
 			pieces: literal<PieceInstance[]>([
 				{
 					...defaultPieceInstanceProps,
@@ -660,6 +665,7 @@ describe('findLookaheadObjectsForPart', () => {
 
 		const partInfo = {
 			part: definePart(rundownId),
+			usesInTransition: true,
 			pieces: sortPieceInstancesByStart(
 				literal<PieceInstance[]>([
 					{

--- a/packages/job-worker/src/playout/lookahead/__tests__/lookahead.test.ts
+++ b/packages/job-worker/src/playout/lookahead/__tests__/lookahead.test.ts
@@ -159,7 +159,7 @@ describe('Lookahead', () => {
 	test('No pieces', async () => {
 		const partInstancesInfo: SelectedPartInstancesTimelineInfo = {}
 
-		const fakeParts = partIds.map((p) => ({ part: { _id: p } as any, pieces: [] }))
+		const fakeParts = partIds.map((p) => ({ part: { _id: p } as any, usesInTransition: true, pieces: [] }))
 		getOrderedPartsAfterPlayheadMock.mockReturnValueOnce(fakeParts.map((p) => p.part))
 
 		const res = await runJobWithPlayoutCache(context, { playlistId }, null, async (cache) =>
@@ -184,7 +184,7 @@ describe('Lookahead', () => {
 	test('got some objects', async () => {
 		const partInstancesInfo: SelectedPartInstancesTimelineInfo = {}
 
-		const fakeParts = partIds.map((p) => ({ part: { _id: p } as any, pieces: [] }))
+		const fakeParts = partIds.map((p) => ({ part: { _id: p } as any, usesInTransition: true, pieces: [] }))
 		getOrderedPartsAfterPlayheadMock.mockReturnValueOnce(fakeParts.map((p) => p.part))
 
 		findLookaheadForLayerMock
@@ -261,7 +261,7 @@ describe('Lookahead', () => {
 	})
 
 	test('PartInstances translation', async () => {
-		const fakeParts = partIds.map((p) => ({ part: { _id: p } as any, pieces: [] }))
+		const fakeParts = partIds.map((p) => ({ part: { _id: p } as any, usesInTransition: true, pieces: [] }))
 		getOrderedPartsAfterPlayheadMock.mockReturnValue(fakeParts.map((p) => p.part))
 
 		// It does have assertions, but hidden inside helper methods
@@ -272,6 +272,7 @@ describe('Lookahead', () => {
 			partInstance: { _id: 'abc2', part: { _id: 'abc' } } as any,
 			nowInPart: 987,
 			pieceInstances: ['1', '2'] as any,
+			calculatedTimings: { inTransitionStart: null } as any,
 		}
 
 		const expectedPrevious = {
@@ -279,6 +280,7 @@ describe('Lookahead', () => {
 			onTimeline: true,
 			nowInPart: partInstancesInfo.previous.nowInPart,
 			allPieces: partInstancesInfo.previous.pieceInstances,
+			calculatedTimings: partInstancesInfo.previous.calculatedTimings,
 		}
 
 		// With a previous
@@ -292,12 +294,14 @@ describe('Lookahead', () => {
 			partInstance: { _id: 'curr', part: {} } as any,
 			nowInPart: 56,
 			pieceInstances: ['3', '4'] as any,
+			calculatedTimings: { inTransitionStart: null } as any,
 		}
 		const expectedCurrent = {
 			part: partInstancesInfo.current.partInstance,
 			onTimeline: true,
 			nowInPart: partInstancesInfo.current.nowInPart,
 			allPieces: partInstancesInfo.current.pieceInstances,
+			calculatedTimings: partInstancesInfo.current.calculatedTimings,
 		}
 		await runJobWithPlayoutCache(context, { playlistId }, null, async (cache) =>
 			getLookeaheadObjects(context, cache, partInstancesInfo)
@@ -309,12 +313,14 @@ describe('Lookahead', () => {
 			partInstance: { _id: 'nxt2', part: { _id: 'nxt' } } as any,
 			nowInPart: -85,
 			pieceInstances: ['5'] as any,
+			calculatedTimings: { inTransitionStart: null } as any,
 		}
 		const expectedNext = {
 			part: partInstancesInfo.next.partInstance,
 			onTimeline: false,
 			nowInPart: partInstancesInfo.next.nowInPart,
 			allPieces: partInstancesInfo.next.pieceInstances,
+			calculatedTimings: partInstancesInfo.next.calculatedTimings,
 		}
 		await runJobWithPlayoutCache(context, { playlistId }, null, async (cache) =>
 			getLookeaheadObjects(context, cache, partInstancesInfo)

--- a/packages/job-worker/src/playout/lookahead/findForLayer.ts
+++ b/packages/job-worker/src/playout/lookahead/findForLayer.ts
@@ -38,6 +38,7 @@ export function findLookaheadForLayer(
 
 		const partInfo: PartAndPieces = {
 			part: partInstanceInfo.part.part,
+			usesInTransition: partInstanceInfo.calculatedTimings.inTransitionStart !== null,
 			pieces: sortPieceInstancesByStart(partInstanceInfo.allPieces, partInstanceInfo.nowInPart),
 		}
 

--- a/packages/job-worker/src/playout/lookahead/findObjects.ts
+++ b/packages/job-worker/src/playout/lookahead/findObjects.ts
@@ -5,7 +5,7 @@ import {
 } from '@sofie-automation/blueprints-integration'
 import { PartInstanceId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { DBPart } from '@sofie-automation/corelib/dist/dataModel/Part'
-import { literal } from '@sofie-automation/corelib/dist/lib'
+import { assertNever, literal } from '@sofie-automation/corelib/dist/lib'
 import { PieceInstance } from '@sofie-automation/corelib/dist/dataModel/PieceInstance'
 import {
 	OnGenerateTimelineObjExt,
@@ -88,6 +88,24 @@ export function findLookaheadObjectsForPart(
 
 	const allObjs: Array<LookaheadTimelineObject> = []
 	for (const rawPiece of partInfo.pieces) {
+		switch (rawPiece.piece.pieceType) {
+			case IBlueprintPieceType.InTransition:
+				// Ignore if the part will not use the transition
+				if (!partInfo.usesInTransition) {
+					continue
+				}
+				break
+			case IBlueprintPieceType.OutTransition:
+				// Always ignore for now
+				continue
+			case IBlueprintPieceType.Normal:
+				// Always allow
+				break
+			default:
+				assertNever(rawPiece.piece.pieceType)
+				break
+		}
+
 		const obj = getObjectMapForPiece(rawPiece).get(layer)
 		if (obj) {
 			allObjs.push(

--- a/packages/job-worker/src/playout/lookahead/index.ts
+++ b/packages/job-worker/src/playout/lookahead/index.ts
@@ -27,6 +27,7 @@ import { prefixSingleObjectId } from '../lib'
 import { LookaheadTimelineObject } from './findObjects'
 import { hasPieceInstanceDefinitelyEnded } from '../timeline/lib'
 import { applyAndValidateOverrides } from '@sofie-automation/corelib/dist/settings/objectWithOverrides'
+import { DBPart } from '@sofie-automation/corelib/dist/dataModel/Part'
 
 const LOOKAHEAD_OBJ_PRIORITY = 0.1
 
@@ -101,6 +102,7 @@ export async function getLookeaheadObjects(
 					onTimeline: true,
 					nowInPart: partInstancesInfo0.current.nowInPart,
 					allPieces: getPrunedEndedPieceInstances(partInstancesInfo0.current),
+					calculatedTimings: partInstancesInfo0.current.calculatedTimings,
 			  })
 			: undefined,
 		partInstancesInfo0.next
@@ -109,6 +111,7 @@ export async function getLookeaheadObjects(
 					onTimeline: !!partInstancesInfo0.current?.partInstance?.part?.autoNext,
 					nowInPart: partInstancesInfo0.next.nowInPart,
 					allPieces: partInstancesInfo0.next.pieceInstances,
+					calculatedTimings: partInstancesInfo0.next.calculatedTimings,
 			  })
 			: undefined,
 	])
@@ -121,6 +124,7 @@ export async function getLookeaheadObjects(
 			onTimeline: true,
 			nowInPart: partInstancesInfo0.previous.nowInPart,
 			allPieces: getPrunedEndedPieceInstances(partInstancesInfo0.previous),
+			calculatedTimings: partInstancesInfo0.previous.calculatedTimings,
 		})
 	}
 
@@ -139,10 +143,18 @@ export async function getLookeaheadObjects(
 		}
 	}
 
-	const orderedPartInfos: Array<PartAndPieces> = orderedPartsFollowingPlayhead.map((part) => ({
-		part,
-		pieces: sortPieceInstancesByStart(piecesByPart.get(part._id) || [], 0),
-	}))
+	const orderedPartInfos: Array<PartAndPieces> = orderedPartsFollowingPlayhead.map((part, i) => {
+		const previousPart: DBPart | undefined =
+			i === 0
+				? (partInstancesInfo0.next?.partInstance ?? partInstancesInfo0.current?.partInstance)?.part
+				: orderedPartsFollowingPlayhead[i - 1]
+
+		return {
+			part,
+			usesInTransition: !previousPart?.disableNextInTransition, // aproximate, but accurate enough
+			pieces: sortPieceInstancesByStart(piecesByPart.get(part._id) || [], 0),
+		}
+	})
 
 	const span2 = context.startSpan('getLookeaheadObjects.iterate')
 	const timelineObjs: Array<TimelineObjRundown & OnGenerateTimelineObjExt> = []

--- a/packages/job-worker/src/playout/lookahead/util.ts
+++ b/packages/job-worker/src/playout/lookahead/util.ts
@@ -3,6 +3,7 @@ import { DBPart, isPartPlayable } from '@sofie-automation/corelib/dist/dataModel
 import { DBPartInstance } from '@sofie-automation/corelib/dist/dataModel/PartInstance'
 import { Piece } from '@sofie-automation/corelib/dist/dataModel/Piece'
 import { PieceInstance, PieceInstancePiece } from '@sofie-automation/corelib/dist/dataModel/PieceInstance'
+import { PartCalculatedTimings } from '@sofie-automation/corelib/dist/playout/timings'
 import { JobContext } from '../../jobs'
 import {
 	CacheForPlayout,
@@ -16,6 +17,7 @@ export interface PartInstanceAndPieceInstances {
 	onTimeline: boolean
 	nowInPart: number
 	allPieces: PieceInstance[]
+	calculatedTimings: PartCalculatedTimings
 }
 export interface PieceInstanceWithObjectMap extends PieceInstance {
 	/** Cache of objects built by findObjects. */
@@ -23,6 +25,8 @@ export interface PieceInstanceWithObjectMap extends PieceInstance {
 }
 export interface PartAndPieces {
 	part: DBPart
+	/** Whether the inTransition from this part should be considered */
+	usesInTransition: boolean
 	pieces: PieceInstanceWithObjectMap[]
 }
 

--- a/packages/job-worker/src/playout/timeline/rundown.ts
+++ b/packages/job-worker/src/playout/timeline/rundown.ts
@@ -16,11 +16,7 @@ import {
 } from '@sofie-automation/corelib/dist/dataModel/Timeline'
 import { getPartGroupId } from '@sofie-automation/corelib/dist/playout/ids'
 import { PieceInstanceWithTimings } from '@sofie-automation/corelib/dist/playout/infinites'
-import {
-	PartCalculatedTimings,
-	getPartTimingsOrDefaults,
-	calculatePartTimings,
-} from '@sofie-automation/corelib/dist/playout/timings'
+import { PartCalculatedTimings } from '@sofie-automation/corelib/dist/playout/timings'
 import { protectString, unprotectString } from '@sofie-automation/corelib/dist/protectedString'
 import { JobContext } from '../../jobs'
 import { ReadonlyDeep } from 'type-fest'
@@ -136,11 +132,6 @@ export function buildTimelineObjsForRundown(
 				  )
 				: new Map()
 
-		const currentPartInstanceTimings = getPartTimingsOrDefaults(
-			partInstancesInfo.current.partInstance,
-			partInstancesInfo.current.pieceInstances
-		)
-
 		// The startTime of this start is used as the reference point for the calculated timings, so we can use 'now' and everything will lie after this point
 		const currentPartEnable: PartEnable = { start: 'now' }
 		if (partInstancesInfo.current.partInstance.timings?.plannedStartedPlayback) {
@@ -155,7 +146,8 @@ export function buildTimelineObjsForRundown(
 		) {
 			// If there is a valid autonext out of the current part, then calculate the duration
 			currentPartEnable.duration =
-				partInstancesInfo.current.partInstance.part.expectedDuration + currentPartInstanceTimings.toPartDelay
+				partInstancesInfo.current.partInstance.part.expectedDuration +
+				partInstancesInfo.current.calculatedTimings.toPartDelay
 		}
 		const currentPartGroup = createPartGroup(partInstancesInfo.current.partInstance, currentPartEnable)
 
@@ -173,7 +165,7 @@ export function buildTimelineObjsForRundown(
 					partInstancesInfo.previous,
 					currentInfinitePieceIds,
 					timingContext,
-					currentPartInstanceTimings
+					partInstancesInfo.current.calculatedTimings
 				)
 			)
 		}
@@ -189,7 +181,7 @@ export function buildTimelineObjsForRundown(
 					timingContext,
 					infinitePiece,
 					currentTime,
-					currentPartInstanceTimings
+					partInstancesInfo.current.calculatedTimings
 				)
 			)
 		}
@@ -210,7 +202,7 @@ export function buildTimelineObjsForRundown(
 				groupClasses,
 				currentPartGroup,
 				partInstancesInfo.current.nowInPart,
-				currentPartInstanceTimings,
+				partInstancesInfo.current.calculatedTimings,
 				activePlaylist.holdState === RundownHoldState.ACTIVE,
 				partInstancesInfo.current.partInstance.part.outTransition ?? null
 			)
@@ -396,7 +388,7 @@ function generatePreviousPartInstanceObjects(
 				groupClasses,
 				previousPartGroup,
 				previousPartInfo.nowInPart,
-				getPartTimingsOrDefaults(previousPartInfo.partInstance, previousPartInfo.pieceInstances),
+				previousPartInfo.calculatedTimings,
 				activePlaylist.holdState === RundownHoldState.ACTIVE,
 				previousPartInfo.partInstance.part.outTransition ?? null
 			),
@@ -413,21 +405,11 @@ function generateNextPartInstanceObjects(
 	nextPartInfo: SelectedPartInstanceTimelineInfo,
 	timingContext: RundownTimelineTimingContext
 ): Array<TimelineObjRundown & OnGenerateTimelineObjExt> {
-	const currentToNextTimings = calculatePartTimings(
-		activePlaylist.holdState,
-		currentPartInfo.partInstance.part,
-		currentPartInfo.pieceInstances.map((p) => p.piece),
-		nextPartInfo.partInstance.part,
-		nextPartInfo.pieceInstances
-			.filter((p) => !p.infinite || p.infinite.infiniteInstanceIndex === 0)
-			.map((p) => p.piece)
-	)
-
 	const nextPartGroup = createPartGroup(nextPartInfo.partInstance, {
-		start: `#${timingContext.currentPartGroup.id}.end - ${currentToNextTimings.fromPartRemaining}`,
+		start: `#${timingContext.currentPartGroup.id}.end - ${nextPartInfo.calculatedTimings.fromPartRemaining}`,
 	})
 	timingContext.nextPartGroup = nextPartGroup
-	timingContext.nextPartOverlap = currentToNextTimings.fromPartRemaining
+	timingContext.nextPartOverlap = nextPartInfo.calculatedTimings.fromPartRemaining
 
 	const nextPieceInstances = nextPartInfo?.pieceInstances.filter(
 		(i) => !i.infinite || i.infinite.infiniteInstanceIndex === 0
@@ -450,7 +432,7 @@ function generateNextPartInstanceObjects(
 			groupClasses,
 			nextPartGroup,
 			0,
-			currentToNextTimings,
+			nextPartInfo.calculatedTimings,
 			false,
 			nextPartInfo.partInstance.part.outTransition ?? null
 		),


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bug fix

* **What is the current behavior?** (You can also link to an open issue here)

lookahead can add an timed object referencing an object in an inTransition piece that is not on the timeline

* **What is the new behavior (if this is a feature change)?**

these pieces are filtered before lookahead searches them for objects.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
