### PR TITLE
Add blueprint versions to /health endpoint (SOFIE-2177)

### DIFF
--- a/meteor/server/systemStatus/blueprintVersions.ts
+++ b/meteor/server/systemStatus/blueprintVersions.ts
@@ -1,0 +1,85 @@
+import { Blueprint } from '@sofie-automation/corelib/dist/dataModel/Blueprint'
+import { BlueprintId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { unprotectString } from '@sofie-automation/corelib/dist/protectedString'
+import { ShowStyleBase } from '../../lib/collections/ShowStyleBases'
+import { Studio } from '../../lib/collections/Studios'
+import { Blueprints, ShowStyleBases, Studios } from '../collections'
+import { getCoreSystemAsync } from '../coreSystem/collection'
+
+/**
+ * Returns the versions for all Blueprints that are in use (in Studio, System or ShowStyles)
+ */
+export async function getBlueprintVersions(): Promise<{
+	[blueprintId: string]: {
+		name: string
+		version: string
+	}
+}> {
+	const versions: {
+		[blueprintId: string]: {
+			name: string
+			version: string
+		}
+	} = {}
+
+	const pCoreSystem = getCoreSystemAsync()
+
+	const pStudios = Studios.findFetchAsync(
+		{ blueprintId: { $exists: true } },
+		{
+			fields: {
+				_id: 1,
+				blueprintId: 1,
+			},
+		}
+	) as Promise<Array<Pick<Studio, '_id' | 'blueprintId'>>>
+
+	const pShowStyleBases = ShowStyleBases.findFetchAsync(
+		{ blueprintId: { $exists: true } },
+		{
+			fields: {
+				_id: 1,
+
+				blueprintId: 1,
+			},
+		}
+	) as Promise<Array<Pick<ShowStyleBase, '_id' | 'blueprintId'>>>
+
+	// Collect Blueprint versions:
+	const blueprintIds: BlueprintId[] = []
+
+	{
+		const coreSystem = await pCoreSystem
+		if (coreSystem?.blueprintId) blueprintIds.push(coreSystem.blueprintId)
+	}
+
+	for (const studio of await pStudios) {
+		if (studio.blueprintId) blueprintIds.push(studio.blueprintId)
+	}
+
+	for (const showStyleBase of await pShowStyleBases) {
+		if (showStyleBase.blueprintId) blueprintIds.push(showStyleBase.blueprintId)
+	}
+
+	const blueprints = (await Blueprints.findFetchAsync(
+		{
+			_id: { $in: blueprintIds },
+		},
+		{
+			fields: {
+				_id: 1,
+				name: 1,
+				blueprintVersion: 1,
+			},
+		}
+	)) as Pick<Blueprint, '_id' | 'name' | 'blueprintVersion'>[]
+
+	for (const blueprint of blueprints) {
+		versions[unprotectString(blueprint._id)] = {
+			name: blueprint.name,
+			version: blueprint.blueprintVersion,
+		}
+	}
+
+	return versions
+}

--- a/meteor/server/systemStatus/systemStatus.ts
+++ b/meteor/server/systemStatus/systemStatus.ts
@@ -33,6 +33,7 @@ import { PeripheralDeviceId, StudioId } from '@sofie-automation/corelib/dist/dat
 import { ServerPeripheralDeviceAPI } from '../api/peripheralDevice'
 import { PeripheralDeviceContentWriteAccess } from '../security/peripheralDevice'
 import { MethodContext } from '../../lib/api/methods'
+import { getBlueprintVersions } from './blueprintVersions'
 
 const PackageInfo = require('../../package.json')
 const integrationVersionRange = parseCoreIntegrationCompatabilityRange(PackageInfo.version)
@@ -295,12 +296,24 @@ export async function getSystemStatus(cred0: Credentials, studioId?: StudioId): 
 		statusObj.components.push(so)
 	}
 
+	const versions: { [name: string]: string } = await RelevantSystemVersions
+
+	for (const [blueprintId, blueprint] of Object.entries(await getBlueprintVersions())) {
+		// Use the name as key to make it easier to read for a human:
+		let key = 'blueprint_' + blueprint.name
+
+		// But if the name isn't unique, append the blueprintId to make it unique:
+		if (versions[key]) key += blueprintId
+
+		versions[key] = blueprint.version
+	}
+
 	const systemStatus: StatusCode = setStatus(statusObj)
 	statusObj._internal = {
 		// statusCode: systemStatus,
 		statusCodeString: StatusCode[systemStatus],
 		messages: collectMesages(statusObj),
-		versions: await RelevantSystemVersions,
+		versions,
 	}
 	statusObj.statusMessage = statusObj._internal.messages.join(', ')
 


### PR DESCRIPTION
This PR adds the versions of currently used blueprints to the /health endpoint.

* **What is the current behavior?**
```json
{
    "name": "Sofie Automation system",
    "instanceId": "xqNyGDH6CGLJ4vAQN",
    "updated": "2023-03-10T08:31:12.884Z",
    "status": "PERFECT",
    "_status": 9000,
    "documentation": "https://github.com/nrkno/sofie-core",
    "_internal": {
        "statusCodeString": "PERFECT",
        "messages": [
        ],
        "versions": {
            "@mos-connection/helper": "3.0.1",
            "superfly-timeline": "8.3.1",
            "core": "1.49.0-in-development",
            "timeline-state-resolver-types": "8.0.0-nightly-release49-20230222-082434-b08fa0305.0"
        }
    },
    "checks": []
}
```


* **What is the new behavior?**
```json
{
    "name": "Sofie Automation system",
    "instanceId": "xqNyGDH6CGLJ4vAQN",
    "updated": "2023-03-10T08:31:12.884Z",
    "status": "PERFECT",
    "_status": 9000,
    "documentation": "https://github.com/nrkno/sofie-core",
    "_internal": {
        "statusCodeString": "PERFECT",
        "messages": [
        ],
        "versions": {
            "@mos-connection/helper": "3.0.1",
            "superfly-timeline": "8.3.1",
            "core": "1.49.0-in-development",
            "timeline-state-resolver-types": "8.0.0-nightly-release49-20230222-082434-b08fa0305.0",
            "blueprint_rk5-rk6-showstyle": "1.41.5+r41.5",
            "blueprint_rk5-rk6-studio": "1.41.5+r41.5",
            "blueprint_rk5-rk6-showstylerk5-rk6-showstyle": "1.41.5+r41.5",
            "blueprint_rk5-rk6-studiork5-rk6-studio": "1.41.5+r41.5",
            "blueprint_system": "1.41.5+r41.5"
        }
    },
    "checks": []
}
```

