### PR TITLE
fix: media format error translation data

### DIFF
--- a/meteor/lib/mediaObjects.ts
+++ b/meteor/lib/mediaObjects.ts
@@ -599,7 +599,7 @@ function checkStreamFormatsAndCounts(
 						status: PieceStatusCode.SOURCE_BROKEN,
 						message: generateTranslation('{{sourceLayer}} has the wrong format: {{format}}', {
 							sourceLayer: sourceLayer.name,
-							deepScanFormat,
+							format: deepScanFormat,
 						}),
 					})
 				}


### PR DESCRIPTION
This PR is being opened on behalf of TV 2 Norway.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

In the Sofie GUI, messages using this translation render with `{{format}}` visible.

* **What is the new behavior (if this is a feature change)?**

Instead of printing `{{format}}`, the actual intended data is printed.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
