### PR TITLE
fix: piece group objects within a part bleeding classes

### DIFF
--- a/packages/corelib/src/playout/__tests__/pieces.test.ts
+++ b/packages/corelib/src/playout/__tests__/pieces.test.ts
@@ -90,7 +90,7 @@ describe('Pieces', () => {
 			pieceInstanceId: 'randomId9000',
 			partInstanceId: protectString('randomId9002'),
 			priority: 123,
-			classes: undefined,
+			classes: [],
 		})
 		const partGroup = { id: 'randomId9003' } as any as TimelineObjRundown
 

--- a/packages/corelib/src/playout/pieces.ts
+++ b/packages/corelib/src/playout/pieces.ts
@@ -67,7 +67,7 @@ export function createPieceGroupAndCap(
 			},
 			callBackStopped: PlayoutChangedType.PIECE_PLAYBACK_STOPPED, // Will cause a callback to be called, when the object stops playing:
 		},
-		classes: controlObjClasses,
+		classes: controlObjClasses ? [...controlObjClasses] : [],
 		inGroup: partGroup && partGroup.id,
 		metaData: {
 			isPieceTimeline: true,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

When creating the `piece_group_control` it has classes provided from the caller. This array is being reused across all the groups in the part, resulting in them using the same array reference.

When `onTimelineGenerate` modifies this property, it gets applied to every piece in the part

* **What is the new behavior (if this is a feature change)?**

Clone the `classes` array before using it

* **Other information**:

One of the timelineObjects I found. I was testing a lot of rapid camera cuts.
```
{
        "id" : "piece_group_control_kSk7b8NmS96qmHZREy_kckQ02DQ__KFnLAQcCicZr8xhYw_4PCDeCegxyTeSnSqk",
        "objectType" : "rundown",
        "enable" : {
            "start" : 138790.0,
            "duration" : 5000.0
        },
        "layer" : "studio0_graphics_super",
        "priority" : 5.0,
        "content" : {
            "deviceType" : 0.0,
            "type" : "callback",
            "callBack" : "piecePlaybackStarted",
            "callBackData" : {
                "rundownPlaylistId" : "ye8T_Hpg5nrN_zXHO2RwRtecqdg_",
                "partInstanceId" : "kSk7b8NmS96qmHZREy_kckQ02DQ__KFnLAQcCicZr8xhYw",
                "pieceInstanceId" : "kSk7b8NmS96qmHZREy_kckQ02DQ__KFnLAQcCicZr8xhYw_4PCDeCegxyTeSnSqk",
                "dynamicallyInserted" : true
            },
            "callBackStopped" : "piecePlaybackStopped"
        },
        "classes" : [
            "current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_camera0_current_part",
            "studio0_live_transition0_current_part",
            "audio_trigger_value_current_part",
            "studio0_graphics_super_current_part",
            "studio0_graphics_super_current_part"
        ],
        "inGroup" : "part_group_kSk7b8NmS96qmHZREy_kckQ02DQ__KFnLAQcCicZr8xhYw",
        "metaData" : {
            "isPieceTimeline" : true,
            "triggerPieceInstanceId" : "kSk7b8NmS96qmHZREy_kckQ02DQ__KFnLAQcCicZr8xhYw_4PCDeCegxyTeSnSqk"
        }
    },
```

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
