### PR TITLE
fix: update budget gap line calculations to prevent it from extending past the editorial line

### DIFF
--- a/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
@@ -781,6 +781,7 @@ export class SegmentTimelineClass extends React.Component<Translated<WithTiming<
 						anyPriorPartWasLive={anyPriorPartWasLive}
 						livePartStartsAt={livePartStartsAt}
 						livePartDisplayDuration={livePartDisplayDuration}
+						budgetDuration={undefined}
 					/>
 					{emitSmallPartsInFlag && emitSmallPartsInFlagAtEnd && (
 						<SegmentTimelineSmallPartFlag
@@ -850,6 +851,7 @@ export class SegmentTimelineClass extends React.Component<Translated<WithTiming<
 				anyPriorPartWasLive={true}
 				livePartStartsAt={livePartStartsAt}
 				livePartDisplayDuration={livePartDisplayDuration}
+				budgetDuration={this.props.budgetDuration}
 			/>
 		)
 	}

--- a/meteor/client/ui/SegmentTimeline/SmallParts/SegmentTimelinePartHoverPreview.tsx
+++ b/meteor/client/ui/SegmentTimeline/SmallParts/SegmentTimelinePartHoverPreview.tsx
@@ -108,6 +108,7 @@ export const SegmentTimelinePartHoverPreview = ({
 							anyPriorPartWasLive={undefined}
 							livePartStartsAt={undefined}
 							livePartDisplayDuration={undefined}
+							budgetDuration={undefined}
 						/>
 					)
 				})}
@@ -141,6 +142,7 @@ export const SegmentTimelinePartHoverPreview = ({
 						anyPriorPartWasLive={undefined}
 						livePartStartsAt={undefined}
 						livePartDisplayDuration={undefined}
+						budgetDuration={undefined}
 					/>
 				)}
 			</div>


### PR DESCRIPTION
This PR is being opened on behalf of TV 2 Norge.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

The squiggly budget gap line rarely lines up with the editorial line:
![image](https://user-images.githubusercontent.com/873012/232864378-8f1c7b59-174d-45fe-bc5f-bee8f1674ee9.png)

* **What is the new behavior (if this is a feature change)?**

It always lines up: 
![image](https://user-images.githubusercontent.com/873012/232863921-2ab6a535-c7d2-41a7-9fa5-98770683b667.png)

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
