### PR TITLE
fix: Package Manager API custom Side-effect

### DIFF
--- a/packages/shared-lib/src/package-manager/package.ts
+++ b/packages/shared-lib/src/package-manager/package.ts
@@ -68,6 +68,9 @@ export namespace ExpectedPackage {
 			/** Which container thumbnails are to be put into */
 			thumbnailContainerId?: string | null // null is used to disable the sideEffect
 			thumbnailPackageSettings?: SideEffectThumbnailSettings
+
+			/** Other custom configuration */
+			[key: string]: any
 		}
 	}
 	export interface SideEffectPreviewSettings {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

The shared-lib restricts the properties one can set on the `sideEffect` property of an `ExpectedPackage`.

* **What is the new behavior (if this is a feature change)?**

The `sideEffect` property has _known_ properties, but allows the blueprints to specify custom ones, that can, at will, be supported by Package Manager. This uncouples Package Manager from Sofie Core and allows Blueprints to make use of new features in Package Manager, without involving Core, at the expense of lack of strong types.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
