### PR TITLE
Fix: Cronjob cleanup

### DIFF
--- a/meteor/lib/api/system.ts
+++ b/meteor/lib/api/system.ts
@@ -26,6 +26,7 @@ export interface SystemAPI {
 	cleanupIndexes(actuallyRemoveOldIndexes: boolean): Promise<any>
 	cleanupOldData(actuallyRemoveOldData: boolean): Promise<CollectionCleanupResult | string>
 
+	runCronjob(): Promise<void>
 	doSystemBenchmark(): Promise<SystemBenchmarkResults>
 
 	getTranslationBundle(bundleId: TranslationsBundleId): Promise<ClientAPI.ClientResponse<TranslationsBundle>>

--- a/meteor/server/api/cleanup.ts
+++ b/meteor/server/api/cleanup.ts
@@ -52,6 +52,10 @@ import {
 	StudioId,
 } from '@sofie-automation/corelib/dist/dataModel/Ids'
 
+/**
+ * If actuallyCleanup=true, cleans up old data. Otherwise just checks what old data there is
+ * @returns A string if there is an issue preventing cleanup. CollectionCleanupResult otherwise
+ */
 export async function cleanupOldDataInner(actuallyCleanup: boolean = false): Promise<CollectionCleanupResult | string> {
 	if (actuallyCleanup) {
 		const notAllowedReason = await isAllowedToRunCleanup()

--- a/meteor/server/api/studio/lib.ts
+++ b/meteor/server/api/studio/lib.ts
@@ -1,6 +1,9 @@
 import { RundownPlaylistId, StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { PackageInfoDB } from '@sofie-automation/corelib/dist/dataModel/PackageInfos'
+import { ExpectedPackages } from '../../../lib/collections/ExpectedPackages'
+import { PackageInfos } from '../../../lib/collections/PackageInfos'
 import { RundownPlaylist, RundownPlaylists } from '../../../lib/collections/RundownPlaylists'
-import { protectString } from '../../../lib/lib'
+import { getCurrentTime, protectString } from '../../../lib/lib'
 
 export async function getActiveRundownPlaylistsInStudioFromDb(
 	studioId: StudioId,
@@ -13,4 +16,33 @@ export async function getActiveRundownPlaylistsInStudioFromDb(
 			$ne: excludeRundownPlaylistId || protectString(''),
 		},
 	})
+}
+
+/** Returns a list of PackageInfos which are no longer valid */
+export async function getRemovedOrOrphanedPackageInfos(): Promise<PackageInfoDB['_id'][]> {
+	const knownExpectedPackageIds = (await ExpectedPackages.findFetchAsync({}, { fields: { _id: 1 } })).map(
+		(pkg) => pkg._id
+	)
+
+	const docs = await PackageInfos.findFetchAsync(
+		{
+			$or: [
+				{
+					// Marked for delayed removal, and that time has passed
+					removeTime: { $lte: getCurrentTime() },
+				},
+				{
+					// Not marked for delayed removal, and the expectedPackage has been deleted
+					packageId: { $nin: knownExpectedPackageIds },
+					removeTime: { $exists: false },
+				},
+			],
+		},
+		{
+			fields: {
+				_id: 1,
+			},
+		}
+	)
+	return docs.map((p) => p._id)
 }

--- a/meteor/server/cronjobs.ts
+++ b/meteor/server/cronjobs.ts
@@ -2,13 +2,11 @@ import { Rundowns } from '../lib/collections/Rundowns'
 import { PeripheralDeviceAPI } from '../lib/api/peripheralDevice'
 import { PeripheralDevices, PeripheralDeviceType } from '../lib/collections/PeripheralDevices'
 import * as _ from 'underscore'
-import { getCurrentTime, stringifyError, waitForPromiseAll } from '../lib/lib'
+import { getCurrentTime, stringifyError, waitForPromise, waitForPromiseAll } from '../lib/lib'
 import { logger } from './logging'
 import { Meteor } from 'meteor/meteor'
 import { IngestDataCache } from '../lib/collections/IngestDataCache'
 import { TSR } from '@sofie-automation/blueprints-integration'
-import { UserActionsLog } from '../lib/collections/UserActionsLog'
-import { Snapshots } from '../lib/collections/Snapshots'
 import { CASPARCG_RESTART_TIME } from '@sofie-automation/shared-lib/dist/core/constants'
 import { getCoreSystem } from '../lib/collections/CoreSystem'
 import { QueueStudioJob } from './worker/worker'
@@ -16,12 +14,10 @@ import { StudioJobs } from '@sofie-automation/corelib/dist/worker/studio'
 import { fetchStudioIds } from '../lib/collections/optimizations'
 import { RundownPlaylists } from '../lib/collections/RundownPlaylists'
 import { internalStoreRundownPlaylistSnapshot } from './api/snapshot'
-import { Parts } from '../lib/collections/Parts'
-import { PartInstances } from '../lib/collections/PartInstances'
-import { PieceInstances } from '../lib/collections/PieceInstances'
 import { getRemovedOrOrphanedPackageInfos } from './api/studio/lib'
 import { PackageInfos } from '../lib/collections/PackageInfos'
 import { deferAsync } from '@sofie-automation/corelib/dist/lib'
+import { cleanupOldDataInner } from './api/cleanup'
 
 const lowPrioFcn = (fcn: () => any) => {
 	// Do it at a random time in the future:
@@ -46,79 +42,21 @@ export function nightlyCronjobInner(): void {
 	logger.info('Nightly cronjob: starting...')
 	const system = getCoreSystem()
 
-	// Clean up Rundown data cache:
-	// Remove caches not related to rundowns:
-	let rundownCacheCount = 0
-	const rundownIds = _.map(Rundowns.find().fetch(), (rundown) => rundown._id)
-	IngestDataCache.find({
-		rundownId: { $nin: rundownIds },
-	}).forEach((roc) => {
-		lowPrioFcn(() => {
-			IngestDataCache.remove(roc._id)
-		})
-		rundownCacheCount++
-	})
-	if (rundownCacheCount) logger.info('Cronjob: Will remove cached data from ' + rundownCacheCount + ' rundowns')
-
-	const cleanLimitTime = getCurrentTime() - 1000 * 3600 * 24 * 50 // 50 days ago
-
-	// Remove old PartInstances and PieceInstances:
-	const getPartInstanceIdsToRemove = () => {
-		const existingPartIds = Parts.find({}, { fields: { _id: 1 } })
-			.fetch()
-			.map((part) => part._id)
-		const oldPartInstanceSelector = {
-			reset: true,
-			'timings.plannedStoppedPlayback': { $lt: cleanLimitTime },
-			'part._id': { $nin: existingPartIds },
+	// Clean up old data:
+	try {
+		const cleanupResults = waitForPromise(cleanupOldDataInner(true))
+		if (typeof cleanupResults === 'string') {
+			logger.warn(`Cronjob: Could not clean up old data due to: ${cleanupResults}`)
+		} else {
+			for (const result of Object.values(cleanupResults)) {
+				if (result.docsToRemove > 0) {
+					logger.info(`Cronjob: Removed ${result.docsToRemove} documents from "${result.collectionName}"`)
+				}
+			}
 		}
-		const oldPartInstanceIds = PartInstances.find(oldPartInstanceSelector, { fields: { _id: 1 } })
-			.fetch()
-			.map((partInstance) => partInstance._id)
-		return oldPartInstanceIds
-	}
-	const partInstanceIdsToRemove = getPartInstanceIdsToRemove()
-	if (partInstanceIdsToRemove.length > 0) {
-		logger.info(`Cronjob: Will remove ${partInstanceIdsToRemove.length} PartInstances`)
-	}
-	const oldPieceInstances = PieceInstances.find({
-		partInstanceId: { $in: partInstanceIdsToRemove },
-	}).count()
-	if (oldPieceInstances > 0) {
-		logger.info(`Cronjob: Will remove ${oldPieceInstances} PieceInstances`)
-	}
-	lowPrioFcn(() => {
-		const partInstanceIdsToRemove = getPartInstanceIdsToRemove()
-		PartInstances.remove({ _id: { $in: partInstanceIdsToRemove } })
-		PieceInstances.remove({
-			partInstanceId: { $in: partInstanceIdsToRemove },
-		})
-	})
-
-	// Remove old entries in UserActionsLog:
-	const oldUserActionsLogCount: number = UserActionsLog.find({
-		timestamp: { $lt: cleanLimitTime },
-	}).count()
-	if (oldUserActionsLogCount > 0) {
-		logger.info(`Cronjob: Will remove ${oldUserActionsLogCount} entries from UserActionsLog`)
-		lowPrioFcn(() => {
-			UserActionsLog.remove({
-				timestamp: { $lt: cleanLimitTime },
-			})
-		})
-	}
-
-	// Remove old entries in Snapshots:
-	const oldSnapshotsCount: number = Snapshots.find({
-		created: { $lt: cleanLimitTime },
-	}).count()
-	if (oldSnapshotsCount > 0) {
-		logger.info(`Cronjob: Will remove ${oldSnapshotsCount} entries from Snapshots`)
-		lowPrioFcn(() => {
-			Snapshots.remove({
-				created: { $lt: cleanLimitTime },
-			})
-		})
+	} catch (error) {
+		logger.error(`Cronjob: Error when cleaning up old data: ${error}`)
+		logger.error(error)
 	}
 
 	const ps: Array<Promise<any>> = []

--- a/packages/job-worker/src/playout/lib.ts
+++ b/packages/job-worker/src/playout/lib.ts
@@ -722,6 +722,13 @@ export function prefixAllObjectIds<T extends TimelineObjGeneric>(
 			obj.inGroup = idMap[obj.inGroup] || obj.inGroup
 		}
 
+		// make sure any keyframes are unique
+		if (obj.keyframes) {
+			for (const kf of obj.keyframes) {
+				kf.id = `${kf.id}_${obj.id}`
+			}
+		}
+
 		return obj
 	})
 }

--- a/scripts/run.js
+++ b/scripts/run.js
@@ -80,3 +80,12 @@ function watchMeteor() {
 		}
 	).result;
 })();
+
+function signalHandler(signal) {
+	process.exit();
+}
+
+// Make sure to exit on interupt
+process.on("SIGINT", signalHandler);
+process.on("SIGTERM", signalHandler);
+process.on("SIGQUIT", signalHandler);


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
Fix, Improve database cleanup during nightly cronjob.


* **What is the current behavior?**
We have an ongoing issue where database collections grow continously (when not having run migrations for some time).
This is due to the nightly cronjob was missing a few cleanup procedures (such as externalMessageQueue).


* **What is the new behavior (if this is a feature change)?**
The nightly cronjob now executes the same function as the migrations cleanup function.
Also the cleanup of ExternalMessageQueue now takes the `expires` property into account.


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
