### PR TITLE
chore: add toString() to ProtectedString

### DIFF
--- a/meteor/server/publications/lib/ReactiveCacheCollection.ts
+++ b/meteor/server/publications/lib/ReactiveCacheCollection.ts
@@ -1,5 +1,5 @@
 import { omit } from '@sofie-automation/corelib/dist/lib'
-import { ProtectedString } from '@sofie-automation/corelib/dist/protectedString'
+import { ProtectedString, isProtectedString, unprotectString } from '@sofie-automation/corelib/dist/protectedString'
 import { Mongo } from 'meteor/mongo'
 import { ObserveCallbacks } from '../../../lib/collections/lib'
 
@@ -18,8 +18,11 @@ export class ReactiveCacheCollection<
 		return id
 	}
 
-	remove(selector: string | Mongo.ObjectID | Mongo.Selector<Document>, callback?: Function): number {
-		const num = super.remove(selector, callback)
+	remove(
+		selector: Document['_id'] | string | Mongo.ObjectID | Mongo.Selector<Document>,
+		callback?: Function
+	): number {
+		const num = super.remove(isProtectedString(selector) ? unprotectString(selector) : selector, callback)
 		if (num > 0) {
 			this.runReaction()
 		}
@@ -27,7 +30,7 @@ export class ReactiveCacheCollection<
 	}
 
 	update(
-		selector: string | Mongo.ObjectID | Mongo.Selector<Document>,
+		selector: Document['_id'] | string | Mongo.ObjectID | Mongo.Selector<Document>,
 		modifier: Mongo.Modifier<Document>,
 		options?: {
 			multi?: boolean | undefined
@@ -36,7 +39,12 @@ export class ReactiveCacheCollection<
 		},
 		callback?: Function
 	): number {
-		const num = super.update(selector, modifier, options, callback)
+		const num = super.update(
+			isProtectedString(selector) ? unprotectString(selector) : selector,
+			modifier,
+			options,
+			callback
+		)
 		if (num > 0) {
 			this.runReaction()
 		}
@@ -44,12 +52,17 @@ export class ReactiveCacheCollection<
 	}
 
 	upsert(
-		selector: string | Mongo.ObjectID | Mongo.Selector<Document>,
+		selector: Document['_id'] | string | Mongo.ObjectID | Mongo.Selector<Document>,
 		modifier: Mongo.Modifier<Document>,
 		options?: { multi?: boolean | undefined },
 		callback?: Function
 	): { numberAffected?: number | undefined; insertedId?: string | undefined } {
-		const res = super.upsert(selector, modifier, options, callback)
+		const res = super.upsert(
+			isProtectedString(selector) ? unprotectString(selector) : selector,
+			modifier,
+			options,
+			callback
+		)
 		if (res.numberAffected || res.insertedId) {
 			this.runReaction()
 		}
@@ -64,10 +77,13 @@ export class ReactiveCacheCollection<
 	}
 
 	async removeAsync(
-		selector: string | Mongo.ObjectID | Mongo.Selector<Document>,
+		selector: Document['_id'] | string | Mongo.ObjectID | Mongo.Selector<Document>,
 		callback?: Function
 	): Promise<number> {
-		const result = await super.removeAsync(selector, callback)
+		const result = await super.removeAsync(
+			isProtectedString(selector) ? unprotectString(selector) : selector,
+			callback
+		)
 		if (result > 0) {
 			this.runReaction()
 		}
@@ -75,7 +91,7 @@ export class ReactiveCacheCollection<
 	}
 
 	async updateAsync(
-		selector: string | Mongo.ObjectID | Mongo.Selector<Document>,
+		selector: Document['_id'] | string | Mongo.ObjectID | Mongo.Selector<Document>,
 		modifier: Mongo.Modifier<Document>,
 		options?: {
 			multi?: boolean | undefined
@@ -84,7 +100,12 @@ export class ReactiveCacheCollection<
 		},
 		callback?: Function
 	): Promise<number> {
-		const result = await super.updateAsync(selector, modifier, options, callback)
+		const result = await super.updateAsync(
+			isProtectedString(selector) ? unprotectString(selector) : selector,
+			modifier,
+			options,
+			callback
+		)
 		if (result > 0) {
 			this.runReaction()
 		}
@@ -92,12 +113,17 @@ export class ReactiveCacheCollection<
 	}
 
 	async upsertAsync(
-		selector: string | Mongo.ObjectID | Mongo.Selector<Document>,
+		selector: Document['_id'] | string | Mongo.ObjectID | Mongo.Selector<Document>,
 		modifier: Mongo.Modifier<Document>,
 		options?: { multi?: boolean | undefined },
 		callback?: Function
 	): Promise<{ numberAffected?: number | undefined; insertedId?: string | undefined }> {
-		const result = await super.upsertAsync(selector, modifier, options, callback)
+		const result = await super.upsertAsync(
+			isProtectedString(selector) ? unprotectString(selector) : selector,
+			modifier,
+			options,
+			callback
+		)
 		if (result.numberAffected || result.insertedId) {
 			this.runReaction()
 		}

--- a/packages/shared-lib/src/lib/__tests__/protectedString.spec.ts
+++ b/packages/shared-lib/src/lib/__tests__/protectedString.spec.ts
@@ -1,0 +1,75 @@
+import {
+	ProtectedString,
+	protectString,
+	protectStringArray,
+	unprotectObject,
+	unprotectString,
+	unprotectStringArray,
+} from '../protectedString'
+
+describe('ProtectedString', () => {
+	test('stringifies properly', async () => {
+		const id = protectString('abc')
+
+		expect(id).toEqual('abc')
+		expect(`hello ${id}`).toEqual('hello abc')
+
+		expect(unprotectString(id)).toEqual('abc')
+	})
+	test('protectStringObject', async () => {
+		const protectedObj = {
+			str: 'abc',
+			protectedStr: protectString('def'),
+			obj: {
+				str: 'abc',
+				protectedStr: protectString('def'),
+			},
+		}
+
+		assertString(protectedObj.str)
+		assertProtectedString(protectedObj.protectedStr)
+		assertString(protectedObj.obj.str)
+		assertProtectedString(protectedObj.obj.protectedStr)
+		expect(protectedObj).toEqual({
+			str: 'abc',
+			protectedStr: 'def',
+			obj: {
+				str: 'abc',
+				protectedStr: 'def',
+			},
+		})
+
+		const stringObj = unprotectObject(protectedObj)
+
+		assertString(stringObj.str)
+		assertString(stringObj.protectedStr)
+		assertString(stringObj.obj.str)
+		assertString(stringObj.obj.protectedStr)
+		expect(stringObj).toEqual({
+			str: 'abc',
+			protectedStr: 'def',
+			obj: {
+				str: 'abc',
+				protectedStr: 'def',
+			},
+		})
+	})
+	test('protectStringArray', async () => {
+		const protectedArray = protectStringArray(['abc', 'def'])
+		assertProtectedString(protectedArray[0])
+		assertProtectedString(protectedArray[1])
+		expect(protectedArray).toEqual(['abc', 'def'])
+
+		const stringArray = unprotectStringArray(protectedArray)
+
+		assertString(stringArray[0])
+		assertString(stringArray[1])
+		expect(stringArray).toEqual(['abc', 'def'])
+	})
+})
+function assertProtectedString(_value: ProtectedString<any>): void {
+	// nothing, is a type guard
+}
+function assertString(_value: string): void {
+	// nothing, is a type guard
+}

--- a/packages/shared-lib/src/lib/protectedString.ts
+++ b/packages/shared-lib/src/lib/protectedString.ts
@@ -7,7 +7,12 @@ import { PartialDeep, ReadonlyDeep } from 'type-fest'
  * in order to provide stringer typings.
  */
 export interface ProtectedString<T> {
+	/**
+	 * @deprecated This property doesn't actually exist, don't try to use it.
+	 */
 	_protectedType: T
+	// Note: the toString method exists to make linters happy that ProtectedString can be used as a string
+	toString(): string
 }
 export type ProtectedStringProperties<T, K extends keyof T> = {
 	[P in keyof T]: P extends K ? ProtectedString<any> : T[P]


### PR DESCRIPTION
Adds toString() to ProtectedString

This is to make linters like SonarLint happy, so that they don't think that stringifying a ProtectedString results in an "[object: object]"
