### PR TITLE
fix: Package Manager status page crash

### DIFF
--- a/meteor/server/api/client.ts
+++ b/meteor/server/api/client.ts
@@ -334,48 +334,52 @@ export namespace ServerClientAPI {
 			)
 		}
 
-		const access = await PeripheralDeviceContentWriteAccess.executeFunction(methodContext, deviceId)
+		try {
+			const access = await PeripheralDeviceContentWriteAccess.executeFunction(methodContext, deviceId)
 
-		await UserActionsLog.insertAsync(
-			literal<UserActionsLogItem>({
-				_id: actionId,
-				clientAddress: methodContext.connection ? methodContext.connection.clientAddress : '',
-				organizationId: access.organizationId,
-				userId: access.userId,
-				context: context,
-				method: `${deviceId}: ${action.functionName || action.actionId}`,
-				args: JSON.stringify(action.args || action.payload),
-				timestamp: getCurrentTime(),
-			})
-		)
-
-		return PeripheralDeviceAPI.executeFunctionWithCustomTimeout(deviceId, timeoutTime, action)
-			.then(async (result) => {
-				await UserActionsLog.updateAsync(actionId, {
-					$set: {
-						success: true,
-						doneTime: getCurrentTime(),
-						executionTime: Date.now() - startTime,
-					},
+			await UserActionsLog.insertAsync(
+				literal<UserActionsLogItem>({
+					_id: actionId,
+					clientAddress: methodContext.connection ? methodContext.connection.clientAddress : '',
+					organizationId: access.organizationId,
+					userId: access.userId,
+					context: context,
+					method: `${deviceId}: ${action.functionName || action.actionId}`,
+					args: JSON.stringify(action.args || action.payload),
+					timestamp: getCurrentTime(),
 				})
+			)
 
-				return result
-			})
-			.catch(async (err) => {
-				const errMsg = err.message || err.reason || (err.toString ? err.toString() : null)
-				logger.error(errMsg)
-				await UserActionsLog.updateAsync(actionId, {
-					$set: {
-						success: false,
-						doneTime: getCurrentTime(),
-						executionTime: Date.now() - startTime,
-						errorMessage: errMsg,
-					},
+			return PeripheralDeviceAPI.executeFunctionWithCustomTimeout(deviceId, timeoutTime, action)
+				.then(async (result) => {
+					await UserActionsLog.updateAsync(actionId, {
+						$set: {
+							success: true,
+							doneTime: getCurrentTime(),
+							executionTime: Date.now() - startTime,
+						},
+					})
+
+					return result
 				})
+				.catch(async (err) => {
+					const errMsg = err.message || err.reason || (err.toString ? err.toString() : null)
+					logger.error(errMsg)
+					await UserActionsLog.updateAsync(actionId, {
+						$set: {
+							success: false,
+							doneTime: getCurrentTime(),
+							executionTime: Date.now() - startTime,
+							errorMessage: errMsg,
+						},
+					})
 
-				// allow the exception to be handled by the Client code
-				return Promise.reject(err)
-			})
+					// allow the exception to be handled by the Client code
+					return Promise.reject(err)
+				})
+		} catch (err) {
+			return Promise.reject(err)
+		}
 	}
 
 	export async function callBackgroundPeripheralDeviceFunction(
@@ -405,17 +409,21 @@ export namespace ServerClientAPI {
 			})
 		}
 
-		void PeripheralDeviceContentWriteAccess.executeFunction(methodContext, deviceId)
+		try {
+			await PeripheralDeviceContentWriteAccess.executeFunction(methodContext, deviceId)
 
-		return PeripheralDeviceAPI.executeFunctionWithCustomTimeout(deviceId, timeoutTime, {
-			functionName,
-			args,
-		}).catch(async (err) => {
-			const errMsg = err.message || err.reason || (err.toString ? err.toString() : null)
-			logger.error(errMsg)
-			// allow the exception to be handled by the Client code
+			return PeripheralDeviceAPI.executeFunctionWithCustomTimeout(deviceId, timeoutTime, {
+				functionName,
+				args,
+			}).catch(async (err) => {
+				const errMsg = err.message || err.reason || (err.toString ? err.toString() : null)
+				logger.error(errMsg)
+				// allow the exception to be handled by the Client code
+				return Promise.reject(err)
+			})
+		} catch (err) {
 			return Promise.reject(err)
-		})
+		}
 	}
 
 	async function getLoggedInCredentials(methodContext: MethodContext): Promise<BasicAccessContext> {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

When you open the Package Manager peripheral device Status page, Core can crash with an uncaught exception, if the device is not assigned to a studio.

* **What is the new behavior (if this is a feature change)?**

The thrown error will be returned back to the client instead of crashing Core.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
