### PR TITLE
feat: collect basic prometheus metrics from meteor and worker threads SOFIE-2306

### DIFF
--- a/meteor/server/Connections.ts
+++ b/meteor/server/Connections.ts
@@ -4,8 +4,13 @@ import { Meteor } from 'meteor/meteor'
 import { logger } from './logging'
 import { sendTrace } from './api/integration/influx'
 import { PeripheralDevices } from './collections'
+import { MetricsGauge } from '@sofie-automation/corelib/dist/prometheus'
 
 const connections = new Set<string>()
+const connectionsGauge = new MetricsGauge({
+	name: `sofie_meteor_ddp_connections_total`,
+	help: 'Number of open ddp connections',
+})
 
 Meteor.onConnection((conn: Meteor.Connection) => {
 	// This is called whenever a new ddp-connection is opened (ie a web-client or a peripheral-device)
@@ -53,6 +58,8 @@ Meteor.onConnection((conn: Meteor.Connection) => {
 
 let logTimeout: number | undefined = undefined
 function traceConnections() {
+	connectionsGauge.set(connections.size)
+
 	if (logTimeout) {
 		clearTimeout(logTimeout)
 	}

--- a/meteor/server/main.ts
+++ b/meteor/server/main.ts
@@ -65,6 +65,7 @@ import './Connections'
 import './coreSystem'
 import './cronjobs'
 import './email'
+import './prometheus'
 import './api/deviceTriggers/observer'
 // import './performanceMonitor' // called above
 

--- a/meteor/server/prometheus.ts
+++ b/meteor/server/prometheus.ts
@@ -1,0 +1,6 @@
+import { Meteor } from 'meteor/meteor'
+import { setupPrometheusMetrics } from '@sofie-automation/corelib/dist/prometheus'
+
+Meteor.startup(() => {
+	setupPrometheusMetrics('meteor')
+})

--- a/meteor/server/publications/lib.ts
+++ b/meteor/server/publications/lib.ts
@@ -15,9 +15,16 @@ import {
 import { protectStringObject, waitForPromise } from '../../lib/lib'
 import { DBShowStyleBase } from '../../lib/collections/ShowStyleBases'
 import { PeripheralDevices, ShowStyleBases } from '../collections'
+import { MetricsGauge } from '@sofie-automation/corelib/dist/prometheus'
 
 export const MeteorPublicationSignatures: { [key: string]: string[] } = {}
 export const MeteorPublications: { [key: string]: Function } = {}
+
+const MeteorPublicationsGauge = new MetricsGauge({
+	name: `sofie_meteor_publication_subscribers_total`,
+	help: 'Number of subscribers on a Meteor publication (ignoring arguments)',
+	labelNames: ['publication'],
+})
 
 export interface SubscriptionContext extends Omit<Subscription, 'userId'> {
 	/**
@@ -26,6 +33,30 @@ export interface SubscriptionContext extends Omit<Subscription, 'userId'> {
 	 * is rerun with the new value, assuming it didn’t throw an error at the previous run.
 	 */
 	userId: UserId | null
+}
+
+/**
+ * Unsafe wrapper around Meteor.publish
+ * @param name
+ * @param callback
+ */
+export function meteorPublishUnsafe(
+	name: string,
+	callback: (this: SubscriptionContext, ...args: any) => Promise<any>
+): void {
+	const signature = extractFunctionSignature(callback)
+	if (signature) MeteorPublicationSignatures[name] = signature
+
+	MeteorPublications[name] = callback
+
+	const publicationGauge = MeteorPublicationsGauge.labels({ publication: name })
+
+	Meteor.publish(name, function (...args: any[]): any {
+		publicationGauge.inc()
+		this.onStop(() => publicationGauge.dec())
+
+		return waitForPromise(callback.apply(protectStringObject<Subscription, 'userId'>(this), args))
+	})
 }
 
 /**
@@ -40,14 +71,7 @@ export function meteorPublish<K extends keyof PubSubTypes>(
 		...args: Parameters<PubSubTypes[K]>
 	) => Promise<MongoCursor<ReturnType<PubSubTypes[K]>> | null>
 ): void {
-	const signature = extractFunctionSignature(callback)
-	if (signature) MeteorPublicationSignatures[name] = signature
-
-	MeteorPublications[name] = callback
-
-	Meteor.publish(name, function (...args: any[]): any {
-		return waitForPromise(callback.apply(protectStringObject<Subscription, 'userId'>(this), args as any)) || []
-	})
+	meteorPublishUnsafe(name, callback)
 }
 
 export namespace AutoFillSelector {

--- a/meteor/server/worker/worker.ts
+++ b/meteor/server/worker/worker.ts
@@ -26,6 +26,7 @@ import { LogEntry } from 'winston'
 import { initializeWorkerStatus, setWorkerStatus } from './workerStatus'
 import { MongoQuery } from '../../lib/typings/meteor'
 import { UserActionsLog } from '../collections'
+import { MetricsCounter } from '@sofie-automation/corelib/dist/prometheus'
 
 const FREEZE_LIMIT = 1000 // how long to wait for a response to a Ping
 const RESTART_TIMEOUT = 30000 // how long to wait for a restart to complete before throwing an error
@@ -37,17 +38,42 @@ interface JobEntry {
 	completionHandler: JobCompletionHandler | null
 }
 
+const metricsQueueTotalCounter = new MetricsCounter({
+	name: 'sofie_meteor_jobqueue_queue_total',
+	help: 'Number of jobs put into each worker job queues',
+	labelNames: ['threadName'],
+})
+const metricsQueueSuccessCounter = new MetricsCounter({
+	name: 'sofie_meteor_jobqueue_success',
+	help: 'Number of successful jobs from each worker',
+	labelNames: ['threadName'],
+})
+const metricsQueueErrorsCounter = new MetricsCounter({
+	name: 'sofie_meteor_jobqueue_queue_errors',
+	help: 'Number of failed jobs from each worker',
+	labelNames: ['threadName'],
+})
+
 interface JobQueue {
 	jobs: Array<JobEntry | null>
 	/** Notify that there is a job waiting (aka worker is long-polling) */
 	notifyWorker: ManualPromise<void> | null
+
+	metricsTotal: MetricsCounter.Internal
+	metricsSuccess: MetricsCounter.Internal
+	metricsErrors: MetricsCounter.Internal
 }
 
 type JobCompletionHandler = (startedTime: number, finishedTime: number, err: any, result: any) => void
 
+interface RunningJob {
+	queueName: string
+	completionHandler: JobCompletionHandler | null
+}
+
 const queues = new Map<string, JobQueue>()
 /** Contains all jobs that are currently being executed by a Worker. */
-const runningJobs = new Map<string, JobCompletionHandler>()
+const runningJobs = new Map<string, RunningJob>()
 
 function getOrCreateQueue(queueName: string): JobQueue {
 	let queue = queues.get(queueName)
@@ -55,6 +81,9 @@ function getOrCreateQueue(queueName: string): JobQueue {
 		queue = {
 			jobs: [],
 			notifyWorker: null,
+			metricsTotal: metricsQueueTotalCounter.labels(queueName),
+			metricsSuccess: metricsQueueSuccessCounter.labels(queueName),
+			metricsErrors: metricsQueueErrorsCounter.labels(queueName),
 		}
 		queues.set(queueName, queue)
 	}
@@ -71,7 +100,20 @@ async function jobFinished(
 	const job = runningJobs.get(id)
 	if (job) {
 		runningJobs.delete(id)
-		job(startedTime, finishedTime, err, result)
+
+		// Update metrics
+		const queue = queues.get(job.queueName)
+		if (queue) {
+			if (err) {
+				queue.metricsErrors.inc()
+			} else {
+				queue.metricsSuccess.inc()
+			}
+		}
+
+		if (job.completionHandler) {
+			job.completionHandler(startedTime, finishedTime, err, result)
+		}
 	}
 }
 /** This is called by each Worker Thread, when it is idle and wants another job */
@@ -108,7 +150,11 @@ async function getNextJob(queueName: string): Promise<JobSpec | null> {
 	const job = queue.jobs.shift()
 	if (job) {
 		// If there is a completion handler, register it for execution
-		if (job.completionHandler) runningJobs.set(job.spec.id, job.completionHandler)
+		runningJobs.set(job.spec.id, {
+			queueName,
+			completionHandler: job.completionHandler,
+		})
+
 		// Pass the job to the worker
 		return job.spec
 	}
@@ -151,6 +197,7 @@ function queueJobInner(queueName: string, jobToQueue: JobEntry): void {
 	// Put the job at the end of the queue:
 	const queue = getOrCreateQueue(queueName)
 	queue.jobs.push(jobToQueue)
+	queue.metricsTotal.inc()
 
 	// If there is a worker waiting to pick up a job
 	if (queue.notifyWorker) {
@@ -301,7 +348,12 @@ MeteorStartupAsync(async () => {
 			// Thread closed, reject all jobs
 			const now = getCurrentTime()
 			for (const job of runningJobs.values()) {
-				job(now, now, new Error('Thread closed'), null)
+				const queue = queues.get(job.queueName)
+				if (queue) queue.metricsErrors.inc()
+
+				if (job.completionHandler) {
+					job.completionHandler(now, now, new Error('Thread closed'), null)
+				}
 			}
 			runningJobs.clear()
 

--- a/meteor/server/worker/worker.ts
+++ b/meteor/server/worker/worker.ts
@@ -335,6 +335,15 @@ export interface WorkerJob<TRes> {
 }
 
 /**
+ * Collect all the prometheus metrics across all the worker threads
+ */
+export async function collectWorkerPrometheusMetrics(): Promise<string[]> {
+	if (!worker) return []
+
+	return worker.collectMetrics()
+}
+
+/**
  * Queue a force clear caches job for all workers
  * @param studioIds Studios to clear caches for
  */

--- a/meteor/yarn.lock
+++ b/meteor/yarn.lock
@@ -2994,6 +2994,11 @@ binary-search@^1.3.3:
   resolved "https://registry.yarnpkg.com/binary-search/-/binary-search-1.3.6.tgz#e32426016a0c5092f0f3598836a1c7da3560565c"
   integrity sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA==
 
+bintrees@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.2.tgz#49f896d6e858a4a499df85c38fb399b9aff840f8"
+  integrity sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==
+
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.9:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
@@ -7775,6 +7780,13 @@ process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
 
+prom-client@^14.2.0:
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-14.2.0.tgz#ca94504e64156f6506574c25fb1c34df7812cf11"
+  integrity sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==
+  dependencies:
+    tdigest "^0.1.1"
+
 promise.allsettled@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/promise.allsettled/-/promise.allsettled-1.0.6.tgz#8dc8ba8edf429feb60f8e81335b920e109c94b6e"
@@ -9212,6 +9224,13 @@ tar@^6.1.11:
     minizlib "^2.1.1"
     mkdirp "^1.0.3"
     yallist "^4.0.0"
+
+tdigest@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.2.tgz#96c64bac4ff10746b910b0e23b515794e12faced"
+  integrity sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==
+  dependencies:
+    bintrees "1.0.2"
 
 temp-dir@^2.0.0:
   version "2.0.0"

--- a/packages/corelib/package.json
+++ b/packages/corelib/package.json
@@ -46,6 +46,7 @@
 		"influx": "^5.9.3",
 		"nanoid": "^3.3.4",
 		"object-path": "^0.11.8",
+		"prom-client": "^14.2.0",
 		"timecode": "0.0.4",
 		"tslib": "^2.4.0",
 		"type-fest": "^2.19.0",

--- a/packages/corelib/src/prometheus.ts
+++ b/packages/corelib/src/prometheus.ts
@@ -1,0 +1,27 @@
+import { register, collectDefaultMetrics } from 'prom-client'
+
+/**
+ * HTTP Content-type header for the metrics
+ */
+export const PrometheusHTTPContentType = register.contentType
+
+/**
+ * Stringified metrics for serving over HTTP
+ */
+export async function getPrometheusMetricsString(): Promise<string> {
+	return register.metrics()
+}
+
+/**
+ * Setup metric reporting for this thread
+ * @param threadName The `threadName` label to add to each metric
+ */
+export function setupPrometheusMetrics(threadName: string): void {
+	// Label all metrics with the source 'thread'
+	register.setDefaultLabels({
+		threadName: threadName,
+	})
+
+	// Collect the default metrics nodejs metrics
+	collectDefaultMetrics()
+}

--- a/packages/corelib/src/prometheus.ts
+++ b/packages/corelib/src/prometheus.ts
@@ -1,5 +1,7 @@
 import { register, collectDefaultMetrics } from 'prom-client'
 
+export { Gauge as MetricsGauge } from 'prom-client'
+
 /**
  * HTTP Content-type header for the metrics
  */

--- a/packages/corelib/src/prometheus.ts
+++ b/packages/corelib/src/prometheus.ts
@@ -1,6 +1,12 @@
 import { register, collectDefaultMetrics } from 'prom-client'
 
-export { Gauge as MetricsGauge } from 'prom-client'
+// Re-export types, to ensure the correct 'instance' of 'prom-client' is used
+export {
+	Gauge as MetricsGauge,
+	Counter as MetricsCounter,
+	Histogram as MetricsHistogram,
+	Summary as MetricsSummary,
+} from 'prom-client'
 
 /**
  * HTTP Content-type header for the metrics

--- a/packages/job-worker/src/main.ts
+++ b/packages/job-worker/src/main.ts
@@ -106,6 +106,16 @@ export abstract class JobWorkerBase {
 			await this.#client.close()
 		}
 	}
+
+	public collectWorkerSetMetrics(): Promise<string>[] {
+		const metrics: Promise<string>[] = []
+
+		for (const workerSet of this.#workers.values()) {
+			metrics.push(...workerSet.collectMetrics())
+		}
+
+		return metrics
+	}
 }
 
 /** Get the ids of the studios to run for */

--- a/packages/job-worker/src/workers/events/parent.ts
+++ b/packages/job-worker/src/workers/events/parent.ts
@@ -69,4 +69,7 @@ export class EventsWorkerParent extends WorkerParentBase {
 	public async workerLockChange(lockId: string, locked: boolean): Promise<void> {
 		return this.#thread.lockChange(lockId, locked)
 	}
+	public async collectMetrics(): Promise<string> {
+		return this.#thread.collectMetrics()
+	}
 }

--- a/packages/job-worker/src/workers/ingest/child.ts
+++ b/packages/job-worker/src/workers/ingest/child.ts
@@ -13,6 +13,7 @@ import { stringifyError } from '@sofie-automation/corelib/dist/lib'
 import { setupInfluxDb } from '../../influx'
 import { getIngestQueueName } from '@sofie-automation/corelib/dist/worker/ingest'
 import { WorkerJobResult } from '../parent-base'
+import { getPrometheusMetricsString, setupPrometheusMetrics } from '@sofie-automation/corelib/dist/prometheus'
 
 interface StaticData {
 	readonly mongoClient: MongoClient
@@ -38,6 +39,7 @@ export class IngestWorkerChild {
 	) {
 		// Intercept logging to pipe back over ipc
 		interceptLogging(getIngestQueueName(studioId), logLine)
+		setupPrometheusMetrics(getIngestQueueName(studioId))
 
 		setupApmAgent()
 		setupInfluxDb()
@@ -85,6 +87,9 @@ export class IngestWorkerChild {
 		} finally {
 			transaction?.end()
 		}
+	}
+	async collectMetrics(): Promise<string> {
+		return getPrometheusMetricsString()
 	}
 	async runJob(jobName: string, data: unknown): Promise<WorkerJobResult> {
 		if (!this.#staticData) throw new Error('Worker not initialised')

--- a/packages/job-worker/src/workers/ingest/parent.ts
+++ b/packages/job-worker/src/workers/ingest/parent.ts
@@ -70,4 +70,7 @@ export class IngestWorkerParent extends WorkerParentBase {
 	public async workerLockChange(lockId: string, locked: boolean): Promise<void> {
 		return this.#thread.lockChange(lockId, locked)
 	}
+	public async collectMetrics(): Promise<string> {
+		return this.#thread.collectMetrics()
+	}
 }

--- a/packages/job-worker/src/workers/parent-base.ts
+++ b/packages/job-worker/src/workers/parent-base.ts
@@ -144,6 +144,8 @@ export abstract class WorkerParentBase {
 	protected abstract restartWorkerThread(): Promise<void>
 	/** Inform the worker thread about a lock change */
 	public abstract workerLockChange(lockId: string, locked: boolean): Promise<void>
+	/** Collect prometheus metrics from the worker thread */
+	public abstract collectMetrics(): Promise<string>
 
 	private async tryRestartThread() {
 		// Ensure that the status is set to manual restart so that if this fails, we'll retry later:

--- a/packages/job-worker/src/workers/studio/parent.ts
+++ b/packages/job-worker/src/workers/studio/parent.ts
@@ -69,4 +69,7 @@ export class StudioWorkerParent extends WorkerParentBase {
 	public async workerLockChange(lockId: string, locked: boolean): Promise<void> {
 		return this.#thread.lockChange(lockId, locked)
 	}
+	public async collectMetrics(): Promise<string> {
+		return this.#thread.collectMetrics()
+	}
 }

--- a/packages/job-worker/src/workers/worker-set.ts
+++ b/packages/job-worker/src/workers/worker-set.ts
@@ -189,6 +189,10 @@ export class StudioWorkerSet {
 		)
 	}
 
+	public collectMetrics(): Promise<string>[] {
+		return this.#threads.map(async (t) => t.collectMetrics())
+	}
+
 	public async terminate(): Promise<void> {
 		await Promise.allSettled(this.#threads.map(async (t) => t.terminate()))
 

--- a/packages/yarn.lock
+++ b/packages/yarn.lock
@@ -3910,7 +3910,7 @@
     webpack-sources "^3.2.2"
 
 "@sofie-automation/blueprints-integration@link:blueprints-integration":
-  version "1.49.0-in-development"
+  version "1.49.0-in-testing.3"
   dependencies:
     "@sofie-automation/shared-lib" "link:shared-lib"
     tslib "^2.4.0"
@@ -3939,7 +3939,7 @@
     shelljs "^0.8.5"
 
 "@sofie-automation/corelib@link:corelib":
-  version "1.49.0-in-development"
+  version "1.49.0-in-testing.3"
   dependencies:
     "@sofie-automation/blueprints-integration" "link:blueprints-integration"
     "@sofie-automation/shared-lib" "link:shared-lib"
@@ -3954,7 +3954,7 @@
     underscore "^1.13.4"
 
 "@sofie-automation/shared-lib@link:shared-lib":
-  version "1.49.0-in-development"
+  version "1.49.0-in-testing.3"
   dependencies:
     "@mos-connection/model" "^3.0.1"
     timeline-state-resolver-types "8.0.0-release49.0"
@@ -5568,6 +5568,11 @@ binary-search@^1.3.3:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/binary-search/-/binary-search-1.3.6.tgz#e32426016a0c5092f0f3598836a1c7da3560565c"
   integrity sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA==
+
+bintrees@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.2.tgz#49f896d6e858a4a499df85c38fb399b9aff840f8"
+  integrity sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==
 
 bitdepth@^7.0.2:
   version "7.0.2"
@@ -12684,6 +12689,13 @@ process-warning@^1.0.0:
   resolved "https://registry.yarnpkg.com/process-warning/-/process-warning-1.0.0.tgz#980a0b25dc38cd6034181be4b7726d89066b4616"
   integrity sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==
 
+prom-client@^14.2.0:
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-14.2.0.tgz#ca94504e64156f6506574c25fb1c34df7812cf11"
+  integrity sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==
+  dependencies:
+    tdigest "^0.1.1"
+
 promise-all-reject-late@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-all-reject-late/-/promise-all-reject-late-1.0.1.tgz#f8ebf13483e5ca91ad809ccc2fcf25f26f8643c2"
@@ -14648,6 +14660,13 @@ tar@^6.1.0, tar@^6.1.11, tar@^6.1.2:
     minizlib "^2.1.1"
     mkdirp "^1.0.3"
     yallist "^4.0.0"
+
+tdigest@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.2.tgz#96c64bac4ff10746b910b0e23b515794e12faced"
+  integrity sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==
+  dependencies:
+    bintrees "1.0.2"
 
 temp-dir@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the new behavior (if this is a feature change)?**

Adds some basic prometheus metrics, exposed at the `/metrics` endpoint

It is collecting the `default` metrics from each of meteor and the worker_threads, and combining them into the one endpoint. Each thread is setup to apply a different `threadName` label value, to allow the data to be identified per-thread.

Current custom metrics:
* `sofie_meteor_ddp_connections_total` - 'Number of open ddp connections'
* `sofie_meteor_publication_subscribers_total - 'Number of subscribers on a Meteor publication (ignoring arguments)'
* `sofie_meteor_jobqueue_queue_total` - 'Number of jobs put into each worker job queues'
* `sofie_meteor_jobqueue_success` - 'Number of successful jobs from each worker'
* `sofie_meteor_jobqueue_queue_errors` - 'Number of failed jobs from each worker'

* **Other information**:

Example output:
```
# HELP sofie_meteor_jobqueue_queue_total Number of jobs put into each worker job queues
# TYPE sofie_meteor_jobqueue_queue_total counter
sofie_meteor_jobqueue_queue_total{threadName="studio:studio0"} 2

# HELP sofie_meteor_jobqueue_success Number of successful jobs from each worker
# TYPE sofie_meteor_jobqueue_success counter
sofie_meteor_jobqueue_success{threadName="studio:studio0"} 2

# HELP sofie_meteor_jobqueue_queue_errors Number of failed jobs from each worker
# TYPE sofie_meteor_jobqueue_queue_errors counter

# HELP sofie_meteor_publication_subscribers_total Number of subscribers on a Meteor publication (ignoring arguments)
# TYPE sofie_meteor_publication_subscribers_total gauge
sofie_meteor_publication_subscribers_total{publication="translationsBundles",threadName="meteor"} 1
sofie_meteor_publication_subscribers_total{publication="rundownPlaylists",threadName="meteor"} 1
sofie_meteor_publication_subscribers_total{publication="coreSystem",threadName="meteor"} 1
sofie_meteor_publication_subscribers_total{publication="uiStudio",threadName="meteor"} 1
sofie_meteor_publication_subscribers_total{publication="loggedInUser",threadName="meteor"} 1
sofie_meteor_publication_subscribers_total{publication="uiSegmentPartNotes",threadName="meteor"} 0
sofie_meteor_publication_subscribers_total{publication="rundowns",threadName="meteor"} 2
sofie_meteor_publication_subscribers_total{publication="uiPieceContentStatuses",threadName="meteor"} 0
sofie_meteor_publication_subscribers_total{publication="rundownLayouts",threadName="meteor"} 1
sofie_meteor_publication_subscribers_total{publication="showStyleVariants",threadName="meteor"} 2
sofie_meteor_publication_subscribers_total{publication="buckets",threadName="meteor"} 0
sofie_meteor_publication_subscribers_total{publication="uiShowStyleBase",threadName="meteor"} 1
sofie_meteor_publication_subscribers_total{publication="packageContainerPackageStatusesSimple",threadName="meteor"} 0
sofie_meteor_publication_subscribers_total{publication="segments",threadName="meteor"} 0
sofie_meteor_publication_subscribers_total{publication="adLibPieces",threadName="meteor"} 0
sofie_meteor_publication_subscribers_total{publication="rundownBaselineAdLibPieces",threadName="meteor"} 0
sofie_meteor_publication_subscribers_total{publication="adLibActions",threadName="meteor"} 0
sofie_meteor_publication_subscribers_total{publication="rundownBaselineAdLibActions",threadName="meteor"} 0
sofie_meteor_publication_subscribers_total{publication="parts",threadName="meteor"} 0
sofie_meteor_publication_subscribers_total{publication="partInstances",threadName="meteor"} 0
sofie_meteor_publication_subscribers_total{publication="pieceInstances",threadName="meteor"} 0
sofie_meteor_publication_subscribers_total{publication=" peripheralDevicesAndSubDevices",threadName="meteor"} 0
sofie_meteor_publication_subscribers_total{publication="uiTriggeredActions",threadName="meteor"} 0
sofie_meteor_publication_subscribers_total{publication="externalMessageQueue",threadName="meteor"} 0
sofie_meteor_publication_subscribers_total{publication="pieces",threadName="meteor"} 0
sofie_meteor_publication_subscribers_total{publication="mediaObjects",threadName="meteor"} 0
sofie_meteor_publication_subscribers_total{publication="bucketAdLibPieces",threadName="meteor"} 0
sofie_meteor_publication_subscribers_total{publication="bucketAdLibActions",threadName="meteor"} 0
sofie_meteor_publication_subscribers_total{publication="studios",threadName="meteor"} 0
sofie_meteor_publication_subscribers_total{publication="showStyleBases",threadName="meteor"} 0
sofie_meteor_publication_subscribers_total{publication="blueprints",threadName="meteor"} 0
sofie_meteor_publication_subscribers_total{publication="peripheralDevices",threadName="meteor"} 0
sofie_meteor_publication_subscribers_total{publication="snapshots",threadName="meteor"} 0

# HELP sofie_meteor_ddp_connections_total Number of open ddp connections
# TYPE sofie_meteor_ddp_connections_total gauge
sofie_meteor_ddp_connections_total{threadName="meteor"} 1

# HELP process_cpu_user_seconds_total Total user CPU time spent in seconds.
# TYPE process_cpu_user_seconds_total counter
process_cpu_user_seconds_total{threadName="meteor"} 9.218116

# HELP process_cpu_system_seconds_total Total system CPU time spent in seconds.
# TYPE process_cpu_system_seconds_total counter
process_cpu_system_seconds_total{threadName="meteor"} 0.711228

# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total{threadName="meteor"} 9.929344

# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds{threadName="meteor"} 1683298255

# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes{threadName="meteor"} 378462208

# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes{threadName="meteor"} 2368294912

# HELP process_heap_bytes Process heap size in bytes.
# TYPE process_heap_bytes gauge
process_heap_bytes{threadName="meteor"} 637808640

# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds{threadName="meteor"} 90

# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds{threadName="meteor"} 1048576

# HELP nodejs_eventloop_lag_seconds Lag of event loop in seconds.
# TYPE nodejs_eventloop_lag_seconds gauge
nodejs_eventloop_lag_seconds{threadName="meteor"} 0.003279238

# HELP nodejs_eventloop_lag_min_seconds The minimum recorded event loop delay.
# TYPE nodejs_eventloop_lag_min_seconds gauge
nodejs_eventloop_lag_min_seconds{threadName="meteor"} 0.00905216

# HELP nodejs_eventloop_lag_max_seconds The maximum recorded event loop delay.
# TYPE nodejs_eventloop_lag_max_seconds gauge
nodejs_eventloop_lag_max_seconds{threadName="meteor"} 0.228196351

# HELP nodejs_eventloop_lag_mean_seconds The mean of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_mean_seconds gauge
nodejs_eventloop_lag_mean_seconds{threadName="meteor"} 0.010233096117368671

# HELP nodejs_eventloop_lag_stddev_seconds The standard deviation of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_stddev_seconds gauge
nodejs_eventloop_lag_stddev_seconds{threadName="meteor"} 0.004584444784617656

# HELP nodejs_eventloop_lag_p50_seconds The 50th percentile of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_p50_seconds gauge
nodejs_eventloop_lag_p50_seconds{threadName="meteor"} 0.010076159

# HELP nodejs_eventloop_lag_p90_seconds The 90th percentile of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_p90_seconds gauge
nodejs_eventloop_lag_p90_seconds{threadName="meteor"} 0.010076159

# HELP nodejs_eventloop_lag_p99_seconds The 99th percentile of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_p99_seconds gauge
nodejs_eventloop_lag_p99_seconds{threadName="meteor"} 0.010870783

# HELP nodejs_active_handles Number of active libuv handles grouped by handle type. Every handle type is C++ class name.
# TYPE nodejs_active_handles gauge
nodejs_active_handles{type="Pipe",threadName="meteor"} 1
nodejs_active_handles{type="Socket",threadName="meteor"} 24
nodejs_active_handles{type="Server",threadName="meteor"} 2
nodejs_active_handles{type="MessagePort",threadName="meteor"} 1

# HELP nodejs_active_handles_total Total number of active handles.
# TYPE nodejs_active_handles_total gauge
nodejs_active_handles_total{threadName="meteor"} 28

# HELP nodejs_active_requests Number of active libuv requests grouped by request type. Every request type is C++ class name.
# TYPE nodejs_active_requests gauge

# HELP nodejs_active_requests_total Total number of active requests.
# TYPE nodejs_active_requests_total gauge
nodejs_active_requests_total{threadName="meteor"} 0

# HELP nodejs_heap_size_total_bytes Process heap size from Node.js in bytes.
# TYPE nodejs_heap_size_total_bytes gauge
nodejs_heap_size_total_bytes{threadName="meteor"} 145088512

# HELP nodejs_heap_size_used_bytes Process heap size used from Node.js in bytes.
# TYPE nodejs_heap_size_used_bytes gauge
nodejs_heap_size_used_bytes{threadName="meteor"} 139605824

# HELP nodejs_external_memory_bytes Node.js external memory size in bytes.
# TYPE nodejs_external_memory_bytes gauge
nodejs_external_memory_bytes{threadName="meteor"} 22483884

# HELP nodejs_heap_space_size_total_bytes Process heap space size total from Node.js in bytes.
# TYPE nodejs_heap_space_size_total_bytes gauge
nodejs_heap_space_size_total_bytes{space="read_only",threadName="meteor"} 151552
nodejs_heap_space_size_total_bytes{space="new",threadName="meteor"} 1048576
nodejs_heap_space_size_total_bytes{space="old",threadName="meteor"} 94531584
nodejs_heap_space_size_total_bytes{space="code",threadName="meteor"} 2195456
nodejs_heap_space_size_total_bytes{space="map",threadName="meteor"} 4198400
nodejs_heap_space_size_total_bytes{space="large_object",threadName="meteor"} 42627072
nodejs_heap_space_size_total_bytes{space="code_large_object",threadName="meteor"} 335872
nodejs_heap_space_size_total_bytes{space="new_large_object",threadName="meteor"} 0

# HELP nodejs_heap_space_size_used_bytes Process heap space size used from Node.js in bytes.
# TYPE nodejs_heap_space_size_used_bytes gauge
nodejs_heap_space_size_used_bytes{space="read_only",threadName="meteor"} 150392
nodejs_heap_space_size_used_bytes{space="new",threadName="meteor"} 367536
nodejs_heap_space_size_used_bytes{space="old",threadName="meteor"} 92859392
nodejs_heap_space_size_used_bytes{space="code",threadName="meteor"} 1695808
nodejs_heap_space_size_used_bytes{space="map",threadName="meteor"} 1804896
nodejs_heap_space_size_used_bytes{space="large_object",threadName="meteor"} 42467568
nodejs_heap_space_size_used_bytes{space="code_large_object",threadName="meteor"} 273920
nodejs_heap_space_size_used_bytes{space="new_large_object",threadName="meteor"} 0

# HELP nodejs_heap_space_size_available_bytes Process heap space size available from Node.js in bytes.
# TYPE nodejs_heap_space_size_available_bytes gauge
nodejs_heap_space_size_available_bytes{space="read_only",threadName="meteor"} 0
nodejs_heap_space_size_available_bytes{space="new",threadName="meteor"} 679888
nodejs_heap_space_size_available_bytes{space="old",threadName="meteor"} 1231800
nodejs_heap_space_size_available_bytes{space="code",threadName="meteor"} 257472
nodejs_heap_space_size_available_bytes{space="map",threadName="meteor"} 2387808
nodejs_heap_space_size_available_bytes{space="large_object",threadName="meteor"} 0
nodejs_heap_space_size_available_bytes{space="code_large_object",threadName="meteor"} 0
nodejs_heap_space_size_available_bytes{space="new_large_object",threadName="meteor"} 1047424

# HELP nodejs_version_info Node.js version info.
# TYPE nodejs_version_info gauge
nodejs_version_info{version="v14.19.3",major="14",minor="19",patch="3",threadName="meteor"} 1

# HELP nodejs_gc_duration_seconds Garbage collection duration by kind, one of major, minor, incremental or weakcb.
# TYPE nodejs_gc_duration_seconds histogram
nodejs_gc_duration_seconds_bucket{le="0.001",kind="minor",threadName="meteor"} 49
nodejs_gc_duration_seconds_bucket{le="0.01",kind="minor",threadName="meteor"} 120
nodejs_gc_duration_seconds_bucket{le="0.1",kind="minor",threadName="meteor"} 121
nodejs_gc_duration_seconds_bucket{le="1",kind="minor",threadName="meteor"} 121
nodejs_gc_duration_seconds_bucket{le="2",kind="minor",threadName="meteor"} 121
nodejs_gc_duration_seconds_bucket{le="5",kind="minor",threadName="meteor"} 121
nodejs_gc_duration_seconds_bucket{le="+Inf",kind="minor",threadName="meteor"} 121
nodejs_gc_duration_seconds_sum{kind="minor",threadName="meteor"} 0.24197180699999998
nodejs_gc_duration_seconds_count{kind="minor",threadName="meteor"} 121
nodejs_gc_duration_seconds_bucket{le="0.001",kind="incremental",threadName="meteor"} 22
nodejs_gc_duration_seconds_bucket{le="0.01",kind="incremental",threadName="meteor"} 22
nodejs_gc_duration_seconds_bucket{le="0.1",kind="incremental",threadName="meteor"} 22
nodejs_gc_duration_seconds_bucket{le="1",kind="incremental",threadName="meteor"} 22
nodejs_gc_duration_seconds_bucket{le="2",kind="incremental",threadName="meteor"} 22
nodejs_gc_duration_seconds_bucket{le="5",kind="incremental",threadName="meteor"} 22
nodejs_gc_duration_seconds_bucket{le="+Inf",kind="incremental",threadName="meteor"} 22
nodejs_gc_duration_seconds_sum{kind="incremental",threadName="meteor"} 0.0052225679999999995
nodejs_gc_duration_seconds_count{kind="incremental",threadName="meteor"} 22
nodejs_gc_duration_seconds_bucket{le="0.001",kind="major",threadName="meteor"} 0
nodejs_gc_duration_seconds_bucket{le="0.01",kind="major",threadName="meteor"} 10
nodejs_gc_duration_seconds_bucket{le="0.1",kind="major",threadName="meteor"} 11
nodejs_gc_duration_seconds_bucket{le="1",kind="major",threadName="meteor"} 11
nodejs_gc_duration_seconds_bucket{le="2",kind="major",threadName="meteor"} 11
nodejs_gc_duration_seconds_bucket{le="5",kind="major",threadName="meteor"} 11
nodejs_gc_duration_seconds_bucket{le="+Inf",kind="major",threadName="meteor"} 11
nodejs_gc_duration_seconds_sum{kind="major",threadName="meteor"} 0.06768383
nodejs_gc_duration_seconds_count{kind="major",threadName="meteor"} 11
nodejs_gc_duration_seconds_bucket{le="0.001",kind="weakcb",threadName="meteor"} 1
nodejs_gc_duration_seconds_bucket{le="0.01",kind="weakcb",threadName="meteor"} 1
nodejs_gc_duration_seconds_bucket{le="0.1",kind="weakcb",threadName="meteor"} 1
nodejs_gc_duration_seconds_bucket{le="1",kind="weakcb",threadName="meteor"} 1
nodejs_gc_duration_seconds_bucket{le="2",kind="weakcb",threadName="meteor"} 1
nodejs_gc_duration_seconds_bucket{le="5",kind="weakcb",threadName="meteor"} 1
nodejs_gc_duration_seconds_bucket{le="+Inf",kind="weakcb",threadName="meteor"} 1
nodejs_gc_duration_seconds_sum{kind="weakcb",threadName="meteor"} 0.000008156
nodejs_gc_duration_seconds_count{kind="weakcb",threadName="meteor"} 1


# HELP process_cpu_user_seconds_total Total user CPU time spent in seconds.
# TYPE process_cpu_user_seconds_total counter
process_cpu_user_seconds_total{threadName="worker-parent"} 10.846325

# HELP process_cpu_system_seconds_total Total system CPU time spent in seconds.
# TYPE process_cpu_system_seconds_total counter
process_cpu_system_seconds_total{threadName="worker-parent"} 0.8451710000000001

# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total{threadName="worker-parent"} 11.691496

# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds{threadName="worker-parent"} 1683298255

# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes{threadName="worker-parent"} 378728448

# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes{threadName="worker-parent"} 2368294912

# HELP process_heap_bytes Process heap size in bytes.
# TYPE process_heap_bytes gauge
process_heap_bytes{threadName="worker-parent"} 637808640

# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds{threadName="worker-parent"} 90

# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds{threadName="worker-parent"} 1048576

# HELP nodejs_eventloop_lag_seconds Lag of event loop in seconds.
# TYPE nodejs_eventloop_lag_seconds gauge
nodejs_eventloop_lag_seconds{threadName="worker-parent"} 0.001695839

# HELP nodejs_eventloop_lag_min_seconds The minimum recorded event loop delay.
# TYPE nodejs_eventloop_lag_min_seconds gauge
nodejs_eventloop_lag_min_seconds{threadName="worker-parent"} 0.009060352

# HELP nodejs_eventloop_lag_max_seconds The maximum recorded event loop delay.
# TYPE nodejs_eventloop_lag_max_seconds gauge
nodejs_eventloop_lag_max_seconds{threadName="worker-parent"} 0.011026431

# HELP nodejs_eventloop_lag_mean_seconds The mean of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_mean_seconds gauge
nodejs_eventloop_lag_mean_seconds{threadName="worker-parent"} 0.010065090219222713

# HELP nodejs_eventloop_lag_stddev_seconds The standard deviation of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_stddev_seconds gauge
nodejs_eventloop_lag_stddev_seconds{threadName="worker-parent"} 0.00012546483403547704

# HELP nodejs_eventloop_lag_p50_seconds The 50th percentile of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_p50_seconds gauge
nodejs_eventloop_lag_p50_seconds{threadName="worker-parent"} 0.010067967

# HELP nodejs_eventloop_lag_p90_seconds The 90th percentile of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_p90_seconds gauge
nodejs_eventloop_lag_p90_seconds{threadName="worker-parent"} 0.010076159

# HELP nodejs_eventloop_lag_p99_seconds The 99th percentile of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_p99_seconds gauge
nodejs_eventloop_lag_p99_seconds{threadName="worker-parent"} 0.010493951

# HELP nodejs_active_handles Number of active libuv handles grouped by handle type. Every handle type is C++ class name.
# TYPE nodejs_active_handles gauge
nodejs_active_handles{type="MessagePort",threadName="worker-parent"} 4
nodejs_active_handles{type="Socket",threadName="worker-parent"} 9

# HELP nodejs_active_handles_total Total number of active handles.
# TYPE nodejs_active_handles_total gauge
nodejs_active_handles_total{threadName="worker-parent"} 13

# HELP nodejs_active_requests Number of active libuv requests grouped by request type. Every request type is C++ class name.
# TYPE nodejs_active_requests gauge

# HELP nodejs_active_requests_total Total number of active requests.
# TYPE nodejs_active_requests_total gauge
nodejs_active_requests_total{threadName="worker-parent"} 0

# HELP nodejs_heap_size_total_bytes Process heap size from Node.js in bytes.
# TYPE nodejs_heap_size_total_bytes gauge
nodejs_heap_size_total_bytes{threadName="worker-parent"} 22974464

# HELP nodejs_heap_size_used_bytes Process heap size used from Node.js in bytes.
# TYPE nodejs_heap_size_used_bytes gauge
nodejs_heap_size_used_bytes{threadName="worker-parent"} 20993464

# HELP nodejs_external_memory_bytes Node.js external memory size in bytes.
# TYPE nodejs_external_memory_bytes gauge
nodejs_external_memory_bytes{threadName="worker-parent"} 20634425

# HELP nodejs_heap_space_size_total_bytes Process heap space size total from Node.js in bytes.
# TYPE nodejs_heap_space_size_total_bytes gauge
nodejs_heap_space_size_total_bytes{space="read_only",threadName="worker-parent"} 151552
nodejs_heap_space_size_total_bytes{space="new",threadName="worker-parent"} 1048576
nodejs_heap_space_size_total_bytes{space="old",threadName="worker-parent"} 16334848
nodejs_heap_space_size_total_bytes{space="code",threadName="worker-parent"} 622592
nodejs_heap_space_size_total_bytes{space="map",threadName="worker-parent"} 1314816
nodejs_heap_space_size_total_bytes{space="large_object",threadName="worker-parent"} 3166208
nodejs_heap_space_size_total_bytes{space="code_large_object",threadName="worker-parent"} 335872
nodejs_heap_space_size_total_bytes{space="new_large_object",threadName="worker-parent"} 0

# HELP nodejs_heap_space_size_used_bytes Process heap space size used from Node.js in bytes.
# TYPE nodejs_heap_space_size_used_bytes gauge
nodejs_heap_space_size_used_bytes{space="read_only",threadName="worker-parent"} 150392
nodejs_heap_space_size_used_bytes{space="new",threadName="worker-parent"} 395272
nodejs_heap_space_size_used_bytes{space="old",threadName="worker-parent"} 15710816
nodejs_heap_space_size_used_bytes{space="code",threadName="worker-parent"} 410976
nodejs_heap_space_size_used_bytes{space="map",threadName="worker-parent"} 930816
nodejs_heap_space_size_used_bytes{space="large_object",threadName="worker-parent"} 3125912
nodejs_heap_space_size_used_bytes{space="code_large_object",threadName="worker-parent"} 273920
nodejs_heap_space_size_used_bytes{space="new_large_object",threadName="worker-parent"} 0

# HELP nodejs_heap_space_size_available_bytes Process heap space size available from Node.js in bytes.
# TYPE nodejs_heap_space_size_available_bytes gauge
nodejs_heap_space_size_available_bytes{space="read_only",threadName="worker-parent"} 0
nodejs_heap_space_size_available_bytes{space="new",threadName="worker-parent"} 652152
nodejs_heap_space_size_available_bytes{space="old",threadName="worker-parent"} 359984
nodejs_heap_space_size_available_bytes{space="code",threadName="worker-parent"} 20736
nodejs_heap_space_size_available_bytes{space="map",threadName="worker-parent"} 382016
nodejs_heap_space_size_available_bytes{space="large_object",threadName="worker-parent"} 0
nodejs_heap_space_size_available_bytes{space="code_large_object",threadName="worker-parent"} 0
nodejs_heap_space_size_available_bytes{space="new_large_object",threadName="worker-parent"} 1047424

# HELP nodejs_version_info Node.js version info.
# TYPE nodejs_version_info gauge
nodejs_version_info{version="v14.19.3",major="14",minor="19",patch="3",threadName="worker-parent"} 1

# HELP nodejs_gc_duration_seconds Garbage collection duration by kind, one of major, minor, incremental or weakcb.
# TYPE nodejs_gc_duration_seconds histogram
nodejs_gc_duration_seconds_bucket{le="0.001",kind="minor",threadName="worker-parent"} 15
nodejs_gc_duration_seconds_bucket{le="0.01",kind="minor",threadName="worker-parent"} 16
nodejs_gc_duration_seconds_bucket{le="0.1",kind="minor",threadName="worker-parent"} 16
nodejs_gc_duration_seconds_bucket{le="1",kind="minor",threadName="worker-parent"} 16
nodejs_gc_duration_seconds_bucket{le="2",kind="minor",threadName="worker-parent"} 16
nodejs_gc_duration_seconds_bucket{le="5",kind="minor",threadName="worker-parent"} 16
nodejs_gc_duration_seconds_bucket{le="+Inf",kind="minor",threadName="worker-parent"} 16
nodejs_gc_duration_seconds_sum{kind="minor",threadName="worker-parent"} 0.004875421999999999
nodejs_gc_duration_seconds_count{kind="minor",threadName="worker-parent"} 16
nodejs_gc_duration_seconds_bucket{le="0.001",kind="incremental",threadName="worker-parent"} 4
nodejs_gc_duration_seconds_bucket{le="0.01",kind="incremental",threadName="worker-parent"} 4
nodejs_gc_duration_seconds_bucket{le="0.1",kind="incremental",threadName="worker-parent"} 4
nodejs_gc_duration_seconds_bucket{le="1",kind="incremental",threadName="worker-parent"} 4
nodejs_gc_duration_seconds_bucket{le="2",kind="incremental",threadName="worker-parent"} 4
nodejs_gc_duration_seconds_bucket{le="5",kind="incremental",threadName="worker-parent"} 4
nodejs_gc_duration_seconds_bucket{le="+Inf",kind="incremental",threadName="worker-parent"} 4
nodejs_gc_duration_seconds_sum{kind="incremental",threadName="worker-parent"} 0.000491284
nodejs_gc_duration_seconds_count{kind="incremental",threadName="worker-parent"} 4
nodejs_gc_duration_seconds_bucket{le="0.001",kind="major",threadName="worker-parent"} 0
nodejs_gc_duration_seconds_bucket{le="0.01",kind="major",threadName="worker-parent"} 2
nodejs_gc_duration_seconds_bucket{le="0.1",kind="major",threadName="worker-parent"} 2
nodejs_gc_duration_seconds_bucket{le="1",kind="major",threadName="worker-parent"} 2
nodejs_gc_duration_seconds_bucket{le="2",kind="major",threadName="worker-parent"} 2
nodejs_gc_duration_seconds_bucket{le="5",kind="major",threadName="worker-parent"} 2
nodejs_gc_duration_seconds_bucket{le="+Inf",kind="major",threadName="worker-parent"} 2
nodejs_gc_duration_seconds_sum{kind="major",threadName="worker-parent"} 0.004367186
nodejs_gc_duration_seconds_count{kind="major",threadName="worker-parent"} 2


# HELP process_cpu_user_seconds_total Total user CPU time spent in seconds.
# TYPE process_cpu_user_seconds_total counter
process_cpu_user_seconds_total{threadName="studio:studio0"} 10.202663999999999

# HELP process_cpu_system_seconds_total Total system CPU time spent in seconds.
# TYPE process_cpu_system_seconds_total counter
process_cpu_system_seconds_total{threadName="studio:studio0"} 0.744947

# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total{threadName="studio:studio0"} 10.947610999999998

# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds{threadName="studio:studio0"} 1683298255

# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes{threadName="studio:studio0"} 378994688

# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes{threadName="studio:studio0"} 2368294912

# HELP process_heap_bytes Process heap size in bytes.
# TYPE process_heap_bytes gauge
process_heap_bytes{threadName="studio:studio0"} 637808640

# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds{threadName="studio:studio0"} 91

# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds{threadName="studio:studio0"} 1048576

# HELP nodejs_eventloop_lag_seconds Lag of event loop in seconds.
# TYPE nodejs_eventloop_lag_seconds gauge
nodejs_eventloop_lag_seconds{threadName="studio:studio0"} 0.002423945

# HELP nodejs_eventloop_lag_min_seconds The minimum recorded event loop delay.
# TYPE nodejs_eventloop_lag_min_seconds gauge
nodejs_eventloop_lag_min_seconds{threadName="studio:studio0"} 0.00905216

# HELP nodejs_eventloop_lag_max_seconds The maximum recorded event loop delay.
# TYPE nodejs_eventloop_lag_max_seconds gauge
nodejs_eventloop_lag_max_seconds{threadName="studio:studio0"} 0.011190271

# HELP nodejs_eventloop_lag_mean_seconds The mean of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_mean_seconds gauge
nodejs_eventloop_lag_mean_seconds{threadName="studio:studio0"} 0.010066274681564246

# HELP nodejs_eventloop_lag_stddev_seconds The standard deviation of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_stddev_seconds gauge
nodejs_eventloop_lag_stddev_seconds{threadName="studio:studio0"} 0.00005853894450633149

# HELP nodejs_eventloop_lag_p50_seconds The 50th percentile of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_p50_seconds gauge
nodejs_eventloop_lag_p50_seconds{threadName="studio:studio0"} 0.010076159

# HELP nodejs_eventloop_lag_p90_seconds The 90th percentile of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_p90_seconds gauge
nodejs_eventloop_lag_p90_seconds{threadName="studio:studio0"} 0.010076159

# HELP nodejs_eventloop_lag_p99_seconds The 99th percentile of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_p99_seconds gauge
nodejs_eventloop_lag_p99_seconds{threadName="studio:studio0"} 0.010174463

# HELP nodejs_active_handles Number of active libuv handles grouped by handle type. Every handle type is C++ class name.
# TYPE nodejs_active_handles gauge
nodejs_active_handles{type="MessagePort",threadName="studio:studio0"} 1
nodejs_active_handles{type="Socket",threadName="studio:studio0"} 7

# HELP nodejs_active_handles_total Total number of active handles.
# TYPE nodejs_active_handles_total gauge
nodejs_active_handles_total{threadName="studio:studio0"} 8

# HELP nodejs_active_requests Number of active libuv requests grouped by request type. Every request type is C++ class name.
# TYPE nodejs_active_requests gauge

# HELP nodejs_active_requests_total Total number of active requests.
# TYPE nodejs_active_requests_total gauge
nodejs_active_requests_total{threadName="studio:studio0"} 0

# HELP nodejs_heap_size_total_bytes Process heap size from Node.js in bytes.
# TYPE nodejs_heap_size_total_bytes gauge
nodejs_heap_size_total_bytes{threadName="studio:studio0"} 37625856

# HELP nodejs_heap_size_used_bytes Process heap size used from Node.js in bytes.
# TYPE nodejs_heap_size_used_bytes gauge
nodejs_heap_size_used_bytes{threadName="studio:studio0"} 36373208

# HELP nodejs_external_memory_bytes Node.js external memory size in bytes.
# TYPE nodejs_external_memory_bytes gauge
nodejs_external_memory_bytes{threadName="studio:studio0"} 20748047

# HELP nodejs_heap_space_size_total_bytes Process heap space size total from Node.js in bytes.
# TYPE nodejs_heap_space_size_total_bytes gauge
nodejs_heap_space_size_total_bytes{space="read_only",threadName="studio:studio0"} 151552
nodejs_heap_space_size_total_bytes{space="new",threadName="studio:studio0"} 1048576
nodejs_heap_space_size_total_bytes{space="old",threadName="studio:studio0"} 20267008
nodejs_heap_space_size_total_bytes{space="code",threadName="studio:studio0"} 884736
nodejs_heap_space_size_total_bytes{space="map",threadName="studio:studio0"} 1576960
nodejs_heap_space_size_total_bytes{space="large_object",threadName="studio:studio0"} 13361152
nodejs_heap_space_size_total_bytes{space="code_large_object",threadName="studio:studio0"} 335872
nodejs_heap_space_size_total_bytes{space="new_large_object",threadName="studio:studio0"} 0

# HELP nodejs_heap_space_size_used_bytes Process heap space size used from Node.js in bytes.
# TYPE nodejs_heap_space_size_used_bytes gauge
nodejs_heap_space_size_used_bytes{space="read_only",threadName="studio:studio0"} 150392
nodejs_heap_space_size_used_bytes{space="new",threadName="studio:studio0"} 1039072
nodejs_heap_space_size_used_bytes{space="old",threadName="studio:studio0"} 19714112
nodejs_heap_space_size_used_bytes{space="code",threadName="studio:studio0"} 612640
nodejs_heap_space_size_used_bytes{space="map",threadName="studio:studio0"} 1282968
nodejs_heap_space_size_used_bytes{space="large_object",threadName="studio:studio0"} 13305776
nodejs_heap_space_size_used_bytes{space="code_large_object",threadName="studio:studio0"} 273920
nodejs_heap_space_size_used_bytes{space="new_large_object",threadName="studio:studio0"} 0

# HELP nodejs_heap_space_size_available_bytes Process heap space size available from Node.js in bytes.
# TYPE nodejs_heap_space_size_available_bytes gauge
nodejs_heap_space_size_available_bytes{space="read_only",threadName="studio:studio0"} 0
nodejs_heap_space_size_available_bytes{space="new",threadName="studio:studio0"} 8352
nodejs_heap_space_size_available_bytes{space="old",threadName="studio:studio0"} 485048
nodejs_heap_space_size_available_bytes{space="code",threadName="studio:studio0"} 220320
nodejs_heap_space_size_available_bytes{space="map",threadName="studio:studio0"} 291592
nodejs_heap_space_size_available_bytes{space="large_object",threadName="studio:studio0"} 0
nodejs_heap_space_size_available_bytes{space="code_large_object",threadName="studio:studio0"} 0
nodejs_heap_space_size_available_bytes{space="new_large_object",threadName="studio:studio0"} 1047424

# HELP nodejs_version_info Node.js version info.
# TYPE nodejs_version_info gauge
nodejs_version_info{version="v14.19.3",major="14",minor="19",patch="3",threadName="studio:studio0"} 1

# HELP nodejs_gc_duration_seconds Garbage collection duration by kind, one of major, minor, incremental or weakcb.
# TYPE nodejs_gc_duration_seconds histogram
nodejs_gc_duration_seconds_bucket{le="0.001",kind="minor",threadName="studio:studio0"} 14
nodejs_gc_duration_seconds_bucket{le="0.01",kind="minor",threadName="studio:studio0"} 22
nodejs_gc_duration_seconds_bucket{le="0.1",kind="minor",threadName="studio:studio0"} 22
nodejs_gc_duration_seconds_bucket{le="1",kind="minor",threadName="studio:studio0"} 22
nodejs_gc_duration_seconds_bucket{le="2",kind="minor",threadName="studio:studio0"} 22
nodejs_gc_duration_seconds_bucket{le="5",kind="minor",threadName="studio:studio0"} 22
nodejs_gc_duration_seconds_bucket{le="+Inf",kind="minor",threadName="studio:studio0"} 22
nodejs_gc_duration_seconds_sum{kind="minor",threadName="studio:studio0"} 0.032291122000000005
nodejs_gc_duration_seconds_count{kind="minor",threadName="studio:studio0"} 22
nodejs_gc_duration_seconds_bucket{le="0.001",kind="incremental",threadName="studio:studio0"} 12
nodejs_gc_duration_seconds_bucket{le="0.01",kind="incremental",threadName="studio:studio0"} 12
nodejs_gc_duration_seconds_bucket{le="0.1",kind="incremental",threadName="studio:studio0"} 12
nodejs_gc_duration_seconds_bucket{le="1",kind="incremental",threadName="studio:studio0"} 12
nodejs_gc_duration_seconds_bucket{le="2",kind="incremental",threadName="studio:studio0"} 12
nodejs_gc_duration_seconds_bucket{le="5",kind="incremental",threadName="studio:studio0"} 12
nodejs_gc_duration_seconds_bucket{le="+Inf",kind="incremental",threadName="studio:studio0"} 12
nodejs_gc_duration_seconds_sum{kind="incremental",threadName="studio:studio0"} 0.0010721869999999998
nodejs_gc_duration_seconds_count{kind="incremental",threadName="studio:studio0"} 12
nodejs_gc_duration_seconds_bucket{le="0.001",kind="major",threadName="studio:studio0"} 0
nodejs_gc_duration_seconds_bucket{le="0.01",kind="major",threadName="studio:studio0"} 6
nodejs_gc_duration_seconds_bucket{le="0.1",kind="major",threadName="studio:studio0"} 6
nodejs_gc_duration_seconds_bucket{le="1",kind="major",threadName="studio:studio0"} 6
nodejs_gc_duration_seconds_bucket{le="2",kind="major",threadName="studio:studio0"} 6
nodejs_gc_duration_seconds_bucket{le="5",kind="major",threadName="studio:studio0"} 6
nodejs_gc_duration_seconds_bucket{le="+Inf",kind="major",threadName="studio:studio0"} 6
nodejs_gc_duration_seconds_sum{kind="major",threadName="studio:studio0"} 0.018469183
nodejs_gc_duration_seconds_count{kind="major",threadName="studio:studio0"} 6


# HELP process_cpu_user_seconds_total Total user CPU time spent in seconds.
# TYPE process_cpu_user_seconds_total counter
process_cpu_user_seconds_total{threadName="events:studio0"} 10.187850999999998

# HELP process_cpu_system_seconds_total Total system CPU time spent in seconds.
# TYPE process_cpu_system_seconds_total counter
process_cpu_system_seconds_total{threadName="events:studio0"} 0.744595

# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total{threadName="events:studio0"} 10.932446

# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds{threadName="events:studio0"} 1683298255

# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes{threadName="events:studio0"} 378994688

# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes{threadName="events:studio0"} 2368294912

# HELP process_heap_bytes Process heap size in bytes.
# TYPE process_heap_bytes gauge
process_heap_bytes{threadName="events:studio0"} 637808640

# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds{threadName="events:studio0"} 90

# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds{threadName="events:studio0"} 1048576

# HELP nodejs_eventloop_lag_seconds Lag of event loop in seconds.
# TYPE nodejs_eventloop_lag_seconds gauge
nodejs_eventloop_lag_seconds{threadName="events:studio0"} 0.001957657

# HELP nodejs_eventloop_lag_min_seconds The minimum recorded event loop delay.
# TYPE nodejs_eventloop_lag_min_seconds gauge
nodejs_eventloop_lag_min_seconds{threadName="events:studio0"} 0.00905216

# HELP nodejs_eventloop_lag_max_seconds The maximum recorded event loop delay.
# TYPE nodejs_eventloop_lag_max_seconds gauge
nodejs_eventloop_lag_max_seconds{threadName="events:studio0"} 0.010813439

# HELP nodejs_eventloop_lag_mean_seconds The mean of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_mean_seconds gauge
nodejs_eventloop_lag_mean_seconds{threadName="events:studio0"} 0.01006369660693507

# HELP nodejs_eventloop_lag_stddev_seconds The standard deviation of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_stddev_seconds gauge
nodejs_eventloop_lag_stddev_seconds{threadName="events:studio0"} 0.00008422692100433447

# HELP nodejs_eventloop_lag_p50_seconds The 50th percentile of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_p50_seconds gauge
nodejs_eventloop_lag_p50_seconds{threadName="events:studio0"} 0.010076159

# HELP nodejs_eventloop_lag_p90_seconds The 90th percentile of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_p90_seconds gauge
nodejs_eventloop_lag_p90_seconds{threadName="events:studio0"} 0.010076159

# HELP nodejs_eventloop_lag_p99_seconds The 99th percentile of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_p99_seconds gauge
nodejs_eventloop_lag_p99_seconds{threadName="events:studio0"} 0.010264575

# HELP nodejs_active_handles Number of active libuv handles grouped by handle type. Every handle type is C++ class name.
# TYPE nodejs_active_handles gauge
nodejs_active_handles{type="MessagePort",threadName="events:studio0"} 1
nodejs_active_handles{type="Socket",threadName="events:studio0"} 4

# HELP nodejs_active_handles_total Total number of active handles.
# TYPE nodejs_active_handles_total gauge
nodejs_active_handles_total{threadName="events:studio0"} 5

# HELP nodejs_active_requests Number of active libuv requests grouped by request type. Every request type is C++ class name.
# TYPE nodejs_active_requests gauge

# HELP nodejs_active_requests_total Total number of active requests.
# TYPE nodejs_active_requests_total gauge
nodejs_active_requests_total{threadName="events:studio0"} 0

# HELP nodejs_heap_size_total_bytes Process heap size from Node.js in bytes.
# TYPE nodejs_heap_size_total_bytes gauge
nodejs_heap_size_total_bytes{threadName="events:studio0"} 29962240

# HELP nodejs_heap_size_used_bytes Process heap size used from Node.js in bytes.
# TYPE nodejs_heap_size_used_bytes gauge
nodejs_heap_size_used_bytes{threadName="events:studio0"} 28809288

# HELP nodejs_external_memory_bytes Node.js external memory size in bytes.
# TYPE nodejs_external_memory_bytes gauge
nodejs_external_memory_bytes{threadName="events:studio0"} 20177068

# HELP nodejs_heap_space_size_total_bytes Process heap space size total from Node.js in bytes.
# TYPE nodejs_heap_space_size_total_bytes gauge
nodejs_heap_space_size_total_bytes{space="read_only",threadName="events:studio0"} 151552
nodejs_heap_space_size_total_bytes{space="new",threadName="events:studio0"} 1048576
nodejs_heap_space_size_total_bytes{space="old",threadName="events:studio0"} 18432000
nodejs_heap_space_size_total_bytes{space="code",threadName="events:studio0"} 622592
nodejs_heap_space_size_total_bytes{space="map",threadName="events:studio0"} 1576960
nodejs_heap_space_size_total_bytes{space="large_object",threadName="events:studio0"} 7794688
nodejs_heap_space_size_total_bytes{space="code_large_object",threadName="events:studio0"} 335872
nodejs_heap_space_size_total_bytes{space="new_large_object",threadName="events:studio0"} 0

# HELP nodejs_heap_space_size_used_bytes Process heap space size used from Node.js in bytes.
# TYPE nodejs_heap_space_size_used_bytes gauge
nodejs_heap_space_size_used_bytes{space="read_only",threadName="events:studio0"} 150392
nodejs_heap_space_size_used_bytes{space="new",threadName="events:studio0"} 1008688
nodejs_heap_space_size_used_bytes{space="old",threadName="events:studio0"} 17865792
nodejs_heap_space_size_used_bytes{space="code",threadName="events:studio0"} 539872
nodejs_heap_space_size_used_bytes{space="map",threadName="events:studio0"} 1227024
nodejs_heap_space_size_used_bytes{space="large_object",threadName="events:studio0"} 7747608
nodejs_heap_space_size_used_bytes{space="code_large_object",threadName="events:studio0"} 273920
nodejs_heap_space_size_used_bytes{space="new_large_object",threadName="events:studio0"} 0

# HELP nodejs_heap_space_size_available_bytes Process heap space size available from Node.js in bytes.
# TYPE nodejs_heap_space_size_available_bytes gauge
nodejs_heap_space_size_available_bytes{space="read_only",threadName="events:studio0"} 0
nodejs_heap_space_size_available_bytes{space="new",threadName="events:studio0"} 38736
nodejs_heap_space_size_available_bytes{space="old",threadName="events:studio0"} 370616
nodejs_heap_space_size_available_bytes{space="code",threadName="events:studio0"} 21184
nodejs_heap_space_size_available_bytes{space="map",threadName="events:studio0"} 347728
nodejs_heap_space_size_available_bytes{space="large_object",threadName="events:studio0"} 0
nodejs_heap_space_size_available_bytes{space="code_large_object",threadName="events:studio0"} 0
nodejs_heap_space_size_available_bytes{space="new_large_object",threadName="events:studio0"} 1047424

# HELP nodejs_version_info Node.js version info.
# TYPE nodejs_version_info gauge
nodejs_version_info{version="v14.19.3",major="14",minor="19",patch="3",threadName="events:studio0"} 1

# HELP nodejs_gc_duration_seconds Garbage collection duration by kind, one of major, minor, incremental or weakcb.
# TYPE nodejs_gc_duration_seconds histogram
nodejs_gc_duration_seconds_bucket{le="0.001",kind="minor",threadName="events:studio0"} 3
nodejs_gc_duration_seconds_bucket{le="0.01",kind="minor",threadName="events:studio0"} 7
nodejs_gc_duration_seconds_bucket{le="0.1",kind="minor",threadName="events:studio0"} 7
nodejs_gc_duration_seconds_bucket{le="1",kind="minor",threadName="events:studio0"} 7
nodejs_gc_duration_seconds_bucket{le="2",kind="minor",threadName="events:studio0"} 7
nodejs_gc_duration_seconds_bucket{le="5",kind="minor",threadName="events:studio0"} 7
nodejs_gc_duration_seconds_bucket{le="+Inf",kind="minor",threadName="events:studio0"} 7
nodejs_gc_duration_seconds_sum{kind="minor",threadName="events:studio0"} 0.017787684
nodejs_gc_duration_seconds_count{kind="minor",threadName="events:studio0"} 7
nodejs_gc_duration_seconds_bucket{le="0.001",kind="incremental",threadName="events:studio0"} 6
nodejs_gc_duration_seconds_bucket{le="0.01",kind="incremental",threadName="events:studio0"} 6
nodejs_gc_duration_seconds_bucket{le="0.1",kind="incremental",threadName="events:studio0"} 6
nodejs_gc_duration_seconds_bucket{le="1",kind="incremental",threadName="events:studio0"} 6
nodejs_gc_duration_seconds_bucket{le="2",kind="incremental",threadName="events:studio0"} 6
nodejs_gc_duration_seconds_bucket{le="5",kind="incremental",threadName="events:studio0"} 6
nodejs_gc_duration_seconds_bucket{le="+Inf",kind="incremental",threadName="events:studio0"} 6
nodejs_gc_duration_seconds_sum{kind="incremental",threadName="events:studio0"} 0.00047207000000000005
nodejs_gc_duration_seconds_count{kind="incremental",threadName="events:studio0"} 6
nodejs_gc_duration_seconds_bucket{le="0.001",kind="major",threadName="events:studio0"} 0
nodejs_gc_duration_seconds_bucket{le="0.01",kind="major",threadName="events:studio0"} 3
nodejs_gc_duration_seconds_bucket{le="0.1",kind="major",threadName="events:studio0"} 3
nodejs_gc_duration_seconds_bucket{le="1",kind="major",threadName="events:studio0"} 3
nodejs_gc_duration_seconds_bucket{le="2",kind="major",threadName="events:studio0"} 3
nodejs_gc_duration_seconds_bucket{le="5",kind="major",threadName="events:studio0"} 3
nodejs_gc_duration_seconds_bucket{le="+Inf",kind="major",threadName="events:studio0"} 3
nodejs_gc_duration_seconds_sum{kind="major",threadName="events:studio0"} 0.010296821000000001
nodejs_gc_duration_seconds_count{kind="major",threadName="events:studio0"} 3


# HELP process_cpu_user_seconds_total Total user CPU time spent in seconds.
# TYPE process_cpu_user_seconds_total counter
process_cpu_user_seconds_total{threadName="ingest:studio0"} 10.116068

# HELP process_cpu_system_seconds_total Total system CPU time spent in seconds.
# TYPE process_cpu_system_seconds_total counter
process_cpu_system_seconds_total{threadName="ingest:studio0"} 0.7429140000000001

# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total{threadName="ingest:studio0"} 10.858982000000001

# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds{threadName="ingest:studio0"} 1683298255

# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes{threadName="ingest:studio0"} 378994688

# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes{threadName="ingest:studio0"} 2368294912

# HELP process_heap_bytes Process heap size in bytes.
# TYPE process_heap_bytes gauge
process_heap_bytes{threadName="ingest:studio0"} 637808640

# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds{threadName="ingest:studio0"} 91

# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds{threadName="ingest:studio0"} 1048576

# HELP nodejs_eventloop_lag_seconds Lag of event loop in seconds.
# TYPE nodejs_eventloop_lag_seconds gauge
nodejs_eventloop_lag_seconds{threadName="ingest:studio0"} 0.00191663

# HELP nodejs_eventloop_lag_min_seconds The minimum recorded event loop delay.
# TYPE nodejs_eventloop_lag_min_seconds gauge
nodejs_eventloop_lag_min_seconds{threadName="ingest:studio0"} 0.009060352

# HELP nodejs_eventloop_lag_max_seconds The maximum recorded event loop delay.
# TYPE nodejs_eventloop_lag_max_seconds gauge
nodejs_eventloop_lag_max_seconds{threadName="ingest:studio0"} 0.010788863

# HELP nodejs_eventloop_lag_mean_seconds The mean of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_mean_seconds gauge
nodejs_eventloop_lag_mean_seconds{threadName="ingest:studio0"} 0.010066964975791433

# HELP nodejs_eventloop_lag_stddev_seconds The standard deviation of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_stddev_seconds gauge
nodejs_eventloop_lag_stddev_seconds{threadName="ingest:studio0"} 0.00004531590437084173

# HELP nodejs_eventloop_lag_p50_seconds The 50th percentile of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_p50_seconds gauge
nodejs_eventloop_lag_p50_seconds{threadName="ingest:studio0"} 0.010076159

# HELP nodejs_eventloop_lag_p90_seconds The 90th percentile of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_p90_seconds gauge
nodejs_eventloop_lag_p90_seconds{threadName="ingest:studio0"} 0.010076159

# HELP nodejs_eventloop_lag_p99_seconds The 99th percentile of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_p99_seconds gauge
nodejs_eventloop_lag_p99_seconds{threadName="ingest:studio0"} 0.010166271

# HELP nodejs_active_handles Number of active libuv handles grouped by handle type. Every handle type is C++ class name.
# TYPE nodejs_active_handles gauge
nodejs_active_handles{type="MessagePort",threadName="ingest:studio0"} 1
nodejs_active_handles{type="Socket",threadName="ingest:studio0"} 3

# HELP nodejs_active_handles_total Total number of active handles.
# TYPE nodejs_active_handles_total gauge
nodejs_active_handles_total{threadName="ingest:studio0"} 4

# HELP nodejs_active_requests Number of active libuv requests grouped by request type. Every request type is C++ class name.
# TYPE nodejs_active_requests gauge

# HELP nodejs_active_requests_total Total number of active requests.
# TYPE nodejs_active_requests_total gauge
nodejs_active_requests_total{threadName="ingest:studio0"} 0

# HELP nodejs_heap_size_total_bytes Process heap size from Node.js in bytes.
# TYPE nodejs_heap_size_total_bytes gauge
nodejs_heap_size_total_bytes{threadName="ingest:studio0"} 36831232

# HELP nodejs_heap_size_used_bytes Process heap size used from Node.js in bytes.
# TYPE nodejs_heap_size_used_bytes gauge
nodejs_heap_size_used_bytes{threadName="ingest:studio0"} 33182928

# HELP nodejs_external_memory_bytes Node.js external memory size in bytes.
# TYPE nodejs_external_memory_bytes gauge
nodejs_external_memory_bytes{threadName="ingest:studio0"} 21196433

# HELP nodejs_heap_space_size_total_bytes Process heap space size total from Node.js in bytes.
# TYPE nodejs_heap_space_size_total_bytes gauge
nodejs_heap_space_size_total_bytes{space="read_only",threadName="ingest:studio0"} 151552
nodejs_heap_space_size_total_bytes{space="new",threadName="ingest:studio0"} 1048576
nodejs_heap_space_size_total_bytes{space="old",threadName="ingest:studio0"} 26820608
nodejs_heap_space_size_total_bytes{space="code",threadName="ingest:studio0"} 622592
nodejs_heap_space_size_total_bytes{space="map",threadName="ingest:studio0"} 1314816
nodejs_heap_space_size_total_bytes{space="large_object",threadName="ingest:studio0"} 6537216
nodejs_heap_space_size_total_bytes{space="code_large_object",threadName="ingest:studio0"} 335872
nodejs_heap_space_size_total_bytes{space="new_large_object",threadName="ingest:studio0"} 0

# HELP nodejs_heap_space_size_used_bytes Process heap space size used from Node.js in bytes.
# TYPE nodejs_heap_space_size_used_bytes gauge
nodejs_heap_space_size_used_bytes{space="read_only",threadName="ingest:studio0"} 150392
nodejs_heap_space_size_used_bytes{space="new",threadName="ingest:studio0"} 958232
nodejs_heap_space_size_used_bytes{space="old",threadName="ingest:studio0"} 23819416
nodejs_heap_space_size_used_bytes{space="code",threadName="ingest:studio0"} 461920
nodejs_heap_space_size_used_bytes{space="map",threadName="ingest:studio0"} 1031112
nodejs_heap_space_size_used_bytes{space="large_object",threadName="ingest:studio0"} 6491944
nodejs_heap_space_size_used_bytes{space="code_large_object",threadName="ingest:studio0"} 273920
nodejs_heap_space_size_used_bytes{space="new_large_object",threadName="ingest:studio0"} 0

# HELP nodejs_heap_space_size_available_bytes Process heap space size available from Node.js in bytes.
# TYPE nodejs_heap_space_size_available_bytes gauge
nodejs_heap_space_size_available_bytes{space="read_only",threadName="ingest:studio0"} 0
nodejs_heap_space_size_available_bytes{space="new",threadName="ingest:studio0"} 89192
nodejs_heap_space_size_available_bytes{space="old",threadName="ingest:studio0"} 2779448
nodejs_heap_space_size_available_bytes{space="code",threadName="ingest:studio0"} 120000
nodejs_heap_space_size_available_bytes{space="map",threadName="ingest:studio0"} 280216
nodejs_heap_space_size_available_bytes{space="large_object",threadName="ingest:studio0"} 0
nodejs_heap_space_size_available_bytes{space="code_large_object",threadName="ingest:studio0"} 0
nodejs_heap_space_size_available_bytes{space="new_large_object",threadName="ingest:studio0"} 1047424

# HELP nodejs_version_info Node.js version info.
# TYPE nodejs_version_info gauge
nodejs_version_info{version="v14.19.3",major="14",minor="19",patch="3",threadName="ingest:studio0"} 1

# HELP nodejs_gc_duration_seconds Garbage collection duration by kind, one of major, minor, incremental or weakcb.
# TYPE nodejs_gc_duration_seconds histogram
nodejs_gc_duration_seconds_bucket{le="0.001",kind="minor",threadName="ingest:studio0"} 1
nodejs_gc_duration_seconds_bucket{le="0.01",kind="minor",threadName="ingest:studio0"} 3
nodejs_gc_duration_seconds_bucket{le="0.1",kind="minor",threadName="ingest:studio0"} 3
nodejs_gc_duration_seconds_bucket{le="1",kind="minor",threadName="ingest:studio0"} 3
nodejs_gc_duration_seconds_bucket{le="2",kind="minor",threadName="ingest:studio0"} 3
nodejs_gc_duration_seconds_bucket{le="5",kind="minor",threadName="ingest:studio0"} 3
nodejs_gc_duration_seconds_bucket{le="+Inf",kind="minor",threadName="ingest:studio0"} 3
nodejs_gc_duration_seconds_sum{kind="minor",threadName="ingest:studio0"} 0.009066459999999998
nodejs_gc_duration_seconds_count{kind="minor",threadName="ingest:studio0"} 3
nodejs_gc_duration_seconds_bucket{le="0.001",kind="incremental",threadName="ingest:studio0"} 6
nodejs_gc_duration_seconds_bucket{le="0.01",kind="incremental",threadName="ingest:studio0"} 6
nodejs_gc_duration_seconds_bucket{le="0.1",kind="incremental",threadName="ingest:studio0"} 6
nodejs_gc_duration_seconds_bucket{le="1",kind="incremental",threadName="ingest:studio0"} 6
nodejs_gc_duration_seconds_bucket{le="2",kind="incremental",threadName="ingest:studio0"} 6
nodejs_gc_duration_seconds_bucket{le="5",kind="incremental",threadName="ingest:studio0"} 6
nodejs_gc_duration_seconds_bucket{le="+Inf",kind="incremental",threadName="ingest:studio0"} 6
nodejs_gc_duration_seconds_sum{kind="incremental",threadName="ingest:studio0"} 0.00043511
nodejs_gc_duration_seconds_count{kind="incremental",threadName="ingest:studio0"} 6
nodejs_gc_duration_seconds_bucket{le="0.001",kind="major",threadName="ingest:studio0"} 0
nodejs_gc_duration_seconds_bucket{le="0.01",kind="major",threadName="ingest:studio0"} 3
nodejs_gc_duration_seconds_bucket{le="0.1",kind="major",threadName="ingest:studio0"} 3
nodejs_gc_duration_seconds_bucket{le="1",kind="major",threadName="ingest:studio0"} 3
nodejs_gc_duration_seconds_bucket{le="2",kind="major",threadName="ingest:studio0"} 3
nodejs_gc_duration_seconds_bucket{le="5",kind="major",threadName="ingest:studio0"} 3
nodejs_gc_duration_seconds_bucket{le="+Inf",kind="major",threadName="ingest:studio0"} 3
nodejs_gc_duration_seconds_sum{kind="major",threadName="ingest:studio0"} 0.004447775
nodejs_gc_duration_seconds_count{kind="major",threadName="ingest:studio0"} 3
```

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
