### PR TITLE
chore: Removed the "Clip: " filename label from hover pop-ups for clips.

### DIFF
--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -2668,11 +2668,12 @@ svg.icon {
 		text-align: center;
 		border-radius: 1em;
 		font-size: 0.9em;
+		letter-spacing:	-0.05em;
 		position: relative;
 		top: -0.3em;
 		left: -0.3em;
 		white-space: nowrap;
-		padding: 0 2px 0 0.3em;
+		padding: 0 0.2em 0 0.2em;
 	}
 
 	> svg.type-warning + .segment-timeline__title__notes__count {
@@ -2838,31 +2839,33 @@ svg.icon {
 	}
 
 	&.segment-timeline__mini-inspector--notice {
-		padding-left: 3.5em;
+		padding-left: 2.7em;
+		padding-bottom:	0.4em;
 	}
 
 	> .segment-timeline__mini-inspector__notice-header {
 		position: absolute;
 		top: 0;
 		left: 0;
-		width: 2.5em;
+		width: 1.8em;
 		bottom: 0;
 		border-top-left-radius: inherit;
 		border-bottom-left-radius: inherit;
 
 		> svg {
 			position: relative;
-			top: 0.6em;
-			left: 0.5em;
+			top: 0.4em;
+			left: 0.2em;
 			filter: drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.3));
-			width: 1.7em;
-			height: 1.7em;
+			width: 1.5em;
+			height: 1.5em;
 		}
 	}
 
 	> .segment-timeline__mini-inspector__notice + .segment-timeline__mini-inspector__properties {
+		color:#999999;
 		margin-top: 0.5em;
-		padding-top: 0.5em;
+		padding-top: 0.2em;
 		border-top: 1px solid #333;
 	}
 
@@ -3025,13 +3028,16 @@ svg.icon {
 	}
 	.mini-inspector__label {
 		font-weight: 200;
-		font-size: 0.9em;
+		font-size: 0.8em;
+		letter-spacing:	0.05em;
 		text-transform: capitalize;
 		padding-right: 0.5em;
 	}
 	.mini-inspector__value {
-		font-weight: 300;
-		font-size: 0.9em;
+		font-weight: 200;
+		font-size: 0.8em;
+		letter-spacing:	0em;
+		line-height: 80%;
 		max-width: 60vw;
 		overflow: hidden;
 		text-overflow: ellipsis;

--- a/meteor/client/ui/FloatingInspectors/VTFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/VTFloatingInspector.tsx
@@ -148,7 +148,6 @@ export const VTFloatingInspector: React.FC<IProps> = ({
 			{showMiniInspectorNotice && noticeLevel && renderNotice(t, noticeLevel, noticeMessages)}
 			{showMiniInspectorClipData && (
 				<div className="segment-timeline__mini-inspector__properties">
-					<span className="mini-inspector__label">{t('Clip:')}</span>
 					<span className="mini-inspector__value">{content?.fileName}</span>
 				</div>
 			)}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Styling tweaks for improved usability.


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**
Removed the "Clip: " filename label from hover pop-ups for clips.
Restyled the clip filename text to be less prominent.
Made the hover pop-ups slightly more space-optimized by shrinking the the pop-up's icon and tightening some margins.
Tweaked the segment header notice counter so that it looks better with multi-digit numbers. Tweaked the same counter's background to appear more circular.


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
