### PR TITLE
fix: avoid name clash in FFProbeDeepScan types which caused unintended and inaccurate type recursion

### DIFF
--- a/packages/shared-lib/src/package-manager/packageInfo.ts
+++ b/packages/shared-lib/src/package-manager/packageInfo.ts
@@ -18,7 +18,7 @@ export namespace PackageInfo {
 	}
 	export interface FFProbeDeepScan extends Base {
 		type: Type.DEEPSCAN
-		payload: FFProbeDeepScan
+		payload: FFProbeDeepScanInfo
 	}
 	export interface FFOther extends Base {
 		// placeholder
@@ -120,7 +120,7 @@ export namespace PackageInfo {
 		}
 	}
 
-	export interface FFProbeDeepScan {
+	export interface FFProbeDeepScanInfo {
 		field_order?: FieldOrder
 		/** Timestamps (in seconds) for when scene-changes are detected */
 		scenes?: number[]


### PR DESCRIPTION
This PR is being opened on behalf of TV 2 Norway.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

The types for `FFProbeDeepScan` unintentionally recurse.

* **What is the new behavior (if this is a feature change)?**

The conflicting interface has been renamed and the `payload` property on `FFProbeDeepScan` updated to point to the renamed interface, instead of itself.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
