### PR TITLE
fix: lower reactivity for PackageContainerPackageStatus

### DIFF
--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1564,7 +1564,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 					studioId: playlist.studioId,
 				})
 				// TODO: This is a hack, which should be replaced by something more clever, like in withMediaObjectStatus()
-				this.subscribe(PubSub.packageContainerPackageStatuses, playlist.studioId)
+				this.subscribe(PubSub.packageContainerPackageStatusesSimple, playlist.studioId)
 			})
 
 			this.autorun(() => {

--- a/meteor/client/utils/globalStores.ts
+++ b/meteor/client/utils/globalStores.ts
@@ -6,6 +6,8 @@ import {
 } from '../../lib/collections/PackageContainerPackageStatus'
 import { ReactiveStore } from '../../lib/ReactiveStore'
 
+export type UiPackageContainerPackageStatus = Omit<PackageContainerPackageStatusDB, 'modified'>
+
 const storePackageContainerPackageStatuses = new ReactiveStore<
 	PackageContainerPackageId,
 	PackageContainerPackageStatusDB | undefined
@@ -16,12 +18,19 @@ export const getPackageContainerPackageStatus = (
 	studioId: StudioId,
 	packageContainerId: string,
 	expectedPackageId: ExpectedPackageId
-): PackageContainerPackageStatusDB | undefined => {
+): UiPackageContainerPackageStatus | undefined => {
 	const id = getPackageContainerPackageId(studioId, packageContainerId, expectedPackageId)
 
 	return storePackageContainerPackageStatuses.getValue(id, () => {
-		return PackageContainerPackageStatuses.findOne({
-			_id: id,
-		})
+		return PackageContainerPackageStatuses.findOne(
+			{
+				_id: id,
+			},
+			{
+				projection: {
+					modified: 0,
+				},
+			}
+		)
 	})
 }

--- a/meteor/lib/api/pubsub.ts
+++ b/meteor/lib/api/pubsub.ts
@@ -111,6 +111,7 @@ export enum PubSub {
 	expectedPackages = 'expectedPackages',
 	expectedPackageWorkStatuses = 'expectedPackageWorkStatuses',
 	packageContainerPackageStatuses = 'packageContainerPackageStatuses',
+	packageContainerPackageStatusesSimple = 'packageContainerPackageStatusesSimple',
 	packageContainerStatuses = 'packageContainerStatuses',
 	packageInfos = 'packageInfos',
 
@@ -215,6 +216,11 @@ export interface PubSubTypes {
 		token?: string
 	) => ExpectedPackageWorkStatus
 	[PubSub.packageContainerPackageStatuses]: (
+		studioId: StudioId,
+		containerId?: string | null,
+		packageId?: ExpectedPackageId | null
+	) => PackageContainerPackageStatusDB
+	[PubSub.packageContainerPackageStatusesSimple]: (
 		studioId: StudioId,
 		containerId?: string | null,
 		packageId?: ExpectedPackageId | null

--- a/meteor/lib/api/pubsub.ts
+++ b/meteor/lib/api/pubsub.ts
@@ -224,7 +224,7 @@ export interface PubSubTypes {
 		studioId: StudioId,
 		containerId?: string | null,
 		packageId?: ExpectedPackageId | null
-	) => PackageContainerPackageStatusDB
+	) => Omit<PackageContainerPackageStatusDB, 'modified'>
 	[PubSub.packageContainerStatuses]: (
 		selector: MongoQuery<PackageContainerStatusDB>,
 		token?: string

--- a/meteor/lib/mediaObjects.ts
+++ b/meteor/lib/mediaObjects.ts
@@ -167,7 +167,7 @@ export function checkPieceContentStatus(
 	getPackageContainerPackageStatus2: (
 		packageContainerId: string,
 		expectedPackageId: ExpectedPackageId
-	) => PackageContainerPackageStatusDB | undefined
+	) => Pick<PackageContainerPackageStatusDB, 'status'> | undefined
 ): PieceContentStatusObj {
 	const ignoreMediaStatus = piece.content && piece.content.ignoreMediaObjectStatus
 	if (!ignoreMediaStatus && sourceLayer && studio) {
@@ -353,7 +353,7 @@ function checkPieceContentExpectedPackageStatus(
 	getPackageContainerPackageStatus2: (
 		packageContainerId: string,
 		expectedPackageId: ExpectedPackageId
-	) => PackageContainerPackageStatusDB | undefined
+	) => Pick<PackageContainerPackageStatusDB, 'status'> | undefined
 ): PieceContentStatusObj {
 	let packageInfoToForward: ScanInfoForPackages | undefined = undefined
 	const settings: IStudioSettings | undefined = studio?.settings
@@ -492,7 +492,7 @@ function checkPieceContentExpectedPackageStatus(
 }
 
 function getPackageWarningMessage(
-	packageOnPackageContainer: PackageContainerPackageStatusDB | undefined,
+	packageOnPackageContainer: Pick<PackageContainerPackageStatusDB, 'status'> | undefined,
 	sourceLayer: ISourceLayer
 ): ContentMessage | null {
 	if (

--- a/meteor/server/publications/studio.ts
+++ b/meteor/server/publications/studio.ts
@@ -22,7 +22,7 @@ import { PackageContainerPackageStatusDB } from '../../lib/collections/PackageCo
 import { Match } from 'meteor/check'
 import { literal } from '../../lib/lib'
 import { ReadonlyDeep } from 'type-fest'
-import { FindOptions } from '../../lib/collections/lib'
+import { FindOptions, MongoCursor } from '../../lib/collections/lib'
 import { applyAndValidateOverrides } from '@sofie-automation/corelib/dist/settings/objectWithOverrides'
 import { ExpectedPackageId, PeripheralDeviceId, StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import {
@@ -164,7 +164,9 @@ meteorPublish(
 		if (packageId) selector.packageId = packageId
 
 		if (await StudioReadAccess.studioContent(selector.studioId, { userId: this.userId })) {
-			return PackageContainerPackageStatuses.find(selector, modifier)
+			return PackageContainerPackageStatuses.find(selector, modifier) as MongoCursor<
+				Omit<PackageContainerPackageStatusDB, 'modified'>
+			>
 		}
 		return null
 	}

--- a/meteor/server/publications/studio.ts
+++ b/meteor/server/publications/studio.ts
@@ -143,6 +143,32 @@ meteorPublish(
 		return null
 	}
 )
+meteorPublish(
+	PubSub.packageContainerPackageStatusesSimple,
+	async function (studioId: StudioId, containerId?: string | null, packageId?: ExpectedPackageId | null) {
+		if (!studioId) throw new Meteor.Error(400, 'studioId argument missing')
+
+		check(studioId, String)
+		check(containerId, Match.Maybe(String))
+		check(packageId, Match.Maybe(String))
+
+		const modifier: FindOptions<PackageContainerPackageStatusDB> = {
+			projection: {
+				modified: 0,
+			},
+		}
+		const selector: MongoQuery<PackageContainerPackageStatusDB> = {
+			studioId: studioId,
+		}
+		if (containerId) selector.containerId = containerId
+		if (packageId) selector.packageId = packageId
+
+		if (await StudioReadAccess.studioContent(selector.studioId, { userId: this.userId })) {
+			return PackageContainerPackageStatuses.find(selector, modifier)
+		}
+		return null
+	}
+)
 
 meteorCustomPublish(
 	PubSub.mappingsForDevice,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

The `PackageContainerPackageStatus` collection can be very reactive, because the `modified` field is getting updated all the time as Package Manager is working. This can cause components to re-render for no reason, other than receiving a new object through a cursor (due to the `modified` having changed).

* **What is the new behavior (if this is a feature change)?**

A new publication for `PackageContainerPackageStatus` is created that omits the `modified` field. This should limit the amount of reactivity on the wire and in the Rundown View, where the `modified` field isn't used anyway.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
