### PR TITLE
fix(SegmentList): indicator pop-up placement in document space

### DIFF
--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -40,6 +40,10 @@ $segment-timeline-padding: $segment-header-height 0 1.5em;
 $segment-layer-height: 1.5em;
 $segment-layer-separator-color: transparentize(#000, 0.5);
 
+:root {
+	--popdown: 2rem;
+}
+
 // A utility mix-in, to add an interactive collapse triangle on an item
 @mixin collapse-triangle {
 	&::before {
@@ -2711,8 +2715,6 @@ svg.icon {
 	max-width: 26em;
 	font-weight: 400;
 
-	--popdown: 2em;
-
 	&.segment-timeline__mini-inspector--sub-inspector {
 		transform: none;
 		bottom: 100%;
@@ -2864,10 +2866,6 @@ svg.icon {
 		> .segment-timeline__mini-inspector__notice-header {
 			background-color: $color-status-fatal;
 		}
-	}
-
-	&.segment-timeline__mini-inspector--pop-down {
-		transform: translate(-50%, var(--popdown));
 	}
 
 	&.segment-timeline__mini-inspector--graphics {

--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -2721,6 +2721,11 @@ svg.icon {
 		width: 26em;
 	}
 
+	&.segment-timeline__mini-inspector--sub-inspector.segment-timeline__mini-inspector--sub-inspector-flipped {
+		bottom: auto;
+		top: 100%;
+	}
+
 	&.segment-timeline__mini-inspector--small-parts {
 		top: 0;
 		z-index: 1001;

--- a/meteor/client/ui/FloatingInspectors/IFloatingInspectorPosition.ts
+++ b/meteor/client/ui/FloatingInspectors/IFloatingInspectorPosition.ts
@@ -1,5 +1,5 @@
 import { VirtualElement } from '@popperjs/core'
-import React, { useMemo } from 'react'
+import React, { useMemo, useEffect, useRef } from 'react'
 import { usePopper } from 'react-popper'
 
 export interface IFloatingInspectorPosition {
@@ -11,65 +11,46 @@ export interface IFloatingInspectorPosition {
 
 export function useInspectorPosition(
 	position: IFloatingInspectorPosition,
-	visible: boolean,
-	displayOn?: 'document' | 'viewport',
 	el?: HTMLElement | null | undefined
 ): React.CSSProperties | undefined {
-	// const [viewportRect, setViewportRect] = useState<IRect | null>(null)
-	// const [elRect, setElRect] = useState<IRect | null>(null)
-
-	// useLayoutEffect(() => {
-	// 	if (!visible) return
-
-	// 	setViewportRect({
-	// 		top: window.scrollY,
-	// 		left: window.scrollY,
-	// 		width: window.innerWidth,
-	// 		height: window.innerHeight,
-	// 	})
-	// }, [visible])
-
-	// useLayoutEffect(() => {
-	//     if (!el) return
-
-	//     const rect = el.getBoundingClientRect()
-	//     setElRect({
-	//         top: rect.top,
-	//         left: rect.left,
-	//         height: rect.height,
-	//         width: rect.width,
-	//     })
-	// }, [el])
-
-	// const result = useMemo<React.CSSProperties | undefined>(() => {
-	// 	if (!visible) return undefined
-
-	// 	return {
-	// 		top: position.top + 'px',
-	// 		left: position.left + 'px',
-	// 		transform: 'translate(0, -100%)',
-	// 	}
-	// }, [position, visible, viewportRect, displayOn])
+	const positionRef = useRef({
+		...position,
+	})
 
 	const virtualElement = useMemo<VirtualElement>(() => {
 		return {
-			getBoundingClientRect: (): DOMRect => ({
-				top: position.top ?? 0,
-				left: position.left ?? 0,
-				width: 0,
-				height: 0,
-				right: position.left ?? 0,
-				bottom: position.top ?? 0,
-				x: position.left ?? 0,
-				y: position.top ?? 0,
-				toJSON: () => '',
-			}),
+			getBoundingClientRect: (): DOMRect => {
+				console.log('getBoundingClientRect')
+				return {
+					top: positionRef.current.top ?? 0,
+					left: positionRef.current.left ?? 0,
+					width: 0,
+					height: 0,
+					right: positionRef.current.left ?? 0,
+					bottom: positionRef.current.top ?? 0,
+					x: positionRef.current.left ?? 0,
+					y: positionRef.current.top ?? 0,
+					toJSON: () => '',
+				}
+			},
+		}
+	}, [])
+
+	useEffect(() => {
+		positionRef.current = {
+			...position,
 		}
 	}, [position])
 
-	const { styles } = usePopper(virtualElement, el, {
+	const { styles, update } = usePopper(virtualElement, el, {
 		placement: position.position,
 	})
 
-	return styles
+	useEffect(() => {
+		if (update) update().catch(console.error)
+	}, [update, position])
+
+	console.log(styles.popper, position)
+
+	return styles.popper
 }

--- a/meteor/client/ui/FloatingInspectors/IFloatingInspectorPosition.ts
+++ b/meteor/client/ui/FloatingInspectors/IFloatingInspectorPosition.ts
@@ -1,0 +1,46 @@
+import React, { useEffect, useMemo, useState } from 'react'
+
+export interface IFloatingInspectorPosition {
+	top?: number
+	left?: number
+	right?: number
+	bottom?: number
+	position: 'top' | 'bottom'
+}
+
+interface IRect {
+	top: number
+	left: number
+	width: number
+	height: number
+}
+
+export function useInspectorPosition(
+	position: IFloatingInspectorPosition,
+	visible: boolean
+): React.CSSProperties | undefined {
+	const [viewportRect, setViewportRect] = useState<IRect | null>(null)
+
+	useEffect(() => {
+		if (!visible) return
+
+		setViewportRect({
+			top: window.scrollY,
+			left: window.scrollY,
+			width: window.innerWidth,
+			height: window.innerHeight,
+		})
+	}, [visible])
+
+	const result = useMemo<React.CSSProperties | undefined>(() => {
+		if (!visible) return undefined
+
+		return {
+			top: position.top + 'px',
+			left: position.left + 'px',
+			transform: 'translate(0, -100%)',
+		}
+	}, [position, visible, viewportRect])
+
+	return result
+}

--- a/meteor/client/ui/FloatingInspectors/IFloatingInspectorPosition.ts
+++ b/meteor/client/ui/FloatingInspectors/IFloatingInspectorPosition.ts
@@ -11,7 +11,7 @@ export interface IFloatingInspectorPosition {
 
 export function useInspectorPosition(
 	position: IFloatingInspectorPosition,
-	el?: HTMLElement | null | undefined
+	el: HTMLElement | null
 ): React.CSSProperties | undefined {
 	const positionRef = useRef({
 		...position,

--- a/meteor/client/ui/FloatingInspectors/IFloatingInspectorPosition.ts
+++ b/meteor/client/ui/FloatingInspectors/IFloatingInspectorPosition.ts
@@ -1,46 +1,75 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import { VirtualElement } from '@popperjs/core'
+import React, { useMemo } from 'react'
+import { usePopper } from 'react-popper'
 
 export interface IFloatingInspectorPosition {
-	top?: number
-	left?: number
-	right?: number
-	bottom?: number
-	position: 'top' | 'bottom'
-}
-
-interface IRect {
 	top: number
 	left: number
-	width: number
-	height: number
+	position: 'top' | 'bottom'
+	anchor: 'start' | 'center' | 'end'
 }
 
 export function useInspectorPosition(
 	position: IFloatingInspectorPosition,
-	visible: boolean
+	visible: boolean,
+	displayOn?: 'document' | 'viewport',
+	el?: HTMLElement | null | undefined
 ): React.CSSProperties | undefined {
-	const [viewportRect, setViewportRect] = useState<IRect | null>(null)
+	// const [viewportRect, setViewportRect] = useState<IRect | null>(null)
+	// const [elRect, setElRect] = useState<IRect | null>(null)
 
-	useEffect(() => {
-		if (!visible) return
+	// useLayoutEffect(() => {
+	// 	if (!visible) return
 
-		setViewportRect({
-			top: window.scrollY,
-			left: window.scrollY,
-			width: window.innerWidth,
-			height: window.innerHeight,
-		})
-	}, [visible])
+	// 	setViewportRect({
+	// 		top: window.scrollY,
+	// 		left: window.scrollY,
+	// 		width: window.innerWidth,
+	// 		height: window.innerHeight,
+	// 	})
+	// }, [visible])
 
-	const result = useMemo<React.CSSProperties | undefined>(() => {
-		if (!visible) return undefined
+	// useLayoutEffect(() => {
+	//     if (!el) return
 
+	//     const rect = el.getBoundingClientRect()
+	//     setElRect({
+	//         top: rect.top,
+	//         left: rect.left,
+	//         height: rect.height,
+	//         width: rect.width,
+	//     })
+	// }, [el])
+
+	// const result = useMemo<React.CSSProperties | undefined>(() => {
+	// 	if (!visible) return undefined
+
+	// 	return {
+	// 		top: position.top + 'px',
+	// 		left: position.left + 'px',
+	// 		transform: 'translate(0, -100%)',
+	// 	}
+	// }, [position, visible, viewportRect, displayOn])
+
+	const virtualElement = useMemo<VirtualElement>(() => {
 		return {
-			top: position.top + 'px',
-			left: position.left + 'px',
-			transform: 'translate(0, -100%)',
+			getBoundingClientRect: (): DOMRect => ({
+				top: position.top ?? 0,
+				left: position.left ?? 0,
+				width: 0,
+				height: 0,
+				right: position.left ?? 0,
+				bottom: position.top ?? 0,
+				x: position.left ?? 0,
+				y: position.top ?? 0,
+				toJSON: () => '',
+			}),
 		}
-	}, [position, visible, viewportRect])
+	}, [position])
 
-	return result
+	const { styles } = usePopper(virtualElement, el, {
+		placement: position.position,
+	})
+
+	return styles
 }

--- a/meteor/client/ui/FloatingInspectors/IFloatingInspectorPosition.ts
+++ b/meteor/client/ui/FloatingInspectors/IFloatingInspectorPosition.ts
@@ -54,21 +54,22 @@ export function useInspectorPosition(
 		placement: position.position,
 		modifiers: [
 			{
-				name: 'offset',
-				options: {
-					offset: [0, 8],
-				},
-			},
-			{
 				name: 'flip',
 				options: {
-					fallbackPlacements: ['top', 'bottom'],
+					padding: { top: getHeaderHeight() - 10 },
+					fallbackPlacements: ['bottom', 'top'],
 				},
 			},
 			{
 				name: 'preventOverflow',
 				options: {
-					padding: { top: getHeaderHeight() },
+					mainAxis: true,
+				},
+			},
+			{
+				name: 'offset',
+				options: {
+					offset: [0, 8],
 				},
 			},
 		],

--- a/meteor/client/ui/FloatingInspectors/InvalidFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/InvalidFloatingInspector.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { FloatingInspector } from '../FloatingInspector'
@@ -34,6 +34,7 @@ function renderReason(noticeLevel: NoteSeverity, noticeMessage: string | null): 
 
 export const InvalidFloatingInspector: React.FunctionComponent<IProps> = (props: IProps) => {
 	const { t } = useTranslation()
+	const ref = useRef<HTMLDivElement>(null)
 
 	if (!props.part.invalidReason) {
 		return null
@@ -41,7 +42,7 @@ export const InvalidFloatingInspector: React.FunctionComponent<IProps> = (props:
 
 	const noteSeverity = props.part.invalidReason.severity || NoteSeverity.INFO
 
-	const floatingInspectorStyle = useInspectorPosition(props.position)
+	const floatingInspectorStyle = useInspectorPosition(props.position, ref.current)
 
 	return (
 		<FloatingInspector shown={props.showMiniInspector && props.itemElement !== undefined} displayOn={props.displayOn}>
@@ -57,6 +58,7 @@ export const InvalidFloatingInspector: React.FunctionComponent<IProps> = (props:
 						: '')
 				}
 				style={floatingInspectorStyle}
+				ref={ref}
 			>
 				{renderReason(noteSeverity, translateMessage(props.part.invalidReason.message, t))}
 			</div>

--- a/meteor/client/ui/FloatingInspectors/InvalidFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/InvalidFloatingInspector.tsx
@@ -44,7 +44,7 @@ export const InvalidFloatingInspector: React.FunctionComponent<IProps> = (props:
 
 	const shown = props.showMiniInspector && props.itemElement !== undefined
 
-	const floatingInspectorStyle = useInspectorPosition(props.position, ref, shown)
+	const { style: floatingInspectorStyle } = useInspectorPosition(props.position, ref, shown)
 
 	return (
 		<FloatingInspector shown={shown} displayOn="viewport">

--- a/meteor/client/ui/FloatingInspectors/InvalidFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/InvalidFloatingInspector.tsx
@@ -6,11 +6,12 @@ import { DBPart } from '../../../lib/collections/Parts'
 import { NoteSeverity } from '@sofie-automation/blueprints-integration'
 import { CriticalIconSmall, WarningIconSmall } from '../../lib/ui/icons/notifications'
 import { translateMessage } from '@sofie-automation/corelib/dist/TranslatableMessage'
+import { IFloatingInspectorPosition, useInspectorPosition } from './IFloatingInspectorPosition'
 
 interface IProps {
 	itemElement: HTMLDivElement | null
 	showMiniInspector: boolean
-	floatingInspectorStyle: React.CSSProperties
+	position: IFloatingInspectorPosition
 	part: DBPart
 
 	displayOn?: 'document' | 'viewport'
@@ -40,6 +41,8 @@ export const InvalidFloatingInspector: React.FunctionComponent<IProps> = (props:
 
 	const noteSeverity = props.part.invalidReason.severity || NoteSeverity.INFO
 
+	const floatingInspectorStyle = useInspectorPosition(props.position)
+
 	return (
 		<FloatingInspector shown={props.showMiniInspector && props.itemElement !== undefined} displayOn={props.displayOn}>
 			<div
@@ -53,7 +56,7 @@ export const InvalidFloatingInspector: React.FunctionComponent<IProps> = (props:
 						? 'segment-timeline__mini-inspector--notice notice-warning'
 						: '')
 				}
-				style={props.floatingInspectorStyle}
+				style={floatingInspectorStyle}
 			>
 				{renderReason(noteSeverity, translateMessage(props.part.invalidReason.message, t))}
 			</div>

--- a/meteor/client/ui/FloatingInspectors/InvalidFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/InvalidFloatingInspector.tsx
@@ -42,10 +42,12 @@ export const InvalidFloatingInspector: React.FunctionComponent<IProps> = (props:
 
 	const noteSeverity = props.part.invalidReason.severity || NoteSeverity.INFO
 
-	const floatingInspectorStyle = useInspectorPosition(props.position, ref.current)
+	const shown = props.showMiniInspector && props.itemElement !== undefined
+
+	const floatingInspectorStyle = useInspectorPosition(props.position, ref, shown)
 
 	return (
-		<FloatingInspector shown={props.showMiniInspector && props.itemElement !== undefined} displayOn="viewport">
+		<FloatingInspector shown={shown} displayOn="viewport">
 			<div
 				className={
 					'segment-timeline__mini-inspector ' +

--- a/meteor/client/ui/FloatingInspectors/InvalidFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/InvalidFloatingInspector.tsx
@@ -45,7 +45,7 @@ export const InvalidFloatingInspector: React.FunctionComponent<IProps> = (props:
 	const floatingInspectorStyle = useInspectorPosition(props.position, ref.current)
 
 	return (
-		<FloatingInspector shown={props.showMiniInspector && props.itemElement !== undefined} displayOn={props.displayOn}>
+		<FloatingInspector shown={props.showMiniInspector && props.itemElement !== undefined} displayOn="viewport">
 			<div
 				className={
 					'segment-timeline__mini-inspector ' +

--- a/meteor/client/ui/FloatingInspectors/InvalidFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/InvalidFloatingInspector.tsx
@@ -36,15 +36,15 @@ export const InvalidFloatingInspector: React.FunctionComponent<IProps> = (props:
 	const { t } = useTranslation()
 	const ref = useRef<HTMLDivElement>(null)
 
+	const shown = props.showMiniInspector && props.itemElement !== undefined
+
+	const { style: floatingInspectorStyle } = useInspectorPosition(props.position, ref, shown)
+
 	if (!props.part.invalidReason) {
 		return null
 	}
 
 	const noteSeverity = props.part.invalidReason.severity || NoteSeverity.INFO
-
-	const shown = props.showMiniInspector && props.itemElement !== undefined
-
-	const { style: floatingInspectorStyle } = useInspectorPosition(props.position, ref, shown)
 
 	return (
 		<FloatingInspector shown={shown} displayOn="viewport">

--- a/meteor/client/ui/FloatingInspectors/L3rdFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/L3rdFloatingInspector.tsx
@@ -32,7 +32,6 @@ export const L3rdFloatingInspector: React.FunctionComponent<IProps> = ({
 	pieceRenderedIn,
 	pieceRenderedDuration,
 	typeClass,
-	displayOn,
 }) => {
 	const noraContent = (content as NoraContent)?.payload?.content ? (content as NoraContent | undefined) : undefined
 
@@ -84,10 +83,10 @@ export const L3rdFloatingInspector: React.FunctionComponent<IProps> = ({
 
 	return noraContent && noraContent.payload && noraContent.previewRenderer ? (
 		showMiniInspector ? (
-			<NoraFloatingInspector noraContent={noraContent} style={floatingInspectorStyle ?? {}} displayOn={displayOn} />
+			<NoraFloatingInspector ref={ref} noraContent={noraContent} style={floatingInspectorStyle ?? {}} />
 		) : null
 	) : (
-		<FloatingInspector shown={showMiniInspector} displayOn={displayOn}>
+		<FloatingInspector shown={showMiniInspector} displayOn="viewport">
 			<div className={'segment-timeline__mini-inspector ' + typeClass} style={floatingInspectorStyle} ref={ref}>
 				{templateName && (
 					<div className="mini-inspector__header">

--- a/meteor/client/ui/FloatingInspectors/L3rdFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/L3rdFloatingInspector.tsx
@@ -79,7 +79,7 @@ export const L3rdFloatingInspector: React.FunctionComponent<IProps> = ({
 
 	const ref = useRef<HTMLDivElement>(null)
 
-	const floatingInspectorStyle = useInspectorPosition(position, ref, showMiniInspector)
+	const { style: floatingInspectorStyle } = useInspectorPosition(position, ref, showMiniInspector)
 
 	return noraContent && noraContent.payload && noraContent.previewRenderer ? (
 		showMiniInspector ? (

--- a/meteor/client/ui/FloatingInspectors/L3rdFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/L3rdFloatingInspector.tsx
@@ -79,7 +79,7 @@ export const L3rdFloatingInspector: React.FunctionComponent<IProps> = ({
 
 	const ref = useRef<HTMLDivElement>(null)
 
-	const floatingInspectorStyle = useInspectorPosition(position, ref.current)
+	const floatingInspectorStyle = useInspectorPosition(position, ref, showMiniInspector)
 
 	return noraContent && noraContent.payload && noraContent.previewRenderer ? (
 		showMiniInspector ? (

--- a/meteor/client/ui/FloatingInspectors/L3rdFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/L3rdFloatingInspector.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import * as _ from 'underscore'
 
 import { GraphicsContent, NoraContent } from '@sofie-automation/blueprints-integration'
@@ -78,7 +78,9 @@ export const L3rdFloatingInspector: React.FunctionComponent<IProps> = ({
 		noraContent?.payload?.metadata?.templateVariant ??
 		(piece.name !== graphicContent?.fileName ? graphicContent?.fileName : undefined)
 
-	const floatingInspectorStyle = useInspectorPosition(position)
+	const ref = useRef<HTMLDivElement>(null)
+
+	const floatingInspectorStyle = useInspectorPosition(position, ref.current)
 
 	return noraContent && noraContent.payload && noraContent.previewRenderer ? (
 		showMiniInspector ? (
@@ -86,7 +88,7 @@ export const L3rdFloatingInspector: React.FunctionComponent<IProps> = ({
 		) : null
 	) : (
 		<FloatingInspector shown={showMiniInspector} displayOn={displayOn}>
-			<div className={'segment-timeline__mini-inspector ' + typeClass} style={floatingInspectorStyle}>
+			<div className={'segment-timeline__mini-inspector ' + typeClass} style={floatingInspectorStyle} ref={ref}>
 				{templateName && (
 					<div className="mini-inspector__header">
 						<span>{templateName}</span>

--- a/meteor/client/ui/FloatingInspectors/L3rdFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/L3rdFloatingInspector.tsx
@@ -8,6 +8,7 @@ import { FloatingInspector } from '../FloatingInspector'
 import { Time } from '../../../lib/lib'
 import { PieceInstancePiece } from '../../../lib/collections/PieceInstances'
 import { FloatingInspectorTimeInformationRow } from './FloatingInspectorHelpers/FloatingInspectorTimeInformationRow'
+import { IFloatingInspectorPosition, useInspectorPosition } from './IFloatingInspectorPosition'
 
 interface IProps {
 	piece: Omit<PieceInstancePiece, 'timelineObjectsString'>
@@ -16,7 +17,7 @@ interface IProps {
 	showMiniInspector: boolean
 	itemElement: HTMLDivElement | null
 	content: GraphicsContent | NoraContent | undefined
-	floatingInspectorStyle: React.CSSProperties
+	position: IFloatingInspectorPosition
 	typeClass?: string
 	displayOn?: 'document' | 'viewport'
 }
@@ -25,7 +26,7 @@ type KeyValue = { key: string; value: string }
 
 export const L3rdFloatingInspector: React.FunctionComponent<IProps> = ({
 	content,
-	floatingInspectorStyle,
+	position,
 	showMiniInspector,
 	piece,
 	pieceRenderedIn,
@@ -77,9 +78,11 @@ export const L3rdFloatingInspector: React.FunctionComponent<IProps> = ({
 		noraContent?.payload?.metadata?.templateVariant ??
 		(piece.name !== graphicContent?.fileName ? graphicContent?.fileName : undefined)
 
+	const floatingInspectorStyle = useInspectorPosition(position)
+
 	return noraContent && noraContent.payload && noraContent.previewRenderer ? (
 		showMiniInspector ? (
-			<NoraFloatingInspector noraContent={noraContent} style={floatingInspectorStyle} displayOn={displayOn} />
+			<NoraFloatingInspector noraContent={noraContent} style={floatingInspectorStyle ?? {}} displayOn={displayOn} />
 		) : null
 	) : (
 		<FloatingInspector shown={showMiniInspector} displayOn={displayOn}>

--- a/meteor/client/ui/FloatingInspectors/MicFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/MicFloatingInspector.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import Moment from 'react-moment'
 
@@ -19,9 +19,11 @@ interface IProps {
 export function MicFloatingInspector(props: IProps): JSX.Element {
 	const { t } = useTranslation()
 
+	const ref = useRef<HTMLDivElement>(null)
+
 	const { startOfScript, endOfScript, breakScript } = getScriptPreview(props.content.fullScript || '')
 
-	const floatingInspectorStyle = useInspectorPosition(props.position)
+	const floatingInspectorStyle = useInspectorPosition(props.position, ref.current)
 
 	return (
 		<FloatingInspector shown={props.showMiniInspector && props.itemElement !== undefined} displayOn={props.displayOn}>
@@ -30,6 +32,7 @@ export function MicFloatingInspector(props: IProps): JSX.Element {
 					'segment-timeline__mini-inspector ' + props.typeClass + ' segment-timeline__mini-inspector--pop-down'
 				}
 				style={floatingInspectorStyle}
+				ref={ref}
 			>
 				<div>
 					{props.content && props.content.fullScript ? (

--- a/meteor/client/ui/FloatingInspectors/MicFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/MicFloatingInspector.tsx
@@ -23,10 +23,12 @@ export function MicFloatingInspector(props: IProps): JSX.Element {
 
 	const { startOfScript, endOfScript, breakScript } = getScriptPreview(props.content.fullScript || '')
 
-	const floatingInspectorStyle = useInspectorPosition(props.position, ref.current)
+	const shown = props.showMiniInspector && props.itemElement !== undefined
+
+	const floatingInspectorStyle = useInspectorPosition(props.position, ref, shown)
 
 	return (
-		<FloatingInspector shown={props.showMiniInspector && props.itemElement !== undefined} displayOn="viewport">
+		<FloatingInspector shown={shown} displayOn="viewport">
 			<div
 				className={
 					'segment-timeline__mini-inspector ' + props.typeClass + ' segment-timeline__mini-inspector--pop-down'

--- a/meteor/client/ui/FloatingInspectors/MicFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/MicFloatingInspector.tsx
@@ -25,7 +25,7 @@ export function MicFloatingInspector(props: IProps): JSX.Element {
 
 	const shown = props.showMiniInspector && props.itemElement !== undefined
 
-	const floatingInspectorStyle = useInspectorPosition(props.position, ref, shown)
+	const { style: floatingInspectorStyle } = useInspectorPosition(props.position, ref, shown)
 
 	return (
 		<FloatingInspector shown={shown} displayOn="viewport">

--- a/meteor/client/ui/FloatingInspectors/MicFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/MicFloatingInspector.tsx
@@ -5,12 +5,13 @@ import Moment from 'react-moment'
 import { FloatingInspector } from '../FloatingInspector'
 import { ScriptContent } from '@sofie-automation/blueprints-integration'
 import { getScriptPreview } from '../../lib/ui/scriptPreview'
+import { IFloatingInspectorPosition, useInspectorPosition } from './IFloatingInspectorPosition'
 
 interface IProps {
 	typeClass?: string
 	showMiniInspector: boolean
 	itemElement: HTMLDivElement | null
-	floatingInspectorStyle: React.CSSProperties
+	position: IFloatingInspectorPosition
 	content: ScriptContent
 	displayOn?: 'document' | 'viewport'
 }
@@ -20,13 +21,15 @@ export function MicFloatingInspector(props: IProps): JSX.Element {
 
 	const { startOfScript, endOfScript, breakScript } = getScriptPreview(props.content.fullScript || '')
 
+	const floatingInspectorStyle = useInspectorPosition(props.position)
+
 	return (
 		<FloatingInspector shown={props.showMiniInspector && props.itemElement !== undefined} displayOn={props.displayOn}>
 			<div
 				className={
 					'segment-timeline__mini-inspector ' + props.typeClass + ' segment-timeline__mini-inspector--pop-down'
 				}
-				style={props.floatingInspectorStyle}
+				style={floatingInspectorStyle}
 			>
 				<div>
 					{props.content && props.content.fullScript ? (

--- a/meteor/client/ui/FloatingInspectors/MicFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/MicFloatingInspector.tsx
@@ -26,7 +26,7 @@ export function MicFloatingInspector(props: IProps): JSX.Element {
 	const floatingInspectorStyle = useInspectorPosition(props.position, ref.current)
 
 	return (
-		<FloatingInspector shown={props.showMiniInspector && props.itemElement !== undefined} displayOn={props.displayOn}>
+		<FloatingInspector shown={props.showMiniInspector && props.itemElement !== undefined} displayOn="viewport">
 			<div
 				className={
 					'segment-timeline__mini-inspector ' + props.typeClass + ' segment-timeline__mini-inspector--pop-down'

--- a/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useImperativeHandle } from 'react'
 import { NoraContent } from '@sofie-automation/blueprints-integration'
 import Escape from './../../lib/Escape'
 
@@ -17,7 +17,18 @@ interface IStateHeader extends IPropsHeader {
 	displayOn: 'document' | 'viewport'
 }
 
-export const NoraFloatingInspector: React.FunctionComponent<IPropsHeader> = (props: IPropsHeader) => {
+export const NoraFloatingInspector = React.forwardRef<HTMLDivElement, IPropsHeader>(function NoraFloatinInspector(
+	props: IPropsHeader,
+	ref
+) {
+	useImperativeHandle(
+		ref,
+		() => {
+			return NoraPreviewRenderer._singletonRef.rootElement
+		},
+		[]
+	)
+
 	useEffect(() => {
 		if (props.noraContent) {
 			NoraPreviewRenderer.show(props.noraContent, props.style, props.displayOn || 'document')
@@ -26,14 +37,16 @@ export const NoraFloatingInspector: React.FunctionComponent<IPropsHeader> = (pro
 		return () => {
 			NoraPreviewRenderer.hide()
 		}
-	})
+	}, [])
+
 	return null
-}
+})
 
 export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 	static _singletonRef: NoraPreviewRenderer
 
 	iframeElement: HTMLIFrameElement
+	rootElement: HTMLDivElement
 
 	private _intersections:
 		| {
@@ -186,6 +199,10 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 		this._observer.observe(e)
 	}
 
+	private _setRootElement = (e: HTMLDivElement) => {
+		this.rootElement = e
+	}
+
 	componentWillUnmount(): void {
 		if (this._observer) this._observer.disconnect()
 	}
@@ -194,13 +211,13 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 		const style = { ...this.state.style }
 		style.visibility = this.state.show ? 'visible' : 'hidden'
 
-		if (this.state.flip.x && this.state.flip.y) {
-			style.transform = 'translate(0, var(--popdown))'
-		} else if (this.state.flip.x) {
-			style.transform = 'translate(0, -100%)'
-		} else if (this.state.flip.y) {
-			style.transform = 'translate(-100%, var(--popdown))'
-		}
+		// if (this.state.flip.x && this.state.flip.y) {
+		// 	style.transform = 'translate(0, var(--popdown))'
+		// } else if (this.state.flip.x) {
+		// 	style.transform = 'translate(0, -100%)'
+		// } else if (this.state.flip.y) {
+		// 	style.transform = 'translate(-100%, var(--popdown))'
+		// }
 
 		return style
 	}
@@ -215,6 +232,7 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 					<div
 						className="segment-timeline__mini-inspector segment-timeline__mini-inspector--graphics segment-timeline__mini-inspector--graphics--preview"
 						style={this.getElStyle()}
+						ref={this._setRootElement}
 					>
 						<div className="preview">
 							<img width="100%" src="/images/previewBG.jpg" alt="" />

--- a/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
@@ -121,7 +121,6 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 	}
 
 	private _hide() {
-		console.log('hide')
 		this.setState({
 			show: false,
 		})

--- a/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
@@ -5,16 +5,10 @@ import Escape from './../../lib/Escape'
 interface IPropsHeader {
 	noraContent: NoraContent | undefined
 	style: React.CSSProperties
-	displayOn?: 'document' | 'viewport'
 }
 
 interface IStateHeader extends IPropsHeader {
 	show: boolean
-	flip: {
-		x: boolean
-		y: boolean
-	}
-	displayOn: 'document' | 'viewport'
 }
 
 export const NoraFloatingInspector = React.forwardRef<HTMLDivElement, IPropsHeader>(function NoraFloatinInspector(
@@ -31,13 +25,19 @@ export const NoraFloatingInspector = React.forwardRef<HTMLDivElement, IPropsHead
 
 	useEffect(() => {
 		if (props.noraContent) {
-			NoraPreviewRenderer.show(props.noraContent, props.style, props.displayOn || 'document')
+			NoraPreviewRenderer.show()
 		}
 
 		return () => {
 			NoraPreviewRenderer.hide()
 		}
 	}, [])
+
+	useEffect(() => {
+		if (props.noraContent) {
+			NoraPreviewRenderer.update(props.noraContent, props.style)
+		}
+	}, [props.noraContent, props.style])
 
 	return null
 })
@@ -48,26 +48,12 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 	iframeElement: HTMLIFrameElement
 	rootElement: HTMLDivElement
 
-	private _intersections:
-		| {
-				boundingClientRect: {
-					top: number
-					right: number
-					bottom: number
-					left: number
-				}
-				intersectionRect: {
-					top: number
-					right: number
-					bottom: number
-					left: number
-				}
-		  }
-		| undefined
-	private _observer: IntersectionObserver | undefined
+	static update(noraContent: NoraContent, style: React.CSSProperties): void {
+		NoraPreviewRenderer._singletonRef._update(noraContent, style)
+	}
 
-	static show(noraContent: NoraContent, style: React.CSSProperties, displayOn: 'document' | 'viewport'): void {
-		NoraPreviewRenderer._singletonRef._show(noraContent, style, displayOn)
+	static show(): void {
+		NoraPreviewRenderer._singletonRef._show()
 	}
 
 	static hide(): void {
@@ -81,11 +67,6 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 			show: false,
 			noraContent: undefined,
 			style: {},
-			flip: {
-				x: false,
-				y: false,
-			},
-			displayOn: 'document',
 		}
 		NoraPreviewRenderer._singletonRef = this
 	}
@@ -120,46 +101,27 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 		)
 	}
 
-	private _show(noraContent: NoraContent, style: React.CSSProperties, displayOn?: 'document' | 'viewport') {
+	private _show() {
+		this.setState({
+			show: true,
+		})
+	}
+
+	private _update(noraContent: NoraContent, style: React.CSSProperties) {
 		if (JSON.stringify(this.state.noraContent) !== JSON.stringify(noraContent)) {
 			if (this.iframeElement && this.iframeElement.contentWindow) {
 				this.postNoraEvent(this.iframeElement.contentWindow, noraContent)
 			}
 		}
 
-		let x = this.state.flip.x
-		let y = this.state.flip.y
-
-		if (this._intersections) {
-			if (y && this._intersections.intersectionRect.bottom < this._intersections.boundingClientRect.bottom) {
-				// flip to bottom
-				y = false
-			} else if (!y && this._intersections.intersectionRect.top > this._intersections.boundingClientRect.top) {
-				// flip to top
-				y = true
-			}
-			if (x && this._intersections.intersectionRect.right < this._intersections.boundingClientRect.right) {
-				// flip to bottom
-				x = false
-			} else if (!x && this._intersections.intersectionRect.left > this._intersections.boundingClientRect.left) {
-				// flip to top
-				x = true
-			}
-		}
-
 		this.setState({
-			show: true,
 			noraContent,
 			style,
-			flip: {
-				x,
-				y,
-			},
-			displayOn: displayOn || 'document',
 		})
 	}
 
 	private _hide() {
+		console.log('hide')
 		this.setState({
 			show: false,
 		})
@@ -185,40 +147,15 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 		for (let i = 0; i < 50; i++) {
 			options.threshold.push(i / 50)
 		}
-
-		this._observer = new IntersectionObserver((entries) => {
-			entries.forEach((entry) => {
-				if (entry.target === e) {
-					this._intersections = {
-						boundingClientRect: entry.boundingClientRect,
-						intersectionRect: entry.intersectionRect,
-					}
-				}
-			})
-		}, options)
-		this._observer.observe(e)
 	}
 
 	private _setRootElement = (e: HTMLDivElement) => {
 		this.rootElement = e
 	}
 
-	componentWillUnmount(): void {
-		if (this._observer) this._observer.disconnect()
-	}
-
 	private getElStyle() {
 		const style = { ...this.state.style }
 		style.visibility = this.state.show ? 'visible' : 'hidden'
-
-		// if (this.state.flip.x && this.state.flip.y) {
-		// 	style.transform = 'translate(0, var(--popdown))'
-		// } else if (this.state.flip.x) {
-		// 	style.transform = 'translate(0, -100%)'
-		// } else if (this.state.flip.y) {
-		// 	style.transform = 'translate(-100%, var(--popdown))'
-		// }
-
 		return style
 	}
 
@@ -228,7 +165,7 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 
 		return (
 			<React.Fragment>
-				<Escape to={this.state.displayOn}>
+				<Escape to="document">
 					<div
 						className="segment-timeline__mini-inspector segment-timeline__mini-inspector--graphics segment-timeline__mini-inspector--graphics--preview"
 						style={this.getElStyle()}

--- a/meteor/client/ui/FloatingInspectors/SplitsFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/SplitsFloatingInspector.tsx
@@ -25,10 +25,12 @@ export const SplitsFloatingInspector: React.FunctionComponent<IProps> = (props) 
 		}
 	}, [props.content.boxSourceConfiguration])
 
-	const floatingInspectorStyle = useInspectorPosition(props.position, ref.current)
+	const shown = props.showMiniInspector && props.itemElement !== undefined
+
+	const floatingInspectorStyle = useInspectorPosition(props.position, ref, shown)
 
 	return (
-		<FloatingInspector shown={props.showMiniInspector && props.itemElement !== undefined} displayOn="viewport">
+		<FloatingInspector shown={shown} displayOn="viewport">
 			<div
 				className="segment-timeline__mini-inspector segment-timeline__mini-inspector--video"
 				style={floatingInspectorStyle}

--- a/meteor/client/ui/FloatingInspectors/SplitsFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/SplitsFloatingInspector.tsx
@@ -3,12 +3,13 @@ import { FloatingInspector } from '../FloatingInspector'
 import { SplitsContent } from '@sofie-automation/blueprints-integration'
 import { getSplitPreview } from '../../lib/ui/splitPreview'
 import { RenderSplitPreview } from '../../lib/SplitPreviewBox'
+import { IFloatingInspectorPosition, useInspectorPosition } from './IFloatingInspectorPosition'
 
 interface IProps {
 	typeClass?: string
 	showMiniInspector: boolean
 	itemElement: HTMLDivElement | null
-	position: React.CSSProperties
+	position: IFloatingInspectorPosition
 	content: Partial<SplitsContent>
 	displayOn?: 'document' | 'viewport'
 }
@@ -22,11 +23,13 @@ export const SplitsFloatingInspector: React.FunctionComponent<IProps> = (props) 
 		}
 	}, [props.content.boxSourceConfiguration])
 
+	const floatingInspectorStyle = useInspectorPosition(props.position)
+
 	return (
 		<FloatingInspector shown={props.showMiniInspector && props.itemElement !== undefined} displayOn={props.displayOn}>
 			<div
 				className="segment-timeline__mini-inspector segment-timeline__mini-inspector--video"
-				style={props.position}
+				style={floatingInspectorStyle}
 			>
 				<RenderSplitPreview subItems={splitItems} showLabels={true} />
 			</div>

--- a/meteor/client/ui/FloatingInspectors/SplitsFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/SplitsFloatingInspector.tsx
@@ -27,7 +27,7 @@ export const SplitsFloatingInspector: React.FunctionComponent<IProps> = (props) 
 
 	const shown = props.showMiniInspector && props.itemElement !== undefined
 
-	const floatingInspectorStyle = useInspectorPosition(props.position, ref, shown)
+	const { style: floatingInspectorStyle } = useInspectorPosition(props.position, ref, shown)
 
 	return (
 		<FloatingInspector shown={shown} displayOn="viewport">

--- a/meteor/client/ui/FloatingInspectors/SplitsFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/SplitsFloatingInspector.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useMemo, useRef } from 'react'
 import { FloatingInspector } from '../FloatingInspector'
 import { SplitsContent } from '@sofie-automation/blueprints-integration'
 import { getSplitPreview } from '../../lib/ui/splitPreview'
@@ -15,6 +15,8 @@ interface IProps {
 }
 
 export const SplitsFloatingInspector: React.FunctionComponent<IProps> = (props) => {
+	const ref = useRef(null)
+
 	const splitItems = useMemo(() => {
 		if (props.content.boxSourceConfiguration) {
 			return getSplitPreview(props.content.boxSourceConfiguration)
@@ -23,13 +25,14 @@ export const SplitsFloatingInspector: React.FunctionComponent<IProps> = (props) 
 		}
 	}, [props.content.boxSourceConfiguration])
 
-	const floatingInspectorStyle = useInspectorPosition(props.position)
+	const floatingInspectorStyle = useInspectorPosition(props.position, ref.current)
 
 	return (
 		<FloatingInspector shown={props.showMiniInspector && props.itemElement !== undefined} displayOn={props.displayOn}>
 			<div
 				className="segment-timeline__mini-inspector segment-timeline__mini-inspector--video"
 				style={floatingInspectorStyle}
+				ref={ref}
 			>
 				<RenderSplitPreview subItems={splitItems} showLabels={true} />
 			</div>

--- a/meteor/client/ui/FloatingInspectors/SplitsFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/SplitsFloatingInspector.tsx
@@ -8,7 +8,7 @@ interface IProps {
 	typeClass?: string
 	showMiniInspector: boolean
 	itemElement: HTMLDivElement | null
-	floatingInspectorStyle: React.CSSProperties
+	position: React.CSSProperties
 	content: Partial<SplitsContent>
 	displayOn?: 'document' | 'viewport'
 }
@@ -26,7 +26,7 @@ export const SplitsFloatingInspector: React.FunctionComponent<IProps> = (props) 
 		<FloatingInspector shown={props.showMiniInspector && props.itemElement !== undefined} displayOn={props.displayOn}>
 			<div
 				className="segment-timeline__mini-inspector segment-timeline__mini-inspector--video"
-				style={props.floatingInspectorStyle}
+				style={props.position}
 			>
 				<RenderSplitPreview subItems={splitItems} showLabels={true} />
 			</div>

--- a/meteor/client/ui/FloatingInspectors/SplitsFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/SplitsFloatingInspector.tsx
@@ -28,7 +28,7 @@ export const SplitsFloatingInspector: React.FunctionComponent<IProps> = (props) 
 	const floatingInspectorStyle = useInspectorPosition(props.position, ref.current)
 
 	return (
-		<FloatingInspector shown={props.showMiniInspector && props.itemElement !== undefined} displayOn={props.displayOn}>
+		<FloatingInspector shown={props.showMiniInspector && props.itemElement !== undefined} displayOn="viewport">
 			<div
 				className="segment-timeline__mini-inspector segment-timeline__mini-inspector--video"
 				style={floatingInspectorStyle}

--- a/meteor/client/ui/FloatingInspectors/VTFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/VTFloatingInspector.tsx
@@ -124,21 +124,26 @@ export const VTFloatingInspector: React.FC<IProps> = ({
 
 	const offsetTimePosition = timePosition + seek
 
-	const previewUrl: string | undefined = getPreviewUrlForExpectedPackagesAndContentMetaData(
-		pieceId,
-		studio,
-		studio?.settings.mediaPreviewsUrl,
-		expectedPackages,
-		contentMetaData
-	)
+	// const previewUrl: string | undefined = getPreviewUrlForExpectedPackagesAndContentMetaData(
+	// 	pieceId,
+	// 	studio,
+	// 	studio?.settings.mediaPreviewsUrl,
+	// 	expectedPackages,
+	// 	contentMetaData
+	// )
+
+	const previewUrl =
+		'https://upload.wikimedia.org/wikipedia/commons/transcoded/2/22/Volcano_Lava_Sample.webm/Volcano_Lava_Sample.webm.160p.webm'
 
 	const showVideoPlayerInspector = !hideHoverscrubPreview && previewUrl
 	const showMiniInspectorClipData = shouldShowFloatingInspectorContent(status, content)
 	const showMiniInspectorNotice = noticeLevel !== null
 	const showMiniInspectorData = showMiniInspectorNotice || showMiniInspectorClipData
-	const showAnyFloatingInspector = showVideoPlayerInspector || showMiniInspectorData
+	const showAnyFloatingInspector = Boolean(showVideoPlayerInspector) || showMiniInspectorData
 
-	const floatingInspectorStyle = useInspectorPosition(position, inspectorRef.current)
+	const shown = showMiniInspector && itemElement !== undefined && showAnyFloatingInspector
+
+	const floatingInspectorStyle = useInspectorPosition(position, inspectorRef, shown)
 
 	if (!showAnyFloatingInspector || !floatingInspectorStyle) {
 		return null
@@ -164,7 +169,7 @@ export const VTFloatingInspector: React.FC<IProps> = ({
 	)
 
 	return (
-		<FloatingInspector shown={showMiniInspector && itemElement !== undefined} displayOn="viewport">
+		<FloatingInspector shown={shown} displayOn="viewport">
 			{showVideoPlayerInspector ? (
 				<VideoPreviewPlayerInspector
 					itemDuration={itemDuration}

--- a/meteor/client/ui/FloatingInspectors/VTFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/VTFloatingInspector.tsx
@@ -111,7 +111,6 @@ export const VTFloatingInspector: React.FC<IProps> = ({
 	noticeMessages,
 	showMiniInspector,
 	itemElement,
-	displayOn,
 	position,
 	typeClass,
 	status,
@@ -165,7 +164,7 @@ export const VTFloatingInspector: React.FC<IProps> = ({
 	)
 
 	return (
-		<FloatingInspector shown={showMiniInspector && itemElement !== undefined} displayOn={displayOn}>
+		<FloatingInspector shown={showMiniInspector && itemElement !== undefined} displayOn="viewport">
 			{showVideoPlayerInspector ? (
 				<VideoPreviewPlayerInspector
 					itemDuration={itemDuration}

--- a/meteor/client/ui/FloatingInspectors/VTFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/VTFloatingInspector.tsx
@@ -15,6 +15,7 @@ import classNames from 'classnames'
 import { UIStudio } from '../../../lib/api/studios'
 import { PieceId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { ITranslatableMessage, translateMessage } from '@sofie-automation/corelib/dist/TranslatableMessage'
+import { IFloatingInspectorPosition, useInspectorPosition } from './IFloatingInspectorPosition'
 
 interface IProps {
 	status: PieceStatusCode
@@ -22,7 +23,7 @@ interface IProps {
 	typeClass?: string
 	showMiniInspector: boolean
 	itemElement: HTMLDivElement | null
-	floatingInspectorStyle: React.CSSProperties
+	position: IFloatingInspectorPosition
 	timePosition: number
 	content: VTContent | undefined
 	noticeLevel: NoticeLevel | null
@@ -106,7 +107,7 @@ export const VTFloatingInspector: React.FC<IProps> = ({
 	showMiniInspector,
 	itemElement,
 	displayOn,
-	floatingInspectorStyle,
+	position,
 	typeClass,
 	status,
 }: IProps) => {
@@ -132,7 +133,9 @@ export const VTFloatingInspector: React.FC<IProps> = ({
 	const showMiniInspectorData = showMiniInspectorNotice || showMiniInspectorClipData
 	const showAnyFloatingInspector = showVideoPlayerInspector || showMiniInspectorData
 
-	if (!showAnyFloatingInspector) {
+	const floatingInspectorStyle = useInspectorPosition(position, showMiniInspector, displayOn)
+
+	if (!showAnyFloatingInspector || !floatingInspectorStyle) {
 		return null
 	}
 

--- a/meteor/client/ui/FloatingInspectors/VTFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/VTFloatingInspector.tsx
@@ -124,16 +124,13 @@ export const VTFloatingInspector: React.FC<IProps> = ({
 
 	const offsetTimePosition = timePosition + seek
 
-	// const previewUrl: string | undefined = getPreviewUrlForExpectedPackagesAndContentMetaData(
-	// 	pieceId,
-	// 	studio,
-	// 	studio?.settings.mediaPreviewsUrl,
-	// 	expectedPackages,
-	// 	contentMetaData
-	// )
-
-	const previewUrl =
-		'https://upload.wikimedia.org/wikipedia/commons/transcoded/2/22/Volcano_Lava_Sample.webm/Volcano_Lava_Sample.webm.160p.webm'
+	const previewUrl: string | undefined = getPreviewUrlForExpectedPackagesAndContentMetaData(
+		pieceId,
+		studio,
+		studio?.settings.mediaPreviewsUrl,
+		expectedPackages,
+		contentMetaData
+	)
 
 	const showVideoPlayerInspector = !hideHoverscrubPreview && previewUrl
 	const showMiniInspectorClipData = shouldShowFloatingInspectorContent(status, content)
@@ -143,7 +140,7 @@ export const VTFloatingInspector: React.FC<IProps> = ({
 
 	const shown = showMiniInspector && itemElement !== undefined && showAnyFloatingInspector
 
-	const floatingInspectorStyle = useInspectorPosition(position, inspectorRef, shown)
+	const { style: floatingInspectorStyle, isFlipped } = useInspectorPosition(position, inspectorRef, shown)
 
 	if (!showAnyFloatingInspector || !floatingInspectorStyle) {
 		return null
@@ -153,6 +150,7 @@ export const VTFloatingInspector: React.FC<IProps> = ({
 		<div
 			className={classNames('segment-timeline__mini-inspector', typeClass, {
 				'segment-timeline__mini-inspector--sub-inspector': showVideoPlayerInspector,
+				'segment-timeline__mini-inspector--sub-inspector-flipped': showVideoPlayerInspector && isFlipped,
 				'segment-timeline__mini-inspector--notice notice-critical': noticeLevel === NoticeLevel.CRITICAL,
 				'segment-timeline__mini-inspector--notice notice-warning': noticeLevel === NoticeLevel.WARNING,
 			})}

--- a/meteor/client/ui/FloatingInspectors/VTFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/VTFloatingInspector.tsx
@@ -133,7 +133,7 @@ export const VTFloatingInspector: React.FC<IProps> = ({
 	const showMiniInspectorData = showMiniInspectorNotice || showMiniInspectorClipData
 	const showAnyFloatingInspector = showVideoPlayerInspector || showMiniInspectorData
 
-	const floatingInspectorStyle = useInspectorPosition(position, showMiniInspector, displayOn)
+	const floatingInspectorStyle = useInspectorPosition(position)
 
 	if (!showAnyFloatingInspector || !floatingInspectorStyle) {
 		return null

--- a/meteor/client/ui/RundownList.tsx
+++ b/meteor/client/ui/RundownList.tsx
@@ -1,25 +1,21 @@
 import Tooltip from 'rc-tooltip'
 import * as React from 'react'
-import {
-	DragElementWrapper,
-	DropTarget,
-	DropTargetCollector,
-	DropTargetConnector,
-	DropTargetMonitor,
-	DropTargetSpec,
-} from 'react-dnd'
+import { DropTargetMonitor, useDrop } from 'react-dnd'
 import { MeteorCall } from '../../lib/api/methods'
 import { PubSub } from '../../lib/api/pubsub'
-import { GENESIS_SYSTEM_VERSION, ICoreSystem } from '../../lib/collections/CoreSystem'
-import { RundownLayoutBase } from '../../lib/collections/RundownLayouts'
+import { GENESIS_SYSTEM_VERSION } from '../../lib/collections/CoreSystem'
 import { RundownPlaylist } from '../../lib/collections/RundownPlaylists'
 import { Rundown } from '../../lib/collections/Rundowns'
 import { getAllowConfigure, getHelpMode } from '../lib/localStorage'
 import { extendMandadory, unprotectString } from '../../lib/lib'
-import { MeteorReactComponent } from '../lib/MeteorReactComponent'
-import { Translated, translateWithTracker } from '../lib/ReactMeteorData/react-meteor-data'
+import { useSubscription, useTracker } from '../lib/ReactMeteorData/react-meteor-data'
 import { Spinner } from '../lib/Spinner'
-import { isRundownDragObject, RundownListDragDropTypes } from './RundownList/DragAndDropTypes'
+import {
+	IRundownDragObject,
+	IRundownPlaylistUiAction,
+	isRundownDragObject,
+	RundownListDragDropTypes,
+} from './RundownList/DragAndDropTypes'
 import { GettingStarted } from './RundownList/GettingStarted'
 import { RegisterHelp } from './RundownList/RegisterHelp'
 import { RundownDropZone } from './RundownList/RundownDropZone'
@@ -29,10 +25,21 @@ import { RundownPlaylistUi } from './RundownList/RundownPlaylistUi'
 import { doUserAction, UserAction } from '../../lib/clientUserAction'
 import { RundownLayoutsAPI } from '../../lib/api/rundownLayouts'
 import { PlaylistTiming } from '@sofie-automation/corelib/dist/playout/rundownTiming'
-import { UIShowStyleBases, UIStudios } from './Collections'
-import { RundownId, RundownPlaylistId, ShowStyleVariantId } from '@sofie-automation/corelib/dist/dataModel/Ids'
-import { getCoreSystem, RundownLayouts, RundownPlaylists, Rundowns, ShowStyleVariants } from '../collections'
+import { UIStudios } from './Collections'
+import { RundownId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import {
+	getCoreSystem,
+	RundownLayouts,
+	RundownPlaylists,
+	Rundowns,
+	ShowStyleBases,
+	ShowStyleVariants,
+} from '../collections'
 import { RundownPlaylistCollectionUtil } from '../../lib/collections/rundownPlaylistUtil'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ShowStyleBase } from '../../lib/collections/ShowStyleBases'
+import { ShowStyleVariant } from '../../lib/collections/ShowStyleVariants'
 
 export enum ToolTipStep {
 	TOOLTIP_START_HERE = 'TOOLTIP_START_HERE',
@@ -40,70 +47,75 @@ export enum ToolTipStep {
 	TOOLTIP_EXTRAS = 'TOOLTIP_EXTRAS',
 }
 
-interface IRundownsListProps {
-	coreSystem: ICoreSystem | undefined
-	rundownPlaylists: Array<RundownPlaylistUi>
-	rundownLayouts: Array<RundownLayoutBase>
-}
-
-interface IRundownsListState {
-	subsReady: boolean
-}
-
 interface IRundownsListDropTargetProps {
-	connectDropTarget: DragElementWrapper<RundownPlaylistUi>
 	activateDropZone: boolean
 }
 
-const dropTargetSpec: DropTargetSpec<IRundownsListProps> = {
-	canDrop: (props: IRundownsListProps, monitor: DropTargetMonitor) => {
-		/* We only accept rundowns from playlists with more than one rundown,
-			since there's no point in replacing a single rundown playlist with a new
-			single rundown playlist
-			*/
-		const item = monitor.getItem()
-		if (isRundownDragObject(item)) {
-			const { id } = item
-			const playlist = props.rundownPlaylists.find(
-				(playlist) => playlist.rundowns.findIndex((rundown) => rundown._id === id) > -1
-			)
-			return playlist?.rundowns !== undefined && playlist.rundowns.length > 1
-		}
+export function RundownList(): JSX.Element {
+	const { t } = useTranslation()
 
-		console.debug('RundownList Not accepting drop of ', item)
-		return false
-	},
-	// hover: (props, monitor) => {
-	// 	console.debug('Rundown list hover', monitor.getItem())
-	// }
-}
+	const playlistIds = useTracker(
+		() =>
+			RundownPlaylists.find(undefined, {
+				projection: {
+					_id: 1,
+				},
+			}).map((doc) => doc._id),
+		[],
+		[]
+	)
 
-const dropTargetCollector: DropTargetCollector<IRundownsListDropTargetProps, IRundownsListProps> = function (
-	connect: DropTargetConnector,
-	monitor: DropTargetMonitor,
-	_props: IRundownsListProps
-): IRundownsListDropTargetProps {
-	const activateDropZone = monitor.canDrop() && monitor.isOver()
+	const showStyleBaseIds = useTracker(
+		() =>
+			Rundowns.find({ playlistId: { $in: playlistIds } }, { projection: { _id: 1 } }).map((doc) => doc.showStyleBaseId),
+		[playlistIds],
+		[]
+	)
 
-	return {
-		connectDropTarget: connect.dropTarget(),
-		activateDropZone,
-	}
-}
+	const showStyleVariantIds = useTracker(
+		() =>
+			Rundowns.find({ playlistId: { $in: playlistIds } }, { projection: { _id: 1 } }).map(
+				(doc) => doc.showStyleVariantId
+			),
+		[playlistIds],
+		[]
+	)
 
-export const RundownList = translateWithTracker((): IRundownsListProps => {
-	const studios = UIStudios.find().fetch()
-	const showStyleBases = UIShowStyleBases.find().fetch()
-	const showStyleVariants = ShowStyleVariants.find().fetch()
-	const rundownLayouts = RundownLayouts.find({
-		$or: [{ exposeAsSelectableLayout: true }, { exposeAsStandalone: true }],
-	}).fetch()
+	const baseSubsReady = [
+		useSubscription(PubSub.rundownPlaylists, {}),
+		useSubscription(PubSub.uiStudio, null),
+		useSubscription(PubSub.rundownLayouts, {}),
 
-	return {
-		coreSystem: getCoreSystem(),
-		rundownPlaylists: RundownPlaylists.find({}, { sort: { created: -1 } })
-			.fetch()
-			.map((playlist: RundownPlaylist) => {
+		useSubscription(PubSub.rundowns, playlistIds, null),
+
+		useSubscription(PubSub.showStyleBases, {
+			_id: { $in: showStyleBaseIds },
+		}),
+
+		useSubscription(PubSub.showStyleVariants, {
+			_id: { $in: showStyleVariantIds },
+		}),
+	].reduce((prev, current) => prev && current, true)
+
+	const [subsReady, setSubsReady] = useState(false)
+
+	useEffect(() => {
+		if (baseSubsReady) setSubsReady(true)
+	}, [baseSubsReady])
+
+	const coreSystem = useTracker(() => getCoreSystem(), [])
+	const studios = useTracker(() => UIStudios.find().fetch(), [], [])
+	const rundownLayouts = useTracker(
+		() =>
+			RundownLayouts.find({
+				$or: [{ exposeAsSelectableLayout: true }, { exposeAsStandalone: true }],
+			}).fetch(),
+		[],
+		[]
+	)
+	const rundownPlaylists = useTracker(
+		() =>
+			RundownPlaylists.find({}, { sort: { created: -1 } }).map((playlist: RundownPlaylist) => {
 				const rundowns = RundownPlaylistCollectionUtil.getRundownsOrdered(playlist)
 
 				const airStatuses: string[] = []
@@ -119,14 +131,18 @@ export const RundownList = translateWithTracker((): IRundownsListProps => {
 						unsyncedRundowns.push(rundown)
 					}
 
-					const showStyleBase = showStyleBases.find((style) => style._id === rundown.showStyleBaseId)
+					const showStyleBase = ShowStyleBases.findOne(rundown.showStyleBaseId, {
+						projection: { _id: 1, name: 1 },
+					}) as Pick<ShowStyleBase, '_id' | 'name'>
 					if (showStyleBase) {
-						const showStyleVariant = showStyleVariants.find((variant) => variant._id === rundown.showStyleVariantId)
+						const showStyleVariant = ShowStyleVariants.findOne(rundown.showStyleVariantId, {
+							projection: { _id: 1, name: 1 },
+						}) as Pick<ShowStyleVariant, '_id' | 'name'>
 
 						showStyles.push({
 							id: showStyleBase._id,
 							baseName: showStyleBase.name || undefined,
-							variantName: (showStyleVariant && showStyleVariant.name) || undefined,
+							variantName: (showStyleVariant && showStyleVariant.name) ?? undefined,
 						})
 					}
 				}
@@ -140,175 +156,133 @@ export const RundownList = translateWithTracker((): IRundownsListProps => {
 					studioName: studios.find((s) => s._id === playlist.studioId)?.name || '',
 				})
 			}),
-		rundownLayouts,
-	}
-})(
-	DropTarget(
-		RundownListDragDropTypes.RUNDOWN,
-		dropTargetSpec,
-		dropTargetCollector
-	)(
-		class RundownList extends MeteorReactComponent<
-			Translated<IRundownsListProps> & IRundownsListDropTargetProps,
-			IRundownsListState
-		> {
-			// private _subscriptions: Array<Meteor.SubscriptionHandle> = []
-			constructor(props: Translated<IRundownsListProps> & IRundownsListDropTargetProps) {
-				super(props)
+		[studios],
+		[]
+	)
 
-				this.state = {
-					subsReady: false,
-				}
-			}
+	const step = useMemo(() => {
+		let gotPlaylists = false
 
-			tooltipStep() {
-				let gotPlaylists = false
-
-				for (const playlist of this.props.rundownPlaylists) {
-					if (playlist.unsyncedRundowns.length > -1) {
-						gotPlaylists = true
-						break
-					}
-				}
-
-				if (this.props.coreSystem?.version === GENESIS_SYSTEM_VERSION && gotPlaylists === true) {
-					return getAllowConfigure() ? ToolTipStep.TOOLTIP_RUN_MIGRATIONS : ToolTipStep.TOOLTIP_START_HERE
-				} else {
-					return ToolTipStep.TOOLTIP_EXTRAS
-				}
-			}
-
-			componentDidMount(): void {
-				// Subscribe to data:
-				this.subscribe(PubSub.rundownPlaylists, {})
-				this.subscribe(PubSub.uiStudio, null)
-				this.subscribe(PubSub.rundownLayouts, {})
-
-				this.autorun(() => {
-					const showStyleVariantIds: Set<ShowStyleVariantId> = new Set()
-					const playlistIds: Set<RundownPlaylistId> = new Set(
-						RundownPlaylists.find()
-							.fetch()
-							.map((i) => i._id)
-					)
-
-					for (const rundown of Rundowns.find().fetch()) {
-						showStyleVariantIds.add(rundown.showStyleVariantId)
-
-						this.subscribe(PubSub.uiShowStyleBase, rundown.showStyleBaseId)
-					}
-
-					this.subscribe(PubSub.showStyleVariants, {
-						_id: { $in: Array.from(showStyleVariantIds) },
-					})
-					this.subscribe(PubSub.rundowns, Array.from(playlistIds), null)
-				})
-
-				this.autorun(() => {
-					const subsReady = this.subscriptionsReady()
-					if (subsReady !== this.state.subsReady && !this.state.subsReady) {
-						this.setState({
-							subsReady: subsReady,
-						})
-					}
-				})
-			}
-
-			private handleRundownDrop(rundownId: RundownId) {
-				const { t } = this.props
-				doUserAction(t, 'drag&drop in dropzone', UserAction.RUNDOWN_ORDER_MOVE, (e, ts) =>
-					MeteorCall.userAction.moveRundown(e, ts, rundownId, null, [rundownId])
-				)
-			}
-
-			renderRundownPlaylists(list: RundownPlaylistUi[]) {
-				const { t, rundownLayouts } = this.props
-
-				if (list.length < 1) {
-					return <p>{t('There are no rundowns ingested into Sofie.')}</p>
-				}
-
-				return (
-					<ul className="rundown-playlists">
-						{list.map((playlist) => (
-							<RundownPlaylistUi
-								key={unprotectString(playlist._id)}
-								playlist={playlist}
-								rundownLayouts={rundownLayouts}
-							/>
-						))}
-					</ul>
-				)
-			}
-
-			render(): JSX.Element {
-				const { t, rundownPlaylists, activateDropZone, connectDropTarget } = this.props
-
-				const step = this.tooltipStep()
-
-				const showGettingStarted =
-					this.props.coreSystem?.version === GENESIS_SYSTEM_VERSION && rundownPlaylists.length === 0
-
-				const handleDropZoneDrop = (id: RundownId) => {
-					this.handleRundownDrop(id)
-				}
-
-				return (
-					<React.Fragment>
-						{this.props.coreSystem ? <RegisterHelp step={step} /> : null}
-
-						{showGettingStarted === true ? <GettingStarted step={step} /> : null}
-
-						{connectDropTarget(
-							<section className="mtl gutter has-statusbar">
-								<header className="mvs">
-									<h1>{t('Rundowns')}</h1>
-								</header>
-								{this.state.subsReady ? (
-									<section className="mod mvl rundown-list">
-										<header className="rundown-list__header">
-											<span className="rundown-list-item__name">
-												<Tooltip
-													overlay={t('Click on a rundown to control your studio')}
-													visible={getHelpMode()}
-													placement="top"
-												>
-													<span>{t('Rundown')}</span>
-												</Tooltip>
-											</span>
-											{/* <span className="rundown-list-item__problems">{t('Problems')}</span> */}
-											<span>{t('Show Style')}</span>
-											<span>{t('On Air Start Time')}</span>
-											<span>{t('Duration')}</span>
-											{this.props.rundownPlaylists.some(
-												(p) =>
-													!!PlaylistTiming.getExpectedEnd(p.timing) ||
-													p.rundowns.some((r) => PlaylistTiming.getExpectedEnd(r.timing))
-											) && <span>{t('Expected End Time')}</span>}
-											<span>{t('Last updated')}</span>
-											{this.props.rundownLayouts.some(
-												(l) =>
-													(RundownLayoutsAPI.isLayoutForShelf(l) && l.exposeAsStandalone) ||
-													(RundownLayoutsAPI.isLayoutForRundownView(l) && l.exposeAsSelectableLayout)
-											) && <span>{t('View Layout')}</span>}
-											<span>&nbsp;</span>
-										</header>
-										{this.renderRundownPlaylists(rundownPlaylists)}
-										<footer>
-											{<RundownDropZone activated={activateDropZone} rundownDropHandler={handleDropZoneDrop} />}
-										</footer>
-										<RundownPlaylistDragLayer />
-									</section>
-								) : (
-									<Spinner />
-								)}
-							</section>
-						)}
-
-						<RundownListFooter />
-					</React.Fragment>
-				)
+		for (const playlist of rundownPlaylists) {
+			if (playlist.unsyncedRundowns.length > -1) {
+				gotPlaylists = true
+				break
 			}
 		}
+
+		if (coreSystem?.version === GENESIS_SYSTEM_VERSION && gotPlaylists === true) {
+			return getAllowConfigure() ? ToolTipStep.TOOLTIP_RUN_MIGRATIONS : ToolTipStep.TOOLTIP_START_HERE
+		} else {
+			return ToolTipStep.TOOLTIP_EXTRAS
+		}
+	}, [coreSystem, rundownPlaylists])
+
+	const showGettingStarted = coreSystem?.version === GENESIS_SYSTEM_VERSION && rundownPlaylists.length === 0
+
+	const [dropCollected, dropRef] = useDrop<IRundownDragObject, IRundownPlaylistUiAction, IRundownsListDropTargetProps>(
+		{
+			collect: (monitor: DropTargetMonitor): IRundownsListDropTargetProps => {
+				const activateDropZone = monitor.canDrop() && monitor.isOver()
+
+				return {
+					activateDropZone,
+				}
+			},
+			canDrop: (item) => {
+				/* We only accept rundowns from playlists with more than one rundown,
+				since there's no point in replacing a single rundown playlist with a new
+				single rundown playlist
+				*/
+				if (isRundownDragObject(item)) {
+					const { id } = item
+					const playlist = rundownPlaylists.find(
+						(playlist) => playlist.rundowns.findIndex((rundown) => rundown._id === id) > -1
+					)
+					return playlist?.rundowns !== undefined && playlist.rundowns.length > 1
+				}
+
+				console.debug('RundownList Not accepting drop of ', item)
+				return false
+			},
+			accept: [RundownListDragDropTypes.RUNDOWN],
+		},
+		[rundownPlaylists]
 	)
-)
+
+	const handleDropZoneDrop = useCallback(
+		(rundownId: RundownId) => {
+			doUserAction(t, 'drag&drop in dropzone', UserAction.RUNDOWN_ORDER_MOVE, (e, ts) =>
+				MeteorCall.userAction.moveRundown(e, ts, rundownId, null, [rundownId])
+			)
+		},
+		[t]
+	)
+
+	function renderRundownPlaylists() {
+		if (rundownPlaylists.length < 1) {
+			return <p>{t('There are no rundowns ingested into Sofie.')}</p>
+		}
+
+		return (
+			<ul className="rundown-playlists">
+				{rundownPlaylists.map((playlist) => (
+					<RundownPlaylistUi key={unprotectString(playlist._id)} playlist={playlist} rundownLayouts={rundownLayouts} />
+				))}
+			</ul>
+		)
+	}
+
+	return (
+		<>
+			{coreSystem ? <RegisterHelp step={step} /> : null}
+
+			{showGettingStarted === true ? <GettingStarted step={step} /> : null}
+
+			<section className="mtl gutter has-statusbar" ref={dropRef}>
+				<header className="mvs">
+					<h1>{t('Rundowns')}</h1>
+				</header>
+				{subsReady ? (
+					<section className="mod mvl rundown-list">
+						<header className="rundown-list__header">
+							<span className="rundown-list-item__name">
+								<Tooltip
+									overlay={t('Click on a rundown to control your studio')}
+									visible={getHelpMode()}
+									placement="top"
+								>
+									<span>{t('Rundown')}</span>
+								</Tooltip>
+							</span>
+							{/* <span className="rundown-list-item__problems">{t('Problems')}</span> */}
+							<span>{t('Show Style')}</span>
+							<span>{t('On Air Start Time')}</span>
+							<span>{t('Duration')}</span>
+							{rundownPlaylists.some(
+								(p) =>
+									!!PlaylistTiming.getExpectedEnd(p.timing) ||
+									p.rundowns.some((r) => PlaylistTiming.getExpectedEnd(r.timing))
+							) && <span>{t('Expected End Time')}</span>}
+							<span>{t('Last updated')}</span>
+							{rundownLayouts.some(
+								(l) =>
+									(RundownLayoutsAPI.isLayoutForShelf(l) && l.exposeAsStandalone) ||
+									(RundownLayoutsAPI.isLayoutForRundownView(l) && l.exposeAsSelectableLayout)
+							) && <span>{t('View Layout')}</span>}
+							<span>&nbsp;</span>
+						</header>
+						{renderRundownPlaylists()}
+						<footer>
+							{<RundownDropZone activated={dropCollected.activateDropZone} rundownDropHandler={handleDropZoneDrop} />}
+						</footer>
+						<RundownPlaylistDragLayer />
+					</section>
+				) : (
+					<Spinner />
+				)}
+			</section>
+
+			<RundownListFooter />
+		</>
+	)
+}

--- a/meteor/client/ui/RundownList/RundownListItemView.tsx
+++ b/meteor/client/ui/RundownList/RundownListItemView.tsx
@@ -35,40 +35,36 @@ interface IRundownListItemViewProps {
 	isOnlyRundownInPlaylist?: boolean
 }
 
-export default function RundownListItemView(props: IRundownListItemViewProps): JSX.Element | null {
-	const {
-		isActive,
-		connectDragSource,
-		connectDropTarget,
-		htmlElementId,
-		rundownViewUrl,
-		showStyleBaseURL,
-		showStyleName,
-		rundown,
-		rundownLayouts,
-		confirmReSyncRundownHandler,
-		confirmDeleteRundownHandler,
-		isOnlyRundownInPlaylist,
-	} = props
+export default function RundownListItemView({
+	isActive,
+	classNames,
+	connectDragSource,
+	connectDropTarget,
+	htmlElementId,
+	rundownViewUrl,
+	showStyleBaseURL,
+	showStyleName,
+	rundown,
+	rundownLayouts,
+	confirmReSyncRundownHandler,
+	confirmDeleteRundownHandler,
+	isOnlyRundownInPlaylist,
+	isDragLayer,
+	renderTooltips,
+}: IRundownListItemViewProps): JSX.Element | null {
 	const { t } = useTranslation()
 
 	if (!rundown.playlistId) throw new Meteor.Error(500, 'Rundown is not a part of a rundown playlist!')
 	const playlist = RundownPlaylists.findOne(rundown.playlistId)
 	if (!playlist) throw new Meteor.Error(404, `Rundown Playlist "${rundown.playlistId}" not found!`)
 
-	const classNames = props.classNames.slice()
-	classNames.push('rundown-list-item')
-	if (props.isDragLayer) {
-		classNames.push('dragging')
-	}
-
 	const rundownNameContent = rundownViewUrl ? (
 		<Link to={rundownViewUrl}>
 			{isOnlyRundownInPlaylist && playlist.loop && <LoopingIcon />}
-			{props.rundown.name}
+			{rundown.name}
 		</Link>
 	) : (
-		props.rundown.name
+		rundown.name
 	)
 
 	const expectedStart = PlaylistTiming.getExpectedStart(rundown.timing)
@@ -76,7 +72,7 @@ export default function RundownListItemView(props: IRundownListItemViewProps): J
 	const expectedEnd = PlaylistTiming.getExpectedEnd(rundown.timing)
 
 	return connectDropTarget(
-		<li id={htmlElementId} className={classNames.join(' ')}>
+		<li id={htmlElementId} className={`${classNames} rundown-list-item ${isDragLayer ? 'dragging' : ''}`}>
 			<span className="rundown-list-item__name">
 				{getAllowStudio()
 					? connectDragSource(
@@ -85,7 +81,7 @@ export default function RundownListItemView(props: IRundownListItemViewProps): J
 									overlay={t('Drag to reorder or move out of playlist')}
 									placement="top"
 									mouseEnterDelay={TOOLTIP_DEFAULT_DELAY}
-									overlayStyle={{ display: props.renderTooltips ? undefined : 'none' }}
+									overlayStyle={{ display: renderTooltips ? undefined : 'none' }}
 								>
 									<button className="rundown-list-item__action">{iconDragHandle()}</button>
 								</Tooltip>
@@ -93,8 +89,8 @@ export default function RundownListItemView(props: IRundownListItemViewProps): J
 					  )
 					: null}
 				<b className="rundown-name">{rundownNameContent}</b>
-				{props.rundown.description ? (
-					<Tooltip overlay={props.rundown.description} trigger={['hover']} placement="right">
+				{rundown.description ? (
+					<Tooltip overlay={rundown.description} trigger={['hover']} placement="right">
 						<span className="rundown-list-description__icon">
 							<PathIcon />
 						</span>

--- a/meteor/client/ui/RundownList/RundownPlaylistDragLayer.tsx
+++ b/meteor/client/ui/RundownList/RundownPlaylistDragLayer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { DragLayer, DragLayerMonitor } from 'react-dnd'
+import { DragLayerMonitor, useDragLayer, XYCoord } from 'react-dnd'
 import { IRundownDragObject, RundownListDragDropTypes } from './DragAndDropTypes'
 import { Rundowns } from '../../collections'
 import RundownListItemView from './RundownListItemView'
@@ -17,8 +17,7 @@ const layerStyles: React.CSSProperties = {
 	height: '100%',
 }
 
-function getItemStyles(props) {
-	const { currentOffset, draggedWidth } = props
+function getItemStyles(currentOffset: XYCoord | null, draggedWidth: number | null) {
 	if (!currentOffset) {
 		return {
 			display: 'none',
@@ -34,8 +33,10 @@ function getItemStyles(props) {
 	}
 }
 
-function RundownPlaylistDragLayer(props) {
-	if (!props.isDragging) {
+export default function RundownPlaylistDragLayer(props: { draggedClassNames?: string[] }): JSX.Element | null {
+	const { isDragging, item, itemType, currentOffset, draggedWidth } = useDragLayer(collect)
+
+	if (!isDragging) {
 		return null
 	}
 
@@ -65,13 +66,13 @@ function RundownPlaylistDragLayer(props) {
 
 	return (
 		<div style={layerStyles} className="rundown-list">
-			<div style={getItemStyles(props)}>{renderItem(props.itemType, props.item)}</div>
+			<div style={getItemStyles(currentOffset, draggedWidth)}>{renderItem(itemType, item)}</div>
 		</div>
 	)
 }
 
 function collect(monitor: DragLayerMonitor) {
-	let draggedWidth: number | undefined
+	let draggedWidth: number | null = null
 	let draggedClassNames: string[] | undefined
 
 	const dragging = monitor.getItem()
@@ -86,13 +87,11 @@ function collect(monitor: DragLayerMonitor) {
 	}
 
 	return {
-		item: monitor.getItem(),
-		itemType: monitor.getItemType(),
+		item: monitor.getItem() as IRundownDragObject,
+		itemType: monitor.getItemType() as RundownListDragDropTypes,
 		currentOffset: monitor.getSourceClientOffset(),
 		isDragging: monitor.isDragging(),
 		draggedWidth,
 		draggedClassNames,
 	}
 }
-
-export default DragLayer(collect)(RundownPlaylistDragLayer)

--- a/meteor/client/ui/RundownList/RundownPlaylistUi.tsx
+++ b/meteor/client/ui/RundownList/RundownPlaylistUi.tsx
@@ -71,11 +71,16 @@ interface IRundownPlaylistDropTargetProps {
 }
 
 const spec: DropTargetSpec<IRundownPlaylistUiProps> = {
+	canDrop: (props, monitor) => {
+		console.log('canDrop', props, monitor)
+		return true
+	},
 	drop: (
 		props: IRundownPlaylistUiProps,
 		monitor: DropTargetMonitor,
 		_component: any
 	): IRundownPlaylistUiAction | undefined => {
+		console.log('drop', monitor.didDrop(), monitor.getItem())
 		if (monitor.didDrop()) {
 			return
 		}
@@ -103,8 +108,9 @@ const collect: DropTargetCollector<IRundownPlaylistDropTargetProps, IRundownPlay
 		draggingId !== undefined && !props.playlist.rundowns.some(({ _id }) => draggingId === _id)
 
 	const dropResult = monitor.getDropResult()
+	console.log('dropResult', dropResult)
 	if (isRundownPlaylistUiAction(dropResult)) {
-		action = dropResult as IRundownPlaylistUiAction
+		action = dropResult
 	}
 
 	return {
@@ -145,6 +151,8 @@ export const RundownPlaylistUi = DropTarget(
 				const { playlist, t } = this.props
 				const playlistId = this.props.playlist._id
 				const rundownOrder = this.state.rundownOrder.slice()
+
+				console.log('handleRundownDrop')
 
 				if (playlist.rundowns.findIndex((rundown) => rundownId === rundown._id) > -1) {
 					// finalize order from component state
@@ -193,6 +201,7 @@ export const RundownPlaylistUi = DropTarget(
 
 			componentDidUpdate(prevProps: IRundownPlaylistUiProps) {
 				const { action } = this.props
+				console.log(action)
 				if (action && action.targetPlaylistId === this.props.playlist._id) {
 					const { type, rundownId } = action
 					switch (type) {

--- a/meteor/client/ui/SegmentList/LinePartPieceIndicator/LinePartScriptPiece.tsx
+++ b/meteor/client/ui/SegmentList/LinePartPieceIndicator/LinePartScriptPiece.tsx
@@ -1,6 +1,7 @@
 import { ScriptContent, SourceLayerType } from '@sofie-automation/blueprints-integration'
 import React, { useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { PieceExtended } from '../../../../lib/Rundown'
+import { IFloatingInspectorPosition } from '../../FloatingInspectors/IFloatingInspectorPosition'
 import { MicFloatingInspector } from '../../FloatingInspectors/MicFloatingInspector'
 
 interface IProps {
@@ -9,7 +10,12 @@ interface IProps {
 
 export function LinePartScriptPiece({ pieces }: IProps): JSX.Element {
 	const pieceEl = useRef<HTMLDivElement>(null)
-	const [miniInspectorPosition, setMiniInspectorPosition] = useState<React.CSSProperties>({})
+	const [miniInspectorPosition, setMiniInspectorPosition] = useState<IFloatingInspectorPosition>({
+		position: 'bottom',
+		anchor: 'start',
+		left: 0,
+		top: 0,
+	})
 	const [isHover, setHover] = useState(false)
 	const thisPieces = useMemo(
 		() =>
@@ -27,8 +33,10 @@ export function LinePartScriptPiece({ pieces }: IProps): JSX.Element {
 		const { top, left, width } = pieceEl.current.getBoundingClientRect()
 
 		setMiniInspectorPosition({
-			top: `${top + window.scrollY}px`,
-			left: `${left + width / 2 + window.scrollX}px`,
+			top: top + window.scrollY,
+			left: left + width / 2 + window.scrollX,
+			position: 'bottom',
+			anchor: 'start',
 		})
 	}, [])
 
@@ -66,7 +74,7 @@ export function LinePartScriptPiece({ pieces }: IProps): JSX.Element {
 			{hasPiece && hasPiece.instance.piece.content && (
 				<MicFloatingInspector
 					content={hasPiece.instance.piece.content as ScriptContent}
-					floatingInspectorStyle={miniInspectorPosition}
+					position={miniInspectorPosition}
 					itemElement={pieceEl.current}
 					showMiniInspector={isHover}
 					typeClass={'script'}

--- a/meteor/client/ui/SegmentList/LinePartPieceIndicator/PieceIndicatorMenu.tsx
+++ b/meteor/client/ui/SegmentList/LinePartPieceIndicator/PieceIndicatorMenu.tsx
@@ -8,9 +8,6 @@ import { StoryboardSecondaryPiece } from '../../SegmentStoryboard/StoryboardPart
 import StudioContext from '../../RundownView/StudioContext'
 import { PieceUi } from '../../SegmentContainer/withResolvedSegment'
 
-const AUTO_HIDE_TIMEOUT = 7000
-const VIEWPORT_PADDING = { right: 70 }
-
 export function PieceIndicatorMenu({
 	pieces,
 	partId,
@@ -27,24 +24,7 @@ export function PieceIndicatorMenu({
 	onPieceDoubleClick?: (item: PieceUi, e: React.MouseEvent<HTMLDivElement>) => void
 }): JSX.Element | null {
 	const [indicatorMenuEl, setIndicatorMenuEl] = useState<HTMLDivElement | null>(null)
-	const { styles, attributes, update } = usePopper(parentEl, indicatorMenuEl, {
-		placement: 'bottom',
-		modifiers: [
-			{
-				name: 'flip',
-				options: {
-					fallbackPlacements: ['top'],
-				},
-			},
-			{
-				name: 'preventOverflow',
-				options: {
-					padding: VIEWPORT_PADDING,
-				},
-			},
-			// sameWidth,
-		],
-	})
+	const { styles, attributes, update } = usePopper(parentEl, indicatorMenuEl, POPPER_OPTIONS)
 
 	useLayoutEffect(() => {
 		update && update().catch(console.error)
@@ -123,4 +103,26 @@ export function PieceIndicatorMenu({
 			}
 		</StudioContext.Consumer>
 	)
+}
+
+const AUTO_HIDE_TIMEOUT = 7000
+const VIEWPORT_PADDING = { right: 70 }
+
+const POPPER_OPTIONS = {
+	placement: 'bottom' as const,
+	modifiers: [
+		{
+			name: 'flip',
+			options: {
+				fallbackPlacements: ['top'],
+			},
+		},
+		{
+			name: 'preventOverflow',
+			options: {
+				padding: VIEWPORT_PADDING,
+			},
+		},
+		// sameWidth,
+	],
 }

--- a/meteor/client/ui/SegmentList/LinePartPieceIndicator/PieceIndicatorMenu.tsx
+++ b/meteor/client/ui/SegmentList/LinePartPieceIndicator/PieceIndicatorMenu.tsx
@@ -9,6 +9,7 @@ import StudioContext from '../../RundownView/StudioContext'
 import { PieceUi } from '../../SegmentContainer/withResolvedSegment'
 
 const AUTO_HIDE_TIMEOUT = 7000
+const VIEWPORT_PADDING = { right: 70 }
 
 export function PieceIndicatorMenu({
 	pieces,
@@ -30,9 +31,15 @@ export function PieceIndicatorMenu({
 		placement: 'bottom',
 		modifiers: [
 			{
-				name: 'offset',
+				name: 'flip',
 				options: {
-					offset: [0, 0],
+					fallbackPlacements: ['top'],
+				},
+			},
+			{
+				name: 'preventOverflow',
+				options: {
+					padding: VIEWPORT_PADDING,
 				},
 			},
 			// sameWidth,

--- a/meteor/client/ui/SegmentList/LinePartTimeline.tsx
+++ b/meteor/client/ui/SegmentList/LinePartTimeline.tsx
@@ -132,7 +132,7 @@ export const LinePartTimeline: React.FC<IProps> = function LinePartTimeline({
 				</StudioContext.Consumer>
 			)}
 			{part.instance.part.invalid && !part.instance.part.gap && (
-				<InvalidPartCover className="segment-opl__main-piece invalid" part={part.instance.part} align="left" />
+				<InvalidPartCover className="segment-opl__main-piece invalid" part={part.instance.part} align="start" />
 			)}
 			{!isLive && !isInvalid && <TakeLine isNext={isNext} autoNext={willAutoNextIntoThisPart} />}
 			{transitionPiece && <LinePartTransitionPiece piece={transitionPiece} />}

--- a/meteor/client/ui/SegmentList/PieceHoverInspector.tsx
+++ b/meteor/client/ui/SegmentList/PieceHoverInspector.tsx
@@ -72,7 +72,7 @@ export function PieceHoverInspector({
 						top: originPosition.top,
 						left: originPosition.left + mousePosition,
 						anchor: 'start',
-						position: 'top',
+						position: 'top-start',
 					}}
 					typeClass={layer && RundownUtils.getSourceLayerClassName(layer.type)}
 					itemElement={null}
@@ -94,7 +94,7 @@ export function PieceHoverInspector({
 						top: originPosition.top,
 						left: originPosition.left + mousePosition,
 						anchor: 'start',
-						position: 'top',
+						position: 'top-start',
 					}}
 					typeClass={layer && RundownUtils.getSourceLayerClassName(layer.type)}
 					itemElement={null}

--- a/meteor/client/ui/SegmentList/PieceHoverInspector.tsx
+++ b/meteor/client/ui/SegmentList/PieceHoverInspector.tsx
@@ -90,10 +90,11 @@ export function PieceHoverInspector({
 					showMiniInspector={hovering}
 					timePosition={hoverScrubTimePosition}
 					content={vtContent}
-					floatingInspectorStyle={{
-						top: originPosition.top + 'px',
-						left: originPosition.left + mousePosition + 'px',
-						transform: 'translate(0, -100%)',
+					position={{
+						top: originPosition.top,
+						left: originPosition.left + mousePosition,
+						anchor: 'start',
+						position: 'top'
 					}}
 					typeClass={layer && RundownUtils.getSourceLayerClassName(layer.type)}
 					itemElement={null}

--- a/meteor/client/ui/SegmentList/PieceHoverInspector.tsx
+++ b/meteor/client/ui/SegmentList/PieceHoverInspector.tsx
@@ -16,7 +16,6 @@ import { L3rdFloatingInspector } from '../FloatingInspectors/L3rdFloatingInspect
 import { VTFloatingInspector } from '../FloatingInspectors/VTFloatingInspector'
 import { PieceUi } from '../SegmentContainer/withResolvedSegment'
 
-// TODO: Clean up upper-level component props
 export function PieceHoverInspector({
 	studio,
 	pieceInstance,
@@ -69,10 +68,11 @@ export function PieceHoverInspector({
 				<L3rdFloatingInspector
 					showMiniInspector={hovering}
 					content={graphicsContent}
-					floatingInspectorStyle={{
-						top: originPosition.top + 'px',
-						left: originPosition.left + mousePosition + 'px',
-						transform: 'translate(0, -100%)',
+					position={{
+						top: originPosition.top,
+						left: originPosition.left + mousePosition,
+						anchor: 'start',
+						position: 'top',
 					}}
 					typeClass={layer && RundownUtils.getSourceLayerClassName(layer.type)}
 					itemElement={null}
@@ -94,7 +94,7 @@ export function PieceHoverInspector({
 						top: originPosition.top,
 						left: originPosition.left + mousePosition,
 						anchor: 'start',
-						position: 'top'
+						position: 'top',
 					}}
 					typeClass={layer && RundownUtils.getSourceLayerClassName(layer.type)}
 					itemElement={null}

--- a/meteor/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/Renderers/GraphicsRenderer.tsx
+++ b/meteor/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/Renderers/GraphicsRenderer.tsx
@@ -21,7 +21,7 @@ export function GraphicsRenderer({
 					top: elementOffset?.top ?? 0,
 					left: elementOffset?.left ?? 0,
 					anchor: 'start',
-					position: 'top',
+					position: 'top-start',
 				}}
 				typeClass={typeClass}
 				itemElement={null}

--- a/meteor/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/Renderers/GraphicsRenderer.tsx
+++ b/meteor/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/Renderers/GraphicsRenderer.tsx
@@ -17,15 +17,12 @@ export function GraphicsRenderer({
 			<L3rdFloatingInspector
 				showMiniInspector={!!hovering}
 				content={content}
-				floatingInspectorStyle={
-					elementOffset
-						? {
-								top: elementOffset.top + 'px',
-								left: elementOffset.left + 'px',
-								transform: 'translate(0, -100%)',
-						  }
-						: {}
-				}
+				position={{
+					top: elementOffset?.top ?? 0,
+					left: elementOffset?.left ?? 0,
+					anchor: 'start',
+					position: 'top',
+				}}
 				typeClass={typeClass}
 				itemElement={null}
 				piece={pieceInstance.instance.piece}

--- a/meteor/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/Renderers/ScriptRenderer.tsx
+++ b/meteor/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/Renderers/ScriptRenderer.tsx
@@ -19,14 +19,12 @@ export function ScriptRenderer(props: IDefaultRendererProps): JSX.Element | stri
 				{content && (
 					<MicFloatingInspector
 						content={content}
-						floatingInspectorStyle={
-							props.elementOffset
-								? {
-										top: `${props.elementOffset.top}px`,
-										left: `${props.elementOffset.left + props.elementOffset.width / 2}px`,
-								  }
-								: {}
-						}
+						position={{
+							top: props.elementOffset?.top ?? 0,
+							left: props.elementOffset?.left ?? 0,
+							anchor: 'start',
+							position: 'top',
+						}}
 						itemElement={null}
 						showMiniInspector={!!props.hovering}
 						typeClass={props.typeClass}

--- a/meteor/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/Renderers/ScriptRenderer.tsx
+++ b/meteor/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/Renderers/ScriptRenderer.tsx
@@ -23,7 +23,7 @@ export function ScriptRenderer(props: IDefaultRendererProps): JSX.Element | stri
 							top: props.elementOffset?.top ?? 0,
 							left: props.elementOffset?.left ?? 0,
 							anchor: 'start',
-							position: 'top',
+							position: 'bottom-start',
 						}}
 						itemElement={null}
 						showMiniInspector={!!props.hovering}

--- a/meteor/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/Renderers/SplitsRenderer.tsx
+++ b/meteor/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/Renderers/SplitsRenderer.tsx
@@ -16,15 +16,12 @@ export function SplitsRenderer({
 		<>
 			<div className="segment-storyboard__part__piece__contents">{splitItems}</div>
 			<SplitsFloatingInspector
-				position={
-					elementOffset
-						? {
-								top: elementOffset.top + 'px',
-								left: elementOffset.left + 'px',
-								transform: 'translate(0, -100%)',
-						  }
-						: {}
-				}
+				position={{
+					top: elementOffset?.top ?? 0,
+					left: elementOffset?.left ?? 0,
+					anchor: 'start',
+					position: 'top',
+				}}
 				itemElement={null}
 				content={pieceInstance.instance.piece.content as Partial<SplitsContent>}
 				showMiniInspector={!!hovering}

--- a/meteor/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/Renderers/SplitsRenderer.tsx
+++ b/meteor/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/Renderers/SplitsRenderer.tsx
@@ -16,7 +16,7 @@ export function SplitsRenderer({
 		<>
 			<div className="segment-storyboard__part__piece__contents">{splitItems}</div>
 			<SplitsFloatingInspector
-				floatingInspectorStyle={
+				position={
 					elementOffset
 						? {
 								top: elementOffset.top + 'px',

--- a/meteor/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/Renderers/SplitsRenderer.tsx
+++ b/meteor/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/Renderers/SplitsRenderer.tsx
@@ -20,7 +20,7 @@ export function SplitsRenderer({
 					top: elementOffset?.top ?? 0,
 					left: elementOffset?.left ?? 0,
 					anchor: 'start',
-					position: 'top',
+					position: 'top-start',
 				}}
 				itemElement={null}
 				content={pieceInstance.instance.piece.content as Partial<SplitsContent>}

--- a/meteor/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/Renderers/VTRenderer.tsx
+++ b/meteor/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/Renderers/VTRenderer.tsx
@@ -27,15 +27,12 @@ export function VTRenderer({
 				showMiniInspector={!!hovering}
 				timePosition={timePosition}
 				content={vtContent}
-				floatingInspectorStyle={
-					elementOffset
-						? {
-								top: elementOffset.top + 'px',
-								left: elementOffset.left + 'px',
-								transform: 'translate(0, -100%)',
-						  }
-						: {}
-				}
+				position={{
+					top: elementOffset?.top ?? 0,
+					left: elementOffset?.left ?? 0,
+					anchor: 'start',
+					position: 'top',
+				}}
 				typeClass={typeClass}
 				itemElement={null}
 				contentMetaData={pieceInstance.contentMetaData || null}

--- a/meteor/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/Renderers/VTRenderer.tsx
+++ b/meteor/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/Renderers/VTRenderer.tsx
@@ -31,7 +31,7 @@ export function VTRenderer({
 					top: elementOffset?.top ?? 0,
 					left: elementOffset?.left ?? 0,
 					anchor: 'start',
-					position: 'top',
+					position: 'top-start',
 				}}
 				typeClass={typeClass}
 				itemElement={null}

--- a/meteor/client/ui/SegmentStoryboard/StoryboardPartThumbnail/Renderers/GraphicsThumbnailRenderer.tsx
+++ b/meteor/client/ui/SegmentStoryboard/StoryboardPartThumbnail/Renderers/GraphicsThumbnailRenderer.tsx
@@ -17,7 +17,7 @@ export function GraphicsThumbnailRenderer({ pieceInstance, hovering, layer, orig
 					top: originPosition.top,
 					left: originPosition.left,
 					anchor: 'start',
-					position: 'top',
+					position: 'top-start',
 				}}
 				typeClass={layer && RundownUtils.getSourceLayerClassName(layer.type)}
 				itemElement={null}

--- a/meteor/client/ui/SegmentStoryboard/StoryboardPartThumbnail/Renderers/GraphicsThumbnailRenderer.tsx
+++ b/meteor/client/ui/SegmentStoryboard/StoryboardPartThumbnail/Renderers/GraphicsThumbnailRenderer.tsx
@@ -13,10 +13,11 @@ export function GraphicsThumbnailRenderer({ pieceInstance, hovering, layer, orig
 			<L3rdFloatingInspector
 				showMiniInspector={hovering}
 				content={content}
-				floatingInspectorStyle={{
-					top: originPosition.top + 'px',
-					left: originPosition.left + 'px',
-					transform: 'translate(0, -100%)',
+				position={{
+					top: originPosition.top,
+					left: originPosition.left,
+					anchor: 'start',
+					position: 'top',
 				}}
 				typeClass={layer && RundownUtils.getSourceLayerClassName(layer.type)}
 				itemElement={null}

--- a/meteor/client/ui/SegmentStoryboard/StoryboardPartThumbnail/Renderers/GraphicsThumbnailRenderer.tsx
+++ b/meteor/client/ui/SegmentStoryboard/StoryboardPartThumbnail/Renderers/GraphicsThumbnailRenderer.tsx
@@ -5,7 +5,13 @@ import { L3rdFloatingInspector } from '../../../FloatingInspectors/L3rdFloatingI
 import { PieceMultistepChevron } from '../../../SegmentContainer/PieceMultistepChevron'
 import { IProps } from './ThumbnailRendererFactory'
 
-export function GraphicsThumbnailRenderer({ pieceInstance, hovering, layer, originPosition }: IProps): JSX.Element {
+export function GraphicsThumbnailRenderer({
+	pieceInstance,
+	hovering,
+	layer,
+	originPosition,
+	height,
+}: IProps): JSX.Element {
 	const content = pieceInstance.instance.piece.content as NoraContent | GraphicsContent | undefined
 
 	return (
@@ -16,6 +22,7 @@ export function GraphicsThumbnailRenderer({ pieceInstance, hovering, layer, orig
 				position={{
 					top: originPosition.top,
 					left: originPosition.left,
+					height,
 					anchor: 'start',
 					position: 'top-start',
 				}}

--- a/meteor/client/ui/SegmentStoryboard/StoryboardPartThumbnail/Renderers/SplitsThumbnailRenderer.tsx
+++ b/meteor/client/ui/SegmentStoryboard/StoryboardPartThumbnail/Renderers/SplitsThumbnailRenderer.tsx
@@ -19,7 +19,7 @@ export function SplitsThumbnailRenderer({ pieceInstance, originPosition, hoverin
 					top: originPosition.top,
 					left: originPosition.left,
 					anchor: 'start',
-					position: 'top',
+					position: 'top-start',
 				}}
 				content={pieceInstance.instance.piece.content as Partial<SplitsContent>}
 				itemElement={null}

--- a/meteor/client/ui/SegmentStoryboard/StoryboardPartThumbnail/Renderers/SplitsThumbnailRenderer.tsx
+++ b/meteor/client/ui/SegmentStoryboard/StoryboardPartThumbnail/Renderers/SplitsThumbnailRenderer.tsx
@@ -16,9 +16,10 @@ export function SplitsThumbnailRenderer({ pieceInstance, originPosition, hoverin
 			</div>
 			<SplitsFloatingInspector
 				position={{
-					top: originPosition.top + 'px',
-					left: originPosition.left + 'px',
-					transform: 'translate(0, -100%)',
+					top: originPosition.top,
+					left: originPosition.left,
+					anchor: 'start',
+					position: 'top',
 				}}
 				content={pieceInstance.instance.piece.content as Partial<SplitsContent>}
 				itemElement={null}

--- a/meteor/client/ui/SegmentStoryboard/StoryboardPartThumbnail/Renderers/SplitsThumbnailRenderer.tsx
+++ b/meteor/client/ui/SegmentStoryboard/StoryboardPartThumbnail/Renderers/SplitsThumbnailRenderer.tsx
@@ -15,7 +15,7 @@ export function SplitsThumbnailRenderer({ pieceInstance, originPosition, hoverin
 				{pieceInstance.instance.piece.name}
 			</div>
 			<SplitsFloatingInspector
-				floatingInspectorStyle={{
+				position={{
 					top: originPosition.top + 'px',
 					left: originPosition.left + 'px',
 					transform: 'translate(0, -100%)',

--- a/meteor/client/ui/SegmentStoryboard/StoryboardPartThumbnail/Renderers/SplitsThumbnailRenderer.tsx
+++ b/meteor/client/ui/SegmentStoryboard/StoryboardPartThumbnail/Renderers/SplitsThumbnailRenderer.tsx
@@ -5,7 +5,13 @@ import { RundownUtils } from '../../../../lib/rundown'
 import { SplitsFloatingInspector } from '../../../FloatingInspectors/SplitsFloatingInspector'
 import { getSplitItems } from '../../../SegmentContainer/getSplitItems'
 
-export function SplitsThumbnailRenderer({ pieceInstance, originPosition, hovering, layer }: IProps): JSX.Element {
+export function SplitsThumbnailRenderer({
+	pieceInstance,
+	originPosition,
+	hovering,
+	layer,
+	height,
+}: IProps): JSX.Element {
 	const splitItems = getSplitItems(pieceInstance, 'segment-storyboard__thumbnail__item')
 
 	return (
@@ -18,6 +24,7 @@ export function SplitsThumbnailRenderer({ pieceInstance, originPosition, hoverin
 				position={{
 					top: originPosition.top,
 					left: originPosition.left,
+					height,
 					anchor: 'start',
 					position: 'top-start',
 				}}

--- a/meteor/client/ui/SegmentStoryboard/StoryboardPartThumbnail/Renderers/ThumbnailRendererFactory.ts
+++ b/meteor/client/ui/SegmentStoryboard/StoryboardPartThumbnail/Renderers/ThumbnailRendererFactory.ts
@@ -19,6 +19,7 @@ export interface IProps {
 	studio: UIStudio
 	pieceInstance: PieceUi
 	hoverScrubTimePosition: number
+	height: number
 	hovering: boolean
 	originPosition: OffsetPosition
 	layer: ISourceLayer | undefined

--- a/meteor/client/ui/SegmentStoryboard/StoryboardPartThumbnail/Renderers/VTThumbnailRenderer.tsx
+++ b/meteor/client/ui/SegmentStoryboard/StoryboardPartThumbnail/Renderers/VTThumbnailRenderer.tsx
@@ -24,6 +24,7 @@ export function VTThumbnailRenderer({
 	originPosition,
 	studio,
 	layer,
+	height,
 }: IProps): JSX.Element {
 	const mediaPreviewUrl = studio.settings.mediaPreviewsUrl
 
@@ -46,6 +47,7 @@ export function VTThumbnailRenderer({
 				position={{
 					top: originPosition.top,
 					left: originPosition.left,
+					height,
 					anchor: 'start',
 					position: 'top-start',
 				}}

--- a/meteor/client/ui/SegmentStoryboard/StoryboardPartThumbnail/Renderers/VTThumbnailRenderer.tsx
+++ b/meteor/client/ui/SegmentStoryboard/StoryboardPartThumbnail/Renderers/VTThumbnailRenderer.tsx
@@ -43,10 +43,11 @@ export function VTThumbnailRenderer({
 				showMiniInspector={hovering}
 				timePosition={hoverScrubTimePosition}
 				content={vtContent}
-				floatingInspectorStyle={{
-					top: originPosition.top + 'px',
-					left: originPosition.left + 'px',
-					transform: 'translate(0, -100%)',
+				position={{
+					top: originPosition.top,
+					left: originPosition.left,
+					anchor: 'start',
+					position: 'top',
 				}}
 				typeClass={layer && RundownUtils.getSourceLayerClassName(layer.type)}
 				itemElement={null}

--- a/meteor/client/ui/SegmentStoryboard/StoryboardPartThumbnail/Renderers/VTThumbnailRenderer.tsx
+++ b/meteor/client/ui/SegmentStoryboard/StoryboardPartThumbnail/Renderers/VTThumbnailRenderer.tsx
@@ -47,7 +47,7 @@ export function VTThumbnailRenderer({
 					top: originPosition.top,
 					left: originPosition.left,
 					anchor: 'start',
-					position: 'top',
+					position: 'top-start',
 				}}
 				typeClass={layer && RundownUtils.getSourceLayerClassName(layer.type)}
 				itemElement={null}

--- a/meteor/client/ui/SegmentStoryboard/StoryboardPartThumbnail/StoryboardPartThumbnailInner.tsx
+++ b/meteor/client/ui/SegmentStoryboard/StoryboardPartThumbnail/StoryboardPartThumbnailInner.tsx
@@ -3,7 +3,7 @@ import { ISourceLayer } from '@sofie-automation/blueprints-integration'
 import { PieceExtended } from '../../../../lib/Rundown'
 import { withMediaObjectStatus } from '../../SegmentTimeline/withMediaObjectStatus'
 import { getElementDocumentOffset, OffsetPosition } from '../../../utils/positions'
-import { getElementWidth } from '../../../utils/dimensions'
+import { getElementHeight, getElementWidth } from '../../../utils/dimensions'
 import renderThumbnail from './Renderers/ThumbnailRendererFactory'
 import { PieceElement } from '../../SegmentContainer/PieceElement'
 import { UIStudio } from '../../../../lib/api/studios'
@@ -38,6 +38,7 @@ export const StoryboardPartThumbnailInner = withMediaObjectStatus<IProps, {}>()(
 		const [hover, setHover] = useState(false)
 		const [origin, setOrigin] = useState<OffsetPosition>({ left: 0, top: 0 })
 		const [width, setWidth] = useState(0)
+		const [height, setHeight] = useState(0)
 		const [mousePosition, setMousePosition] = useState(0)
 		const thumbnailEl = useRef<HTMLDivElement>(null)
 
@@ -54,6 +55,10 @@ export const StoryboardPartThumbnailInner = withMediaObjectStatus<IProps, {}>()(
 			const newWidth = thumbnailEl.current && getElementWidth(thumbnailEl.current)
 			if (newWidth !== null) {
 				setWidth(newWidth)
+			}
+			const newHeight = thumbnailEl.current && getElementHeight(thumbnailEl.current)
+			if (newHeight !== null) {
+				setHeight(newHeight)
 			}
 		}
 
@@ -93,6 +98,7 @@ export const StoryboardPartThumbnailInner = withMediaObjectStatus<IProps, {}>()(
 						hoverScrubTimePosition: mousePosition * (piece.instance.piece.content.sourceDuration || 0),
 						hovering: hover,
 						layer: layer,
+						height,
 						originPosition: origin,
 						pieceInstance: piece,
 						studio,

--- a/meteor/client/ui/SegmentTimeline/Parts/InvalidPartCover.tsx
+++ b/meteor/client/ui/SegmentTimeline/Parts/InvalidPartCover.tsx
@@ -5,7 +5,7 @@ import { InvalidFloatingInspector } from '../../FloatingInspectors/InvalidFloati
 interface IProps {
 	className?: string
 	part: DBPart
-	align?: 'left' | 'center' | 'right'
+	align?: 'start' | 'center' | 'end'
 }
 
 export function InvalidPartCover({ className, part, align }: IProps): JSX.Element {
@@ -32,22 +32,18 @@ export function InvalidPartCover({ className, part, align }: IProps): JSX.Elemen
 		setHover(false)
 	}
 
-	function getInspectorStyle(): React.CSSProperties {
-		if (align === 'left') {
-			return { top: `${position.top}px`, left: `${position.left}px` }
-		} else if (align === 'right') {
-			return { top: `${position.top}px`, left: 'auto', right: `${position.right}px` }
-		}
-		return { top: `${position.top}px`, left: `${position.left + position.width / 2}px` }
-	}
-
 	return (
 		<div className={className} ref={element} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
 			<InvalidFloatingInspector
 				part={part}
 				showMiniInspector={hover}
 				itemElement={element.current}
-				floatingInspectorStyle={getInspectorStyle()}
+				position={{
+					top: position.top,
+					left: position.left,
+					anchor: align ?? 'start',
+					position: 'top',
+				}}
 			/>
 		</div>
 	)

--- a/meteor/client/ui/SegmentTimeline/Renderers/CustomLayerItemRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/CustomLayerItemRenderer.tsx
@@ -82,7 +82,7 @@ export class CustomLayerItemRenderer<
 			left: this.props.elementPosition.left + this.props.cursorPosition.left,
 			top: this.props.elementPosition.top,
 			anchor: 'start',
-			position: 'top',
+			position: 'top-start',
 		}
 	}
 

--- a/meteor/client/ui/SegmentTimeline/Renderers/CustomLayerItemRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/CustomLayerItemRenderer.tsx
@@ -8,6 +8,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { PieceLifespan, VTContent } from '@sofie-automation/blueprints-integration'
 import { OffsetPosition } from '../../../utils/positions'
 import { CalculateTimingsPiece } from '@sofie-automation/corelib/dist/playout/timings'
+import { IFloatingInspectorPosition } from '../../FloatingInspectors/IFloatingInspectorPosition'
 
 export type SourceDurationLabelAlignment = 'left' | 'right'
 
@@ -76,10 +77,12 @@ export class CustomLayerItemRenderer<
 		}
 	}
 
-	protected getFloatingInspectorStyle(): React.CSSProperties {
+	protected getFloatingInspectorStyle(): IFloatingInspectorPosition {
 		return {
-			left: (this.props.elementPosition.left + this.props.cursorPosition.left).toString() + 'px',
-			top: this.props.elementPosition.top + 'px',
+			left: this.props.elementPosition.left + this.props.cursorPosition.left,
+			top: this.props.elementPosition.top,
+			anchor: 'start',
+			position: 'top',
 		}
 	}
 

--- a/meteor/client/ui/SegmentTimeline/Renderers/L3rdSourceRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/L3rdSourceRenderer.tsx
@@ -99,7 +99,7 @@ export class L3rdSourceRenderer extends CustomLayerItemRenderer<IProps, IState> 
 					itemElement={this.props.itemElement}
 					piece={this.props.piece.instance.piece}
 					showMiniInspector={this.props.showMiniInspector}
-					floatingInspectorStyle={this.getFloatingInspectorStyle()}
+					position={this.getFloatingInspectorStyle()}
 					pieceRenderedDuration={this.props.piece.renderedDuration}
 					pieceRenderedIn={this.props.piece.renderedInPoint}
 				/>

--- a/meteor/client/ui/SegmentTimeline/Renderers/MicSourceRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/MicSourceRenderer.tsx
@@ -10,6 +10,7 @@ import { getElementWidth } from '../../../utils/dimensions'
 import { MicFloatingInspector } from '../../FloatingInspectors/MicFloatingInspector'
 import { calculatePartInstanceExpectedDurationWithPreroll } from '@sofie-automation/corelib/dist/playout/timings'
 import { unprotectString } from '../../../../lib/lib'
+import { IFloatingInspectorPosition } from '../../FloatingInspectors/IFloatingInspectorPosition'
 
 type IProps = ICustomLayerItemProps
 interface IState {}
@@ -182,6 +183,15 @@ export const MicSourceRenderer = withTranslation()(
 				this.lineItem?.remove()
 			} catch (err) {
 				console.error('Error in MicSourceRenderer.componentWillUnmount', err)
+			}
+		}
+
+		protected getFloatingInspectorStyle(): IFloatingInspectorPosition {
+			return {
+				left: this.props.elementPosition.left + this.props.cursorPosition.left,
+				top: this.props.elementPosition.top,
+				anchor: 'start',
+				position: 'bottom',
 			}
 		}
 

--- a/meteor/client/ui/SegmentTimeline/Renderers/MicSourceRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/MicSourceRenderer.tsx
@@ -226,7 +226,7 @@ export const MicSourceRenderer = withTranslation()(
 					{content && (
 						<MicFloatingInspector
 							content={content}
-							floatingInspectorStyle={this.getFloatingInspectorStyle()}
+							position={this.getFloatingInspectorStyle()}
 							itemElement={this.props.itemElement}
 							showMiniInspector={this.props.showMiniInspector}
 							typeClass={this.props.typeClass}

--- a/meteor/client/ui/SegmentTimeline/Renderers/SplitsSourceRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/SplitsSourceRenderer.tsx
@@ -123,7 +123,7 @@ export class SplitsSourceRenderer extends CustomLayerItemRenderer<IProps, IState
 				)}
 				{this.props.piece.instance.piece.content ? (
 					<SplitsFloatingInspector
-						floatingInspectorStyle={this.getFloatingInspectorStyle()}
+						position={this.getFloatingInspectorStyle()}
 						content={this.props.piece.instance.piece.content as Partial<SplitsContent>}
 						itemElement={this.props.itemElement}
 						showMiniInspector={this.props.showMiniInspector}

--- a/meteor/client/ui/SegmentTimeline/Renderers/TransitionSourceRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/TransitionSourceRenderer.tsx
@@ -95,7 +95,7 @@ function TransitionFloatingInspector({
 	position: IFloatingInspectorPosition
 }) {
 	const ref = useRef<HTMLDivElement>(null)
-	const floatingInspectorStyle = useInspectorPosition(position, ref.current)
+	const floatingInspectorStyle = useInspectorPosition(position, ref)
 
 	return (
 		<FloatingInspector shown={true}>

--- a/meteor/client/ui/SegmentTimeline/Renderers/TransitionSourceRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/TransitionSourceRenderer.tsx
@@ -1,10 +1,11 @@
-import * as React from 'react'
+import React, { useRef } from 'react'
 import { getElementWidth } from '../../../utils/dimensions'
 
 import { TransitionContent } from '@sofie-automation/blueprints-integration'
 
 import { CustomLayerItemRenderer, ICustomLayerItemProps } from './CustomLayerItemRenderer'
 import { FloatingInspector } from '../../FloatingInspector'
+import { IFloatingInspectorPosition, useInspectorPosition } from '../../FloatingInspectors/IFloatingInspectorPosition'
 
 // type KeyValue = { key: string, value: string }
 
@@ -78,19 +79,34 @@ export class TransitionSourceRenderer extends CustomLayerItemRenderer<IProps, IS
 						)}
 					</span>
 				) : null}
-				<FloatingInspector
-					shown={this.props.showMiniInspector && !this.state.iconFailed && this.props.itemElement !== null}
-				>
-					{content && content.preview && (
-						<div
-							className="segment-timeline__mini-inspector segment-timeline__mini-inspector--video"
-							style={this.getFloatingInspectorStyle()}
-						>
-							<img src={'/blueprints/assets/' + content.preview} className="thumbnail" />
-						</div>
-					)}
-				</FloatingInspector>
+				{this.props.showMiniInspector && !this.state.iconFailed && this.props.itemElement !== null && content && (
+					<TransitionFloatingInspector position={this.getFloatingInspectorStyle()} content={content} />
+				)}
 			</>
 		)
 	}
+}
+
+function TransitionFloatingInspector({
+	content,
+	position,
+}: {
+	content: TransitionContent
+	position: IFloatingInspectorPosition
+}) {
+	const ref = useRef<HTMLDivElement>(null)
+	const floatingInspectorStyle = useInspectorPosition(position, ref.current)
+
+	return (
+		<FloatingInspector shown={true}>
+			{content.preview && (
+				<div
+					className="segment-timeline__mini-inspector segment-timeline__mini-inspector--video"
+					style={floatingInspectorStyle}
+				>
+					<img src={`/blueprints/assets/${content.preview}`} className="thumbnail" />
+				</div>
+			)}
+		</FloatingInspector>
+	)
 }

--- a/meteor/client/ui/SegmentTimeline/Renderers/TransitionSourceRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/TransitionSourceRenderer.tsx
@@ -95,7 +95,7 @@ function TransitionFloatingInspector({
 	position: IFloatingInspectorPosition
 }) {
 	const ref = useRef<HTMLDivElement>(null)
-	const floatingInspectorStyle = useInspectorPosition(position, ref)
+	const { style: floatingInspectorStyle } = useInspectorPosition(position, ref)
 
 	return (
 		<FloatingInspector shown={true}>

--- a/meteor/client/ui/SegmentTimeline/Renderers/VTSourceRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/VTSourceRenderer.tsx
@@ -611,7 +611,7 @@ export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithT
 				{this.rightLabelContainer && ReactDOM.createPortal(this.rightLabelNodes, this.rightLabelContainer)}
 				<VTFloatingInspector
 					status={this.props.piece.instance.piece.status}
-					floatingInspectorStyle={this.getFloatingInspectorStyle()}
+					position={this.getFloatingInspectorStyle()}
 					content={vtContent}
 					itemElement={this.props.itemElement}
 					noticeLevel={this.state.noticeLevel}

--- a/meteor/client/ui/SegmentTimeline/Renderers/VTSourceRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/VTSourceRenderer.tsx
@@ -26,6 +26,7 @@ import { Settings } from '../../../../lib/Settings'
 import { UIStudio } from '../../../../lib/api/studios'
 import { PieceStatusCode } from '@sofie-automation/corelib/dist/dataModel/Piece'
 import { HourglassIconSmall } from '../../../lib/ui/icons/notifications'
+import { IFloatingInspectorPosition } from '../../FloatingInspectors/IFloatingInspectorPosition'
 
 interface IProps extends ICustomLayerItemProps {
 	studio: UIStudio | undefined
@@ -538,6 +539,15 @@ export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithT
 		}
 
 		return this.countdownContainer && ReactDOM.createPortal(countdown, this.countdownContainer)
+	}
+
+	protected getFloatingInspectorStyle(): IFloatingInspectorPosition {
+		return {
+			left: this.props.elementPosition.left + this.props.cursorPosition.left,
+			top: this.props.elementPosition.top,
+			anchor: 'start',
+			position: 'top-start',
+		}
 	}
 
 	render(): JSX.Element {

--- a/meteor/client/ui/Shelf/DashboardPieceButton.tsx
+++ b/meteor/client/ui/Shelf/DashboardPieceButton.tsx
@@ -161,9 +161,10 @@ export class DashboardPieceButtonBase<T = {}> extends MeteorReactComponent<
 					timePosition={this.state.timePosition}
 					content={adLib.content as VTContent | undefined}
 					position={{
-						top: this.positionAndSize?.top + 'px',
-						left: this.positionAndSize?.left + 'px',
-						transform: 'translate(0, -100%)',
+						top: this.positionAndSize?.top ?? 0,
+						left: this.positionAndSize?.left ?? 0,
+						anchor: 'start',
+						position: 'top',
 					}}
 					typeClass={this.props.layer && RundownUtils.getSourceLayerClassName(this.props.layer.type)}
 					itemElement={null}

--- a/meteor/client/ui/Shelf/DashboardPieceButton.tsx
+++ b/meteor/client/ui/Shelf/DashboardPieceButton.tsx
@@ -160,7 +160,7 @@ export class DashboardPieceButtonBase<T = {}> extends MeteorReactComponent<
 					showMiniInspector={this.state.isHovered}
 					timePosition={this.state.timePosition}
 					content={adLib.content as VTContent | undefined}
-					floatingInspectorStyle={{
+					position={{
 						top: this.positionAndSize?.top + 'px',
 						left: this.positionAndSize?.left + 'px',
 						transform: 'translate(0, -100%)',

--- a/meteor/client/ui/Shelf/DashboardPieceButton.tsx
+++ b/meteor/client/ui/Shelf/DashboardPieceButton.tsx
@@ -115,10 +115,11 @@ export class DashboardPieceButtonBase<T = {}> extends MeteorReactComponent<
 				<L3rdFloatingInspector
 					showMiniInspector={this.state.isHovered}
 					content={noraContent}
-					floatingInspectorStyle={{
-						top: this.positionAndSize?.top + 'px',
-						left: this.positionAndSize?.left + 'px',
-						transform: 'translate(0, -100%)',
+					position={{
+						top: this.positionAndSize?.top ?? 0,
+						left: this.positionAndSize?.left ?? 0,
+						anchor: 'start',
+						position: 'top',
 					}}
 					typeClass={this.props.layer && RundownUtils.getSourceLayerClassName(this.props.layer.type)}
 					itemElement={this.element}

--- a/meteor/client/ui/Shelf/Renderers/L3rdListItemRenderer.tsx
+++ b/meteor/client/ui/Shelf/Renderers/L3rdListItemRenderer.tsx
@@ -160,10 +160,11 @@ export const L3rdListItemRenderer: React.FunctionComponent<ILayerItemRendererPro
 				<L3rdFloatingInspector
 					showMiniInspector={showMiniInspector}
 					content={noraContent}
-					floatingInspectorStyle={{
-						top: itemIconPosition?.top + 'px',
-						left: itemIconPosition?.left + 'px',
-						transform: 'translate(0, -100%)',
+					position={{
+						top: itemIconPosition?.top ?? 0,
+						left: itemIconPosition?.left ?? 0,
+						anchor: 'start',
+						position: 'top',
 					}}
 					typeClass={props.layer && RundownUtils.getSourceLayerClassName(props.layer.type)}
 					itemElement={itemIcon.current}

--- a/meteor/client/ui/Shelf/Renderers/L3rdListItemRenderer.tsx
+++ b/meteor/client/ui/Shelf/Renderers/L3rdListItemRenderer.tsx
@@ -164,7 +164,7 @@ export const L3rdListItemRenderer: React.FunctionComponent<ILayerItemRendererPro
 						top: itemIconPosition?.top ?? 0,
 						left: itemIconPosition?.left ?? 0,
 						anchor: 'start',
-						position: 'top',
+						position: 'top-start',
 					}}
 					typeClass={props.layer && RundownUtils.getSourceLayerClassName(props.layer.type)}
 					itemElement={itemIcon.current}

--- a/meteor/client/ui/Shelf/Renderers/VTListItemRenderer.tsx
+++ b/meteor/client/ui/Shelf/Renderers/VTListItemRenderer.tsx
@@ -131,9 +131,10 @@ export const VTListItemRenderer: React.FunctionComponent<ILayerItemRendererProps
 					timePosition={hoverScrubTimePosition}
 					content={vtContent}
 					position={{
-						top: itemIconPosition?.top + 'px',
-						left: itemIconPosition?.left + 'px',
-						transform: 'translate(0, -100%)',
+						top: itemIconPosition?.top ?? 0,
+						left: itemIconPosition?.left ?? 0,
+						anchor: 'start',
+						position: 'top',
 					}}
 					typeClass={props.layer && RundownUtils.getSourceLayerClassName(props.layer.type)}
 					itemElement={itemIcon.current}

--- a/meteor/client/ui/Shelf/Renderers/VTListItemRenderer.tsx
+++ b/meteor/client/ui/Shelf/Renderers/VTListItemRenderer.tsx
@@ -130,7 +130,7 @@ export const VTListItemRenderer: React.FunctionComponent<ILayerItemRendererProps
 					showMiniInspector={showMiniInspector}
 					timePosition={hoverScrubTimePosition}
 					content={vtContent}
-					floatingInspectorStyle={{
+					position={{
 						top: itemIconPosition?.top + 'px',
 						left: itemIconPosition?.left + 'px',
 						transform: 'translate(0, -100%)',

--- a/meteor/client/ui/Shelf/Renderers/VTListItemRenderer.tsx
+++ b/meteor/client/ui/Shelf/Renderers/VTListItemRenderer.tsx
@@ -134,7 +134,7 @@ export const VTListItemRenderer: React.FunctionComponent<ILayerItemRendererProps
 						top: itemIconPosition?.top ?? 0,
 						left: itemIconPosition?.left ?? 0,
 						anchor: 'start',
-						position: 'top',
+						position: 'top-start',
 					}}
 					typeClass={props.layer && RundownUtils.getSourceLayerClassName(props.layer.type)}
 					itemElement={itemIcon.current}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

The secondary Piece inspector pop-up is positioned incorrectly, not taking padding into account.

* **What is the new behavior (if this is a feature change)?**

The pop-up is using popper for correct placement and repositioning on scrolling.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
