### PR TITLE
refactor: simplify media status

### DIFF
--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1563,8 +1563,6 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 				this.subscribe(PubSub.buckets, {
 					studioId: playlist.studioId,
 				})
-				// TODO: This is a hack, which should be replaced by something more clever, like in withMediaObjectStatus()
-				this.subscribe(PubSub.packageContainerPackageStatuses, playlist.studioId)
 			})
 
 			this.autorun(() => {

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1563,6 +1563,8 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 				this.subscribe(PubSub.buckets, {
 					studioId: playlist.studioId,
 				})
+
+				this.subscribe(PubSub.packageContainerPackageStatusesSimple, playlist.studioId)
 			})
 
 			this.autorun(() => {

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1564,6 +1564,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 					studioId: playlist.studioId,
 				})
 
+				// TODO: This is a hack, which should be replaced by something more clever, like in withMediaObjectStatus()
 				this.subscribe(PubSub.packageContainerPackageStatusesSimple, playlist.studioId)
 			})
 

--- a/meteor/client/ui/SegmentList/LinePartMainPiece/LinePartMainPiece.tsx
+++ b/meteor/client/ui/SegmentList/LinePartMainPiece/LinePartMainPiece.tsx
@@ -135,7 +135,7 @@ function getBlacks(piece: PieceUi): Array<PackageInfo.Anomaly> | undefined {
 }
 
 // TODO: Create useMediaObjectStatus that would set up new subscriptions
