### PR TITLE
chore: add waituntil() function for use in unit tests

### DIFF
--- a/meteor/__mocks__/helpers/jest.ts
+++ b/meteor/__mocks__/helpers/jest.ts
@@ -61,4 +61,39 @@ export async function runTimersUntilNow(): Promise<void> {
 	}
 }
 
+/** Returns a Promise that resolves after a speficied number of milliseconds */
+export function waitTime(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms))
+}
+/**
+ * Executes {expectFcn} intermittently until it doesn't throw anymore.
+ * Waits up to {maxWaitTime} ms, then throws the latest error.
+ * Useful in unit-tests as a way to wait until a predicate is fulfilled.
+ * Example usage:
+ * ```
+ * const myArray = []
+ * asynchoronouslyPopulateArray(myArray)
+ * await waitUntil(() => {
+ *   expect(myArray).toHaveLength(42)
+ * }, 500)
+ * ```
+ */
+export async function waitUntil(expectFcn: () => void, maxWaitTime: number): Promise<void> {
+	/** How often to check expectFcn() */
+	const iterateInterval = maxWaitTime < 100 ? 10 : 100
+
+	const startTime = Date.now()
+	while (true) {
+		await waitTime(iterateInterval)
+		try {
+			expectFcn()
+			return
+		} catch (err) {
+			let waitedTime = Date.now() - startTime
+			if (waitedTime > maxWaitTime) throw err
+			// else ignore error and try again later
+		}
+	}
+}
+
 // testInFiber.only = testInFiberOnly

--- a/meteor/__mocks__/helpers/jest.ts
+++ b/meteor/__mocks__/helpers/jest.ts
@@ -62,7 +62,7 @@ export async function runTimersUntilNow(): Promise<void> {
 }
 
 /** Returns a Promise that resolves after a speficied number of milliseconds */
