### PR TITLE
fix: Insert and update peripheralDevice type as number

### DIFF
--- a/meteor/client/ui/Settings/components/DeviceConfigSchemaSettings.tsx
+++ b/meteor/client/ui/Settings/components/DeviceConfigSchemaSettings.tsx
@@ -74,7 +74,7 @@ export function SubDevicesConfig({
 		const selectedType = schemaTypes[0] // Future: This is slightly 'random' but will be consistent
 		const selectedSchemaJson = parsedSchemas[selectedType]
 		const defaults = selectedSchemaJson ? getSchemaDefaultValues(selectedSchemaJson) : {}
-		defaults.type = selectedType
+		defaults.type = parseInt(selectedType)
 
 		const existingDevices = new Set(Object.keys((PeripheralDevices.findOne(deviceId)?.settings as any)?.devices || {}))
 
@@ -284,7 +284,7 @@ function SubDeviceEditRow({
 		(val: any) => {
 			PeripheralDevices.update(parentId, {
 				$set: {
-					[`settings.devices.${subdeviceId}.type`]: val,
+					[`settings.devices.${subdeviceId}.type`]: parseInt(val),
 				},
 			})
 		},


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Playout gateway can't add devices as the device type is passed as a string


* **What is the new behavior (if this is a feature change)?**
Device type is converted to a number before adding to / modifying collection


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