-export const LinePartMainPiece = withMediaObjectStatus<IProps, {}>()(function LinePartMainPiece({
+export const LinePartMainPiece = withMediaObjectStatus<IProps>()(function LinePartMainPiece({
 	partId,
 	partInstanceId,
 	piece,

--- a/meteor/client/ui/SegmentList/LinePartPieceIndicator/LinePartIndicator.tsx
+++ b/meteor/client/ui/SegmentList/LinePartPieceIndicator/LinePartIndicator.tsx
@@ -20,7 +20,7 @@ interface IProps {
 	onDoubleClick?: React.EventHandler<React.MouseEvent<HTMLDivElement>>
 }
 
-export const LinePartIndicator = withMediaObjectStatus<IProps, {}>()(function LinePartIndicator({
+export const LinePartIndicator = withMediaObjectStatus<IProps>()(function LinePartIndicator({
 	overlay,
 	count,
 	allSourceLayers,

--- a/meteor/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/StoryboardSecondaryPiece.tsx
+++ b/meteor/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/StoryboardSecondaryPiece.tsx
@@ -61,7 +61,7 @@ function renderPieceInside(
 
 type MousePagePosition = { pageX: number; pageY: number }
 
-export const StoryboardSecondaryPiece = withMediaObjectStatus<IProps, {}>()(function StoryboardSecondaryPiece(
+export const StoryboardSecondaryPiece = withMediaObjectStatus<IProps>()(function StoryboardSecondaryPiece(
 	props: IProps
 ) {
 	const {

--- a/meteor/client/ui/SegmentStoryboard/StoryboardPartThumbnail/StoryboardPartThumbnailInner.tsx
+++ b/meteor/client/ui/SegmentStoryboard/StoryboardPartThumbnail/StoryboardPartThumbnailInner.tsx
@@ -22,7 +22,7 @@ interface IProps {
 	highlight?: boolean
 }
 
-export const StoryboardPartThumbnailInner = withMediaObjectStatus<IProps, {}>()(
+export const StoryboardPartThumbnailInner = withMediaObjectStatus<IProps>()(
 	({ piece, layer, partId, partInstanceId, studio, highlight, partAutoNext, isLive, isNext, isFinished }: IProps) => {
 		const [hover, setHover] = useState(false)
 		const [origin, setOrigin] = useState<OffsetPosition>({ left: 0, top: 0 })

--- a/meteor/client/ui/SegmentTimeline/SourceLayerItemContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SourceLayerItemContainer.tsx
@@ -9,6 +9,6 @@ interface IPropsHeader extends ISourceLayerItemProps {
 	studio: UIStudio
 }
 
-export const SourceLayerItemContainer = withMediaObjectStatus<IPropsHeader, {}>()((props: IPropsHeader) => (
+export const SourceLayerItemContainer = withMediaObjectStatus<IPropsHeader>()((props: IPropsHeader) => (
 	<SourceLayerItem {...props} />
 ))

--- a/meteor/client/ui/SegmentTimeline/withMediaObjectStatus.tsx
+++ b/meteor/client/ui/SegmentTimeline/withMediaObjectStatus.tsx
@@ -5,7 +5,6 @@ import { RundownUtils } from '../../lib/rundown'
 import { IAdLibListItem } from '../Shelf/AdLibListItem'
 import { BucketAdLibUi, BucketAdLibActionUi } from '../Shelf/RundownViewBuckets'
 
-import * as _ from 'underscore'
 import { AdLibPieceUi } from '../../lib/shelf'
 import { UIStudio } from '../../../lib/api/studios'
 import { PieceId } from '@sofie-automation/corelib/dist/dataModel/Ids'

--- a/meteor/client/ui/Shelf/AdLibListItem.tsx
+++ b/meteor/client/ui/Shelf/AdLibListItem.tsx
@@ -36,7 +36,7 @@ interface IListViewItemProps {
 	playlist: RundownPlaylist
 }
 
-export const AdLibListItem = withMediaObjectStatus<IListViewItemProps, {}>()(
+export const AdLibListItem = withMediaObjectStatus<IListViewItemProps>()(
 	class AdLibListItem extends MeteorReactComponent<IListViewItemProps> {
 		constructor(props: IListViewItemProps) {
 			super(props)

--- a/meteor/client/ui/Shelf/AdLibRegionPanel.tsx
+++ b/meteor/client/ui/Shelf/AdLibRegionPanel.tsx
@@ -235,10 +235,10 @@ export class AdLibRegionPanelBase extends MeteorReactComponent<
 	}
 }
 
-export const AdLibRegionPanelWithStatus = withMediaObjectStatus<
-	Translated<IAdLibPanelProps & IAdLibRegionPanelProps & AdLibFetchAndFilterProps & IAdLibRegionPanelTrackedProps>,
-	{}
->()(AdLibRegionPanelBase)
+export const AdLibRegionPanelWithStatus =
+	withMediaObjectStatus<
+		Translated<IAdLibPanelProps & IAdLibRegionPanelProps & AdLibFetchAndFilterProps & IAdLibRegionPanelTrackedProps>
+	>()(AdLibRegionPanelBase)
 
 export const AdLibRegionPanel = translateWithTracker<
 	Translated<IAdLibPanelProps & IAdLibRegionPanelProps>,

--- a/meteor/client/ui/Shelf/BucketPieceButton.tsx
+++ b/meteor/client/ui/Shelf/BucketPieceButton.tsx
@@ -101,7 +101,7 @@ export class BucketPieceButtonBase extends DashboardPieceButtonBase<
 	}
 }
 
-export const BucketPieceButton = withMediaObjectStatus<IDashboardButtonProps & BucketPieceButtonBaseProps, {}>()(
+export const BucketPieceButton = withMediaObjectStatus<IDashboardButtonProps & BucketPieceButtonBaseProps>()(
 	DropTarget(DragDropItemTypes.BUCKET_ADLIB_PIECE, buttonTarget, (connect) => ({
 		connectDropTarget: connect.dropTarget(),
 	}))(

--- a/meteor/client/ui/Shelf/DashboardPieceButton.tsx
+++ b/meteor/client/ui/Shelf/DashboardPieceButton.tsx
@@ -493,4 +493,4 @@ export class DashboardPieceButtonBase<T = {}> extends MeteorReactComponent<IDash
 	}
 }
 
-export const DashboardPieceButton = withMediaObjectStatus<IDashboardButtonProps, {}>()(DashboardPieceButtonBase)
+export const DashboardPieceButton = withMediaObjectStatus<IDashboardButtonProps>()(DashboardPieceButtonBase)

--- a/meteor/client/ui/Shelf/Inspector/ItemRenderers/InspectorTitle.tsx
+++ b/meteor/client/ui/Shelf/Inspector/ItemRenderers/InspectorTitle.tsx
@@ -16,7 +16,7 @@ interface IProps {
 	studio: UIStudio
 }
 
-const InspectorTitle = withMediaObjectStatus<IProps, {}>()(function InspectorTitle(props: IProps) {
+const InspectorTitle = withMediaObjectStatus<IProps>()(function InspectorTitle(props: IProps) {
 	const piece = RundownUtils.isPieceInstance(props.piece)
 		? (props.piece.instance.piece as Piece)
 		: (props.piece as AdLibPieceUi)

--- a/meteor/client/utils/globalStores.ts
+++ b/meteor/client/utils/globalStores.ts
@@ -6,6 +6,8 @@ import {
 } from '../../lib/collections/PackageContainerPackageStatus'
 import { ReactiveStore } from '../../lib/ReactiveStore'
 
+export type UiPackageContainerPackageStatus = Omit<PackageContainerPackageStatusDB, 'modified'>
+
 const storePackageContainerPackageStatuses = new ReactiveStore<
 	PackageContainerPackageId,
 	PackageContainerPackageStatusDB | undefined
@@ -16,12 +18,19 @@ export const getPackageContainerPackageStatus = (
 	studioId: StudioId,
 	packageContainerId: string,
 	expectedPackageId: ExpectedPackageId
-): PackageContainerPackageStatusDB | undefined => {
+): UiPackageContainerPackageStatus | undefined => {
 	const id = getPackageContainerPackageId(studioId, packageContainerId, expectedPackageId)
 
 	return storePackageContainerPackageStatuses.getValue(id, () => {
-		return PackageContainerPackageStatuses.findOne({
-			_id: id,
-		})
+		return PackageContainerPackageStatuses.findOne(
+			{
+				_id: id,
+			},
+			{
+				projection: {
+					modified: 0,
+				},
+			}
+		)
 	})
 }

--- a/meteor/lib/api/pubsub.ts
+++ b/meteor/lib/api/pubsub.ts
@@ -111,6 +111,7 @@ export enum PubSub {
 	expectedPackages = 'expectedPackages',
 	expectedPackageWorkStatuses = 'expectedPackageWorkStatuses',
 	packageContainerPackageStatuses = 'packageContainerPackageStatuses',
+	packageContainerPackageStatusesSimple = 'packageContainerPackageStatusesSimple',
 	packageContainerStatuses = 'packageContainerStatuses',
 	packageInfos = 'packageInfos',
 
@@ -215,6 +216,11 @@ export interface PubSubTypes {
 		token?: string
 	) => ExpectedPackageWorkStatus
 	[PubSub.packageContainerPackageStatuses]: (
+		studioId: StudioId,
+		containerId?: string | null,
+		packageId?: ExpectedPackageId | null
+	) => PackageContainerPackageStatusDB
+	[PubSub.packageContainerPackageStatusesSimple]: (
 		studioId: StudioId,
 		containerId?: string | null,
 		packageId?: ExpectedPackageId | null

--- a/meteor/lib/mediaObjects.ts
+++ b/meteor/lib/mediaObjects.ts
@@ -167,7 +167,7 @@ export function checkPieceContentStatus(
 	getPackageContainerPackageStatus2: (
 		packageContainerId: string,
 		expectedPackageId: ExpectedPackageId
-	) => PackageContainerPackageStatusDB | undefined
+	) => Pick<PackageContainerPackageStatusDB, 'status'> | undefined
 ): PieceContentStatusObj {
 	const ignoreMediaStatus = piece.content && piece.content.ignoreMediaObjectStatus
 	if (!ignoreMediaStatus && sourceLayer && studio) {
@@ -353,7 +353,7 @@ function checkPieceContentExpectedPackageStatus(
 	getPackageContainerPackageStatus2: (
 		packageContainerId: string,
 		expectedPackageId: ExpectedPackageId
-	) => PackageContainerPackageStatusDB | undefined
+	) => Pick<PackageContainerPackageStatusDB, 'status'> | undefined
 ): PieceContentStatusObj {
 	let packageInfoToForward: ScanInfoForPackages | undefined = undefined
 	const settings: IStudioSettings | undefined = studio?.settings
@@ -492,7 +492,7 @@ function checkPieceContentExpectedPackageStatus(
 }
 
 function getPackageWarningMessage(
-	packageOnPackageContainer: PackageContainerPackageStatusDB | undefined,
+	packageOnPackageContainer: Pick<PackageContainerPackageStatusDB, 'status'> | undefined,
 	sourceLayer: ISourceLayer
 ): ContentMessage | null {
 	if (

--- a/meteor/server/publications/studio.ts
+++ b/meteor/server/publications/studio.ts
@@ -143,6 +143,32 @@ meteorPublish(
 		return null
 	}
 )
+meteorPublish(
+	PubSub.packageContainerPackageStatusesSimple,
+	async function (studioId: StudioId, containerId?: string | null, packageId?: ExpectedPackageId | null) {
+		if (!studioId) throw new Meteor.Error(400, 'studioId argument missing')
+
+		check(studioId, String)
+		check(containerId, Match.Maybe(String))
+		check(packageId, Match.Maybe(String))
+
+		const modifier: FindOptions<PackageContainerPackageStatusDB> = {
+			projection: {
+				modified: 0,
+			},
+		}
+		const selector: MongoQuery<PackageContainerPackageStatusDB> = {
+			studioId: studioId,
+		}
+		if (containerId) selector.containerId = containerId
+		if (packageId) selector.packageId = packageId
+
+		if (await StudioReadAccess.studioContent(selector.studioId, { userId: this.userId })) {
+			return PackageContainerPackageStatuses.find(selector, modifier)
+		}
+		return null
+	}
+)
 
 meteorCustomPublish(
 	PubSub.mappingsForDevice,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Refactoring

* **What is the current behavior?** (You can also link to an open issue here)

We are pulling a lot of very reactive data to render previews, thumbnails, etc. We also have a lot of duplicated logic between server & client for the Piece statuses.

* **What is the new behavior (if this is a feature change)?**

We use the `uiPieceContentStatuses` publication for Media Statuses on Pieces and we use a new `packageContainerPackageStatusesSimple` publication for low reactivity PackageContainerPackageStatuses, without the `modified` field, which we don't need in most cases anyway.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
