### PR TITLE
feat: report inability to remove rundown to the caller SOFIE-1131

### DIFF
--- a/meteor/lib/api/rundown.ts
+++ b/meteor/lib/api/rundown.ts
@@ -1,5 +1,4 @@
-import { RundownId, RundownPlaylistId } from '@sofie-automation/corelib/dist/dataModel/Ids'
-import { ReloadRundownPlaylistResponse, TriggerReloadDataResponse } from './userActions'
+import { RundownPlaylistId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 
 export interface RundownPlaylistValidateBlueprintConfigResult {
 	studio: string[]
@@ -12,25 +11,13 @@ export interface RundownPlaylistValidateBlueprintConfigResult {
 }
 
 export interface NewRundownAPI {
-	resyncRundownPlaylist(playlistId: RundownPlaylistId): Promise<ReloadRundownPlaylistResponse>
 	rundownPlaylistNeedsResync(playlistId: RundownPlaylistId): Promise<string[]>
 	rundownPlaylistValidateBlueprintConfig(
 		playlistId: RundownPlaylistId
 	): Promise<RundownPlaylistValidateBlueprintConfigResult>
-	removeRundown(rundownId: RundownId): Promise<void>
-	resyncRundown(rundownId: RundownId): Promise<TriggerReloadDataResponse>
-	unsyncRundown(rundownId: RundownId): Promise<void>
 }
 
 export enum RundownAPIMethods {
-	'removeRundownPlaylist' = 'rundown.removeRundownPlaylist',
-	'resyncRundownPlaylist' = 'rundown.resyncRundownPlaylist',
 	'rundownPlaylistNeedsResync' = 'rundown.rundownPlaylistNeedsResync',
 	'rundownPlaylistValidateBlueprintConfig' = 'rundown.rundownPlaylistValidateBlueprintConfig',
-
-	'removeRundown' = 'rundown.removeRundown',
-	'resyncRundown' = 'rundown.resyncRundown',
-	'unsyncRundown' = 'rundown.unsyncRundown',
-	'moveRundown' = 'rundown.moveRundown',
-	'restoreRundownsInPlaylistToDefaultOrder' = 'rundown.restoreRundownsInPlaylistToDefaultOrder',
 }

--- a/meteor/server/api/ingest/actions.ts
+++ b/meteor/server/api/ingest/actions.ts
@@ -13,15 +13,17 @@ export namespace IngestActions {
 	/**
 	 * Trigger a reload of a rundown
 	 */
-	export async function reloadRundown(rundown: Rundown): Promise<TriggerReloadDataResponse> {
-		const device = getPeripheralDeviceFromRundown(rundown)
+	export async function reloadRundown(
+		rundown: Pick<Rundown, '_id' | 'studioId' | 'externalId' | 'peripheralDeviceId'>
+	): Promise<TriggerReloadDataResponse> {
+		const device = await getPeripheralDeviceFromRundown(rundown)
 
-		// TODO: refacor this into something nicer perhaps?
+		// The Rundown.orphaned flag will be reset by the response update
+
+		// TODO: refactor this into something nicer perhaps?
 		if (device.type === PeripheralDeviceType.MOS) {
 			return MOSDeviceActions.reloadRundown(device, rundown)
-		} else if (device.type === PeripheralDeviceType.SPREADSHEET) {
-			return GenericDeviceActions.reloadRundown(device, rundown)
-		} else if (device.type === PeripheralDeviceType.INEWS) {
+		} else if (device.type === PeripheralDeviceType.SPREADSHEET || device.type === PeripheralDeviceType.INEWS) {
 			return GenericDeviceActions.reloadRundown(device, rundown)
 		} else {
 			throw new Meteor.Error(400, `The device ${device._id} does not support the method "reloadRundown"`)

--- a/meteor/server/api/ingest/genericDevice/actions.ts
+++ b/meteor/server/api/ingest/genericDevice/actions.ts
@@ -14,7 +14,7 @@ import { DEFAULT_NRCS_TIMEOUT_TIME } from '@sofie-automation/shared-lib/dist/cor
 export namespace GenericDeviceActions {
 	export async function reloadRundown(
 		peripheralDevice: PeripheralDevice,
-		rundown: Rundown
+		rundown: Pick<Rundown, '_id' | 'studioId' | 'externalId'>
 	): Promise<TriggerReloadDataResponse> {
 		logger.info('reloadRundown ' + rundown._id)
 

--- a/meteor/server/api/ingest/lib.ts
+++ b/meteor/server/api/ingest/lib.ts
@@ -112,11 +112,13 @@ export async function fetchStudioIdFromDevice(peripheralDevice: PeripheralDevice
 	span?.end()
 	return studioId
 }
-export function getPeripheralDeviceFromRundown(rundown: Rundown): PeripheralDevice {
+export async function getPeripheralDeviceFromRundown(
+	rundown: Pick<Rundown, '_id' | 'peripheralDeviceId'>
+): Promise<PeripheralDevice> {
 	if (!rundown.peripheralDeviceId)
 		throw new Meteor.Error(500, `Rundown "${rundown._id}" does not have a peripheralDeviceId`)
 
-	const device = PeripheralDevices.findOne(rundown.peripheralDeviceId)
+	const device = await PeripheralDevices.findOneAsync(rundown.peripheralDeviceId)
 	if (!device)
 		throw new Meteor.Error(
 			404,

--- a/meteor/server/api/rundown.ts
+++ b/meteor/server/api/rundown.ts
@@ -49,7 +49,7 @@ export namespace ServerRundownAPI {
 			rundowns.map(async (rundown) => {
 				return {
 					rundownId: rundown._id,
-					response: await innerResyncRundown(rundown),
+					response: await IngestActions.reloadRundown(rundown),
 				}
 			})
 		)
@@ -59,11 +59,8 @@ export namespace ServerRundownAPI {
 		}
 	}
 
-	export async function innerResyncRundown(rundown: Rundown): Promise<TriggerReloadDataResponse> {
-		logger.info('resyncRundown ' + rundown._id)
-
-		// Orphaned flag will be reset by the response update
-		return IngestActions.reloadRundown(rundown)
+	export async function resyncRundown(access: VerifiedRundownContentAccess): Promise<TriggerReloadDataResponse> {
+		return IngestActions.reloadRundown(access.rundown)
 	}
 }
 

--- a/meteor/server/api/rundown.ts
+++ b/meteor/server/api/rundown.ts
@@ -16,16 +16,11 @@ import { findMissingConfigs } from './blueprints/config'
 import { runIngestOperation } from './ingest/lib'
 import { createShowStyleCompound } from './showStyles'
 import { IngestJobs } from '@sofie-automation/corelib/dist/worker/ingest'
-import {
-	checkAccessToPlaylist,
-	checkAccessToRundown,
-	VerifiedRundownContentAccess,
-	VerifiedRundownPlaylistContentAccess,
-} from './lib'
+import { VerifiedRundownContentAccess, VerifiedRundownPlaylistContentAccess } from './lib'
 import { Blueprint } from '../../lib/collections/Blueprints'
 import { Studio } from '../../lib/collections/Studios'
 import { applyAndValidateOverrides } from '@sofie-automation/corelib/dist/settings/objectWithOverrides'
-import { RundownId, RundownPlaylistId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { RundownPlaylistId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { Blueprints, Rundowns, ShowStyleBases, ShowStyleVariants, Studios } from '../collections'
 import { normalizeArrayToMap } from '@sofie-automation/corelib/dist/lib'
 
@@ -71,6 +66,7 @@ export namespace ServerRundownAPI {
 		return IngestActions.reloadRundown(rundown)
 	}
 }
+
 export namespace ClientRundownAPI {
 	export async function rundownPlaylistNeedsResync(
 		context: MethodContext,
@@ -256,29 +252,11 @@ export namespace ClientRundownAPI {
 }
 
 class ServerRundownAPIClass extends MethodContextAPI implements NewRundownAPI {
-	async resyncRundownPlaylist(playlistId: RundownPlaylistId) {
-		check(playlistId, String)
-		const access = await checkAccessToPlaylist(this, playlistId)
-
-		return ServerRundownAPI.resyncRundownPlaylist(access)
-	}
 	async rundownPlaylistNeedsResync(playlistId: RundownPlaylistId) {
 		return ClientRundownAPI.rundownPlaylistNeedsResync(this, playlistId)
 	}
 	async rundownPlaylistValidateBlueprintConfig(playlistId: RundownPlaylistId) {
 		return ClientRundownAPI.rundownPlaylistValidateBlueprintConfig(this, playlistId)
-	}
-	async removeRundown(rundownId: RundownId) {
-		const access = await checkAccessToRundown(this, rundownId)
-		return ServerRundownAPI.removeRundown(access)
-	}
-	async resyncRundown(rundownId: RundownId) {
-		const access = await checkAccessToRundown(this, rundownId)
-		return ServerRundownAPI.innerResyncRundown(access.rundown)
-	}
-	async unsyncRundown(rundownId: RundownId) {
-		const access = await checkAccessToRundown(this, rundownId)
-		return ServerRundownAPI.unsyncRundown(access)
 	}
 }
 registerClassToMeteorMethods(RundownAPIMethods, ServerRundownAPIClass, false)

--- a/meteor/server/api/rundown.ts
+++ b/meteor/server/api/rundown.ts
@@ -1,7 +1,6 @@
 import { Meteor } from 'meteor/meteor'
 import * as _ from 'underscore'
 import { check } from '../../lib/check'
-import { Rundown } from '../../lib/collections/Rundowns'
 import { logger } from '../logging'
 import { registerClassToMeteorMethods } from '../methods'
 import { NewRundownAPI, RundownAPIMethods, RundownPlaylistValidateBlueprintConfigResult } from '../../lib/api/rundown'

--- a/meteor/server/api/userActions.ts
+++ b/meteor/server/api/userActions.ts
@@ -718,7 +718,7 @@ class ServerUserActionAPI
 			'resyncRundown',
 			[rundownId],
 			async (access) => {
-				return ServerRundownAPI.innerResyncRundown(access.rundown)
+				return ServerRundownAPI.resyncRundown(access)
 			}
 		)
 	}

--- a/packages/corelib/src/error.ts
+++ b/packages/corelib/src/error.ts
@@ -45,6 +45,7 @@ export enum UserErrorMessage {
 	DisableNoPieceFound = 30,
 	TakeBlockedDuration = 31,
 	TakeFromIncorrectPart = 32,
+	RundownRemoveWhileActive = 33,
 }
 
 const UserErrorMessagesTranslations: { [key in UserErrorMessage]: string } = {
@@ -89,6 +90,7 @@ const UserErrorMessagesTranslations: { [key in UserErrorMessage]: string } = {
 	[UserErrorMessage.DisableNoPieceFound]: t(`Found no future pieces`),
 	[UserErrorMessage.TakeBlockedDuration]: t(`Cannot perform take for {{duration}}ms`),
 	[UserErrorMessage.TakeFromIncorrectPart]: t(`Ignoring take as playing part has changed since TAKE was requested.`),
+	[UserErrorMessage.RundownRemoveWhileActive]: t(`Cannot remove the rundown "{{name}}" while it is on-air.`),
 }
 
 export class UserError {

--- a/packages/job-worker/src/ingest/__tests__/ingest.test.ts
+++ b/packages/job-worker/src/ingest/__tests__/ingest.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/unbound-method */
+import '../../__mocks__/_extendJest'
 import {
 	IBlueprintPiece,
 	IngestPart,
@@ -45,6 +46,7 @@ import { protectString } from '@sofie-automation/corelib/dist/protectedString'
 import { innerStartQueuedAdLib } from '../../playout/adlibUtils'
 import { IngestJobs, RemoveOrphanedSegmentsProps } from '@sofie-automation/corelib/dist/worker/ingest'
 import { removeRundownPlaylistFromDb } from './lib'
+import { UserErrorMessage } from '@sofie-automation/corelib/dist/error'
 
 require('../../peripheralDevice.ts') // include in order to create the Meteor methods needed
 
@@ -1642,10 +1644,12 @@ describe('Test ingest actions for rundowns and segments', () => {
 			})
 			await expect(getRundownOrphaned()).resolves.toBeUndefined()
 
-			await handleRemovedRundown(context, {
-				peripheralDeviceId: device2._id,
-				rundownExternalId: rundownData.externalId,
-			})
+			await expect(
+				handleRemovedRundown(context, {
+					peripheralDeviceId: device2._id,
+					rundownExternalId: rundownData.externalId,
+				})
+			).rejects.toMatchUserError(UserErrorMessage.RundownRemoveWhileActive)
 			await expect(getRundownOrphaned()).resolves.toEqual('deleted')
 
 			await resyncRundown()

--- a/packages/job-worker/src/ingest/ingestRundownJobs.ts
+++ b/packages/job-worker/src/ingest/ingestRundownJobs.ts
@@ -15,6 +15,7 @@ import {
 	UserRemoveRundownProps,
 	UserUnsyncRundownProps,
 } from '@sofie-automation/corelib/dist/worker/ingest'
+import { UserError, UserErrorMessage } from '@sofie-automation/corelib/dist/error'
 
 /**
  * Attempt to remove a rundown, or orphan it
@@ -30,11 +31,15 @@ export async function handleRemovedRundown(context: JobContext, data: IngestRemo
 		async (_context, cache) => {
 			const rundown = getRundown(cache)
 
+			const canRemove = data.forceDelete || canRundownBeUpdated(rundown, false)
+			if (!canRemove) throw UserError.create(UserErrorMessage.RundownRemoveWhileActive, { name: rundown.name })
+
 			return literal<CommitIngestData>({
 				changedSegmentIds: [],
 				removedSegmentIds: [],
 				renamedSegments: new Map(),
-				removeRundown: data.forceDelete || canRundownBeUpdated(rundown, false),
+				removeRundown: true,
+				returnRemoveFailure: true,
 			})
 		}
 	)

--- a/packages/job-worker/src/ingest/lock.ts
+++ b/packages/job-worker/src/ingest/lock.ts
@@ -11,6 +11,7 @@ import { IngestPropsBase } from '@sofie-automation/corelib/dist/worker/ingest'
 import { DBRundown } from '@sofie-automation/corelib/dist/dataModel/Rundown'
 import { RundownLock } from '../jobs/lock'
 import { groupByToMap } from '@sofie-automation/corelib/dist/lib'
+import { UserError } from '@sofie-automation/corelib/dist/error'
 
 /**
  * The result of the initial stage of an Ingest operation
@@ -30,6 +31,9 @@ export interface CommitIngestData {
 
 	/** Set to true if the rundown should be removed or orphaned */
 	removeRundown: boolean
+
+	/** Whether to return an error if the rundown is unable to be removed */
+	returnRemoveFailure?: boolean
 }
 
 export enum UpdateIngestRundownAction {
@@ -90,6 +94,8 @@ export async function runIngestJob(
 		// Start saving the ingest data
 		const pSaveIngestChanges = ingestObjCache.saveToDatabase()
 
+		let resultingError: UserError | void
+
 		try {
 			const ingestCache = await pIngestCache
 
@@ -104,7 +110,13 @@ export async function runIngestJob(
 			if (commitData) {
 				const span = context.startSpan('ingest.commit')
 				// The change is accepted. Perform some playout calculations and save it all
-				await CommitIngestOperation(context, ingestCache, beforeRundown, beforePartMap, commitData)
+				resultingError = await CommitIngestOperation(
+					context,
+					ingestCache,
+					beforeRundown,
+					beforePartMap,
+					commitData
+				)
 				span?.end()
 			} else {
 				// Should be no changes
@@ -116,6 +128,8 @@ export async function runIngestJob(
 
 			span?.end()
 		}
+
+		if (resultingError) throw resultingError
 	})
 }
 

--- a/packages/job-worker/src/ingest/mosDevice/__tests__/mosIngest.test.ts
+++ b/packages/job-worker/src/ingest/mosDevice/__tests__/mosIngest.test.ts
@@ -35,6 +35,7 @@ import { removeRundownPlaylistFromDb } from '../../__tests__/lib'
 
 jest.mock('../../updateNext')
 import { ensureNextPartIsValid } from '../../updateNext'
+import { UserErrorMessage } from '@sofie-automation/corelib/dist/error'
 type TensureNextPartIsValid = jest.MockedFunction<typeof ensureNextPartIsValid>
 const ensureNextPartIsValidMock = ensureNextPartIsValid as TensureNextPartIsValid
 
@@ -246,10 +247,12 @@ describe('Test recieved mos ingest payloads', () => {
 		expect(rundown).toBeTruthy()
 		expect(await context.directCollections.RundownPlaylists.findOne(rundown.playlistId)).toBeTruthy()
 
-		await handleRemovedRundown(context, {
-			peripheralDeviceId: device._id,
-			rundownExternalId: parseMosString(roData.ID),
-		})
+		await expect(
+			handleRemovedRundown(context, {
+				peripheralDeviceId: device._id,
+				rundownExternalId: parseMosString(roData.ID),
+			})
+		).rejects.toMatchUserError(UserErrorMessage.RundownRemoveWhileActive)
 
 		expect(
 			await context.directCollections.Rundowns.findOne({


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

* **What is the current behavior?** (You can also link to an open issue here)

When the user clicks delete for a Rundown in the Lobby, if the Rundown is active the delete will fail and no failure is reported to the user.

* **What is the new behavior (if this is a feature change)?**

An error message will be shown when the delete fails.  
This will be shown when the rundown is either already orphaned, or when the rundown transitions into being orphaned

![Screenshot from 2023-03-20 15-33-12](https://user-images.githubusercontent.com/1327476/226394543-7a646e13-8f7f-4dab-a126-86e4480850e3.png)


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
