### PR TITLE
Fix: out of sync playhead countdown

### DIFF
--- a/meteor/client/lib/__tests__/rundownTiming.test.ts
+++ b/meteor/client/lib/__tests__/rundownTiming.test.ts
@@ -107,6 +107,7 @@ describe('rundown Timing Calculator', () => {
 		)
 		expect(result).toEqual(
 			literal<RundownTimingContext>({
+				currentPartInstanceId: null,
 				isLowResolution: false,
 				asDisplayedPlaylistDuration: 0,
 				asPlayedPlaylistDuration: 0,
@@ -168,6 +169,7 @@ describe('rundown Timing Calculator', () => {
 		)
 		expect(result).toEqual(
 			literal<RundownTimingContext>({
+				currentPartInstanceId: null,
 				isLowResolution: false,
 				asDisplayedPlaylistDuration: 4000,
 				asPlayedPlaylistDuration: 4000,
@@ -268,6 +270,7 @@ describe('rundown Timing Calculator', () => {
 		)
 		expect(result).toEqual(
 			literal<RundownTimingContext>({
+				currentPartInstanceId: null,
 				isLowResolution: false,
 				asDisplayedPlaylistDuration: 4000,
 				asPlayedPlaylistDuration: 4000,
@@ -370,6 +373,7 @@ describe('rundown Timing Calculator', () => {
 		)
 		expect(result).toEqual(
 			literal<RundownTimingContext>({
+				currentPartInstanceId: null,
 				isLowResolution: false,
 				asDisplayedPlaylistDuration: 4000,
 				asPlayedPlaylistDuration: 4000,
@@ -496,6 +500,7 @@ describe('rundown Timing Calculator', () => {
 		)
 		expect(result).toEqual(
 			literal<RundownTimingContext>({
+				currentPartInstanceId: null,
 				isLowResolution: false,
 				asDisplayedPlaylistDuration: 4000,
 				asPlayedPlaylistDuration: 4000,
@@ -611,6 +616,7 @@ describe('rundown Timing Calculator', () => {
 		)
 		expect(result).toEqual(
 			literal<RundownTimingContext>({
+				currentPartInstanceId: null,
 				isLowResolution: false,
 				asDisplayedPlaylistDuration: 4000,
 				asPlayedPlaylistDuration: 8000,

--- a/meteor/client/lib/rundownTiming.ts
+++ b/meteor/client/lib/rundownTiming.ts
@@ -605,6 +605,7 @@ export class RundownTimingCalculator {
 		}
 
 		return literal<RundownTimingContext>({
+			currentPartInstanceId: playlist?.currentPartInstanceId,
 			totalPlaylistDuration: totalRundownDuration,
 			remainingPlaylistDuration: remainingRundownDuration,
 			asDisplayedPlaylistDuration: asDisplayedRundownDuration,
@@ -692,6 +693,8 @@ export class RundownTimingCalculator {
 }
 
 export interface RundownTimingContext {
+	/** This stores the part instance that was active when this timing information was generated. */
+	currentPartInstanceId?: PartInstanceId | null
 	/** This is the total duration of the playlist as planned (using expectedDurations). */
 	totalPlaylistDuration?: number
 	/** This is the content remaining to be played in the playlist (based on the expectedDurations).  */

--- a/meteor/client/lib/rundownTiming.ts
+++ b/meteor/client/lib/rundownTiming.ts
@@ -598,7 +598,7 @@ export class RundownTimingCalculator {
 			}
 
 			remainingTimeOnCurrentPart = lastStartedPlayback
-				? now - (lastStartedPlayback + onAirPartDuration)
+				? now - (Math.min(lastStartedPlayback, now) + onAirPartDuration)
 				: onAirPartDuration * -1
 
 			currentPartWillAutoNext = !!(currentLivePart.autoNext && currentLivePart.expectedDuration)

--- a/meteor/client/ui/RundownView/RundownTiming/CurrentPartRemaining.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming/CurrentPartRemaining.tsx
@@ -32,11 +32,12 @@ export const CurrentPartRemaining = withTiming<IPartRemainingProps, {}>({
 			if (!this.props.timingDurations || !this.props.timingDurations.currentTime) return null
 			if (this.props.timingDurations.currentPartInstanceId !== this.props.currentPartInstanceId) return null
 			const displayTimecode = this.props.timingDurations.remainingTimeOnCurrentPart
+			if (displayTimecode === undefined) return null
 			return (
 				<span
 					className={ClassNames(
 						this.props.className,
-						Math.floor((displayTimecode || 0) / 1000) > 0 ? this.props.heavyClassName : undefined
+						Math.floor(displayTimecode / 1000) > 0 ? this.props.heavyClassName : undefined
 					)}
 					role="timer"
 				>

--- a/meteor/client/ui/RundownView/RundownTiming/CurrentPartRemaining.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming/CurrentPartRemaining.tsx
@@ -28,7 +28,9 @@ export const CurrentPartRemaining = withTiming<IPartRemainingProps, {}>({
 	dataResolution: TimingDataResolution.Synced,
 })(
 	class CurrentPartRemaining extends React.Component<WithTiming<IPartRemainingProps>> {
-		render() {
+		render(): JSX.Element | null {
+			if (!this.props.timingDurations || !this.props.timingDurations.currentTime) return null
+			if (this.props.timingDurations.currentPartInstanceId !== this.props.currentPartInstanceId) return null
 			const displayTimecode = this.props.timingDurations.remainingTimeOnCurrentPart
 			return (
 				<span

--- a/meteor/client/ui/RundownView/RundownTiming/RundownTimingProvider.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming/RundownTimingProvider.tsx
@@ -207,12 +207,11 @@ export const RundownTimingProvider = withTracker<
 				this.dispatchLREvent(calmedDownNow)
 			}
 
-			const syncedEventTimeNow = Math.floor(now / 1000) * 1000
-			const dispatchSynced = Math.abs(syncedEventTimeNow - this.lastSyncedTime) >= 1000
+			const dispatchSynced = Math.abs(calmedDownNow - this.lastSyncedTime) >= 1000
 			if (dispatchSynced) {
-				this.lastSyncedTime = syncedEventTimeNow
-				this.updateDurations(syncedEventTimeNow, true)
-				this.dispatchSyncedEvent(syncedEventTimeNow)
+				this.lastSyncedTime = calmedDownNow
+				this.updateDurations(calmedDownNow, true)
+				this.dispatchSyncedEvent(calmedDownNow)
 			}
 
 			this.refreshDecimator++
@@ -239,6 +238,8 @@ export const RundownTimingProvider = withTracker<
 			) {
 				// empty the temporary Part Instances cache
 				this.timingCalculator.clearTempPartInstances()
+				this.refreshDecimator = 0 // Force LR update
+				this.lastSyncedTime = 0 // Force synced update
 				this.onRefreshTimer()
 			}
 		}

--- a/meteor/client/ui/RundownView/RundownTiming/RundownTimingProvider.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming/RundownTimingProvider.tsx
@@ -207,11 +207,12 @@ export const RundownTimingProvider = withTracker<
 				this.dispatchLREvent(calmedDownNow)
 			}
 
-			const dispatchSynced = Math.abs(calmedDownNow - this.lastSyncedTime) >= 1000
+			const syncedEventTimeNow = Math.floor(now / 1000) * 1000
+			const dispatchSynced = Math.abs(syncedEventTimeNow - this.lastSyncedTime) >= 1000
 			if (dispatchSynced) {
-				this.lastSyncedTime = calmedDownNow
-				this.updateDurations(calmedDownNow, true)
-				this.dispatchSyncedEvent(calmedDownNow)
+				this.lastSyncedTime = syncedEventTimeNow
+				this.updateDurations(syncedEventTimeNow, true)
+				this.dispatchSyncedEvent(syncedEventTimeNow)
 			}
 
 			this.refreshDecimator++


### PR DESCRIPTION
This PR has been opened by SuperFly.tv on behalf of EVS Broadcast Equipment.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.


**What is the current behavior?** (You can also link to an open issue here)
When taking from one Part to another, the timing data for the previous Part lingers in the context provided by the `RundownTimingProvider` and is provided to the `CurrentPartRemaining` component. This results in the coundown continuing to display the countdown for the previous Part.


**What is the new behavior (if this is a feature change)?**
To fix this issue, two measures have been taken:
1. The `RundownTimingProvider` now reports what the `currentPartInstanceId` was when it performed the timing calculation as part of the `RundownTimingContext` object that it provides. This allows the `CurrentPartRemaining` component to not render the countdown timer if the timing data that it has received is stale. This does result in the timer being briefly hidden if up-to-date timing data does not arrive quickly.
2. To that end, the `RundownTimingProvider` has been updated to force all of the timing events (LR, HR, Synced) to be emitted whenever the current or next part instances change. This results in a much shorter period of time where there is stale data, and reduces the number of frames for which the coundown is hidden while it catches up with reality. I would like to stress that it is a matter of frames - during a screen capture I was unable to see any time where the coundown ended up hidden even when stepping through frame-by-frame. This is more of a safety guard to prevent bad data from being presented to the user.


**Other information**:
A change that has been made here is that the `syncedEventTimeNow` value in `RundownTimingProvider` has been removed so that `calmedDownNow` is used everywhere. This is because there was a disagreement between `syncedEventTimeNow` and `calmedDownNow` as to which second we were in, which caused a coundown of: `00:10`, `00:11`, `00:10`, `00:09`, for example. I am unsure if this is the right thing to do.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