-export function waitTime(ms: number): Promise<void> {
+export async function waitTime(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms))
 }
 /**
@@ -83,13 +83,14 @@ export async function waitUntil(expectFcn: () => void, maxWaitTime: number): Pro
 	const iterateInterval = maxWaitTime < 100 ? 10 : 100
 
 	const startTime = Date.now()
+	// eslint-disable-next-line no-constant-condition
 	while (true) {
 		await waitTime(iterateInterval)
 		try {
 			expectFcn()
 			return
 		} catch (err) {
-			let waitedTime = Date.now() - startTime
+			const waitedTime = Date.now() - startTime
 			if (waitedTime > maxWaitTime) throw err
 			// else ignore error and try again later
 		}

--- a/meteor/server/api/__tests__/userActions/mediaManager.test.ts
+++ b/meteor/server/api/__tests__/userActions/mediaManager.test.ts
@@ -1,5 +1,5 @@
 import '../../../../__mocks__/_extendJest'
-import { testInFiber } from '../../../../__mocks__/helpers/jest'
+import { testInFiber, waitUntil } from '../../../../__mocks__/helpers/jest'
 import { getCurrentTime, getRandomId, protectString } from '../../../../lib/lib'
 import { setupDefaultStudioEnvironment, DefaultEnvironment } from '../../../../__mocks__/helpers/database'
 import { MeteorCall } from '../../../../lib/api/methods'
@@ -8,6 +8,8 @@ import { MediaWorkFlows, PeripheralDeviceCommands, PeripheralDevices } from '../
 
 require('../../client') // include in order to create the Meteor methods needed
 require('../../userActions') // include in order to create the Meteor methods needed
+
+const MAX_WAIT_TIME = 300
 
 describe('User Actions - Media Manager', () => {
 	let env: DefaultEnvironment
@@ -53,12 +55,7 @@ describe('User Actions - Media Manager', () => {
 
 		{
 			// should execute function on the target device
-			let pResolve
-			const p = new Promise((resolve) => {
-				pResolve = resolve
-			})
-
-			setTimeout(() => {
+			const p = waitUntil(() => {
 				const functionCall = PeripheralDeviceCommands.find({
 					deviceId: env.ingestDevice._id,
 					functionName: 'restartWorkflow',
@@ -70,8 +67,7 @@ describe('User Actions - Media Manager', () => {
 						reply: 'done',
 					},
 				})
-				pResolve()
-			}, 50)
+			}, MAX_WAIT_TIME)
 
 			await MeteorCall.userAction.mediaRestartWorkflow('', getCurrentTime(), workFlowId)
 			await p
@@ -87,12 +83,8 @@ describe('User Actions - Media Manager', () => {
 
 		{
 			// should execute function on the target device
-			let pResolve
-			const p = new Promise((resolve) => {
-				pResolve = resolve
-			})
 
-			setTimeout(() => {
+			const p = waitUntil(() => {
 				const functionCall = PeripheralDeviceCommands.find({
 					deviceId: env.ingestDevice._id,
 					functionName: 'abortWorkflow',
@@ -104,8 +96,7 @@ describe('User Actions - Media Manager', () => {
 						reply: 'done',
 					},
 				})
-				pResolve()
-			}, 50)
+			}, MAX_WAIT_TIME)
 
 			await MeteorCall.userAction.mediaAbortWorkflow('', getCurrentTime(), workFlowId)
 			await p
@@ -121,12 +112,7 @@ describe('User Actions - Media Manager', () => {
 
 		{
 			// should execute function on the target device
-			let pResolve
-			const p = new Promise((resolve) => {
-				pResolve = resolve
-			})
-
-			setTimeout(() => {
+			const p = waitUntil(() => {
 				const functionCall = PeripheralDeviceCommands.find({
 					deviceId: env.ingestDevice._id,
 					functionName: 'prioritizeWorkflow',
@@ -138,8 +124,7 @@ describe('User Actions - Media Manager', () => {
 						reply: 'done',
 					},
 				})
-				pResolve()
-			}, 50)
+			}, MAX_WAIT_TIME)
 
 			await MeteorCall.userAction.mediaPrioritizeWorkflow('', getCurrentTime(), workFlowId)
 			await p
@@ -150,7 +135,7 @@ describe('User Actions - Media Manager', () => {
 
 		{
 			// should execute function on all the target devices
-			setTimeout(() => {
+			const p = waitUntil(() => {
 				const functionCalls = PeripheralDeviceCommands.find({
 					functionName: 'restartAllWorkflows',
 				}).fetch()
@@ -161,9 +146,10 @@ describe('User Actions - Media Manager', () => {
 						reply: 'done',
 					},
 				})
-			}, 50)
+			}, MAX_WAIT_TIME)
 
 			await MeteorCall.userAction.mediaRestartAllWorkflows('', getCurrentTime())
+			await p
 		}
 	})
 	testInFiber('Abort all workflows', async () => {
@@ -171,7 +157,7 @@ describe('User Actions - Media Manager', () => {
 
 		{
 			// should execute function on all the target devices
-			setTimeout(() => {
+			const p = waitUntil(() => {
 				const functionCalls = PeripheralDeviceCommands.find({
 					functionName: 'abortAllWorkflows',
 				}).fetch()
@@ -182,9 +168,10 @@ describe('User Actions - Media Manager', () => {
 						reply: 'done',
 					},
 				})
-			}, 50)
+			}, MAX_WAIT_TIME)
 
 			await MeteorCall.userAction.mediaAbortAllWorkflows('', getCurrentTime())
+			await p
 		}
 	})
 })


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Add `waituntil()` function, for use in tests


* **What is the current behavior?** (You can also link to an open issue here)
Sometimes tests fail randomly, [such as this one](https://github.com/nrkno/sofie-core/actions/runs/4490302734/jobs/7897200526), because they are dependent on time, and the tests run slow sometimes in CI.


* **What is the new behavior (if this is a feature change)?**
CI tests are more roboust. `waituntil` runs the test preducate multiple times until it passes (or times out).


