### PR TITLE
fix: small parts after #903

### DIFF
--- a/meteor/client/lib/rundownTiming.ts
+++ b/meteor/client/lib/rundownTiming.ts
@@ -334,8 +334,11 @@ export class RundownTimingCalculator {
 						0,
 						(partInstance.timings?.duration && partInstance.timings?.duration + playOffset) ||
 							displayDurationFromGroup ||
-							calculatePartInstanceExpectedDurationWithPreroll(partInstance, piecesForPart) ||
-							defaultDuration
+							ensureMinimumDefaultDurationIfNotAuto(
+								partInstance,
+								calculatePartInstanceExpectedDurationWithPreroll(partInstance, piecesForPart),
+								defaultDuration
+							)
 					)
 					partDisplayDuration = partDisplayDurationNoPlayback
 					this.partPlayed[unprotectString(partInstance.part._id)] =
@@ -809,4 +812,16 @@ export function getPlaylistTimingDiff(
 	}
 
 	return diff
+}
+
+function ensureMinimumDefaultDurationIfNotAuto(
+	partInstance: PartInstance,
+	incomingDuration: number | undefined,
+	defaultDuration: number
+): number {
+	if (incomingDuration === undefined || !Number.isFinite(incomingDuration)) return defaultDuration
+
+	if (partInstance.part.autoNext) return incomingDuration
+
+	return Math.max(incomingDuration, defaultDuration)
 }

--- a/meteor/client/lib/ui/pieceUiClassNames.ts
+++ b/meteor/client/lib/ui/pieceUiClassNames.ts
@@ -11,7 +11,6 @@ export function pieceUiClassNames(
 	layerType?: SourceLayerType,
 	partId?: PartId,
 	highlight?: boolean,
-	relative?: boolean,
 	elementWidth?: number,
 	uiState?: {
 		leftAnchoredWidth: number
@@ -24,12 +23,10 @@ export function pieceUiClassNames(
 
 	return classNames(baseClassName, typeClass, {
 		'with-in-transition':
-			!relative &&
 			innerPiece.transitions &&
 			innerPiece.transitions.inTransition &&
 			(innerPiece.transitions.inTransition.duration || 0) > 0,
 		'with-out-transition':
-			!relative &&
 			innerPiece.transitions &&
 			innerPiece.transitions.outTransition &&
 			(innerPiece.transitions.outTransition.duration || 0) > 0,

--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -2721,12 +2721,12 @@ svg.icon {
 
 	&.segment-timeline__mini-inspector--small-parts {
 		top: 0;
-		z-index: 1001;
+		bottom: 0;
 		width: 350px;
 		max-width: 30vw;
 		transform: translate(0, 0);
 		border-radius: 0;
-		margin-left: 0;
+		margin-left: -1px;
 		box-shadow: 1px -1.5px 30px 15px rgba(0, 0, 0, 0.9);
 		animation: 0.2s inspector-wipeRight;
 		animation-timing-function: ease-out;

--- a/meteor/client/ui/SegmentContainer/PieceElement.tsx
+++ b/meteor/client/ui/SegmentContainer/PieceElement.tsx
@@ -38,7 +38,7 @@ export const PieceElement = React.forwardRef<HTMLDivElement, React.PropsWithChil
 ) {
 	return (
 		<div
-			className={pieceUiClassNames(piece, className, layer?.type, partId, highlight, true, undefined, undefined)}
+			className={pieceUiClassNames(piece, className, layer?.type, partId, highlight, undefined, undefined)}
 			data-obj-id={piece.instance._id}
 			onPointerEnter={onPointerEnter}
 			onPointerLeave={onPointerLeave}

--- a/meteor/client/ui/SegmentTimeline/Parts/FlattenedSourceLayers.tsx
+++ b/meteor/client/ui/SegmentTimeline/Parts/FlattenedSourceLayers.tsx
@@ -78,7 +78,6 @@ export function FlattenedSourceLayers(props: IFlattenedSourceLayerProps): JSX.El
 									partDuration={props.duration}
 									partExpectedDuration={props.expectedDuration}
 									timeScale={props.timeScale}
-									relative={props.relative}
 									autoNextPart={props.autoNextPart}
 									liveLinePadding={props.liveLinePadding}
 									scrollLeft={props.scrollLeft}

--- a/meteor/client/ui/SegmentTimeline/Parts/OutputGroup.tsx
+++ b/meteor/client/ui/SegmentTimeline/Parts/OutputGroup.tsx
@@ -41,7 +41,6 @@ interface IOutputGroupProps {
 	scrollWidth: number
 	liveLinePadding: number
 	autoNextPart: boolean
-	relative: boolean
 	onContextMenu?: (contextMenuContext: IContextMenuContext) => void
 	indexOffset: number
 	isPreview: boolean
@@ -87,7 +86,6 @@ export function OutputGroup(props: IOutputGroupProps): JSX.Element {
 							isTooSmallForText={props.isTooSmallForText}
 							liveLineHistorySize={props.liveLineHistorySize}
 							livePosition={props.livePosition}
-							relative={props.relative}
 							scrollLeft={props.scrollLeft}
 							scrollWidth={props.scrollWidth}
 							onContextMenu={props.onContextMenu}
@@ -125,7 +123,6 @@ export function OutputGroup(props: IOutputGroupProps): JSX.Element {
 						isTooSmallForText={props.isTooSmallForText}
 						liveLineHistorySize={props.liveLineHistorySize}
 						livePosition={props.livePosition}
-						relative={props.relative}
 						scrollLeft={props.scrollLeft}
 						scrollWidth={props.scrollWidth}
 						onContextMenu={props.onContextMenu}

--- a/meteor/client/ui/SegmentTimeline/Parts/SourceLayer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Parts/SourceLayer.tsx
@@ -32,7 +32,6 @@ export interface ISourceLayerPropsBase {
 	onFollowLiveLine?: (state: boolean, event: any) => void
 	onPieceClick?: (piece: PieceUi, e: React.MouseEvent<HTMLDivElement>) => void
 	onPieceDoubleClick?: (item: PieceUi, e: React.MouseEvent<HTMLDivElement>) => void
-	relative: boolean
 	followLiveLine: boolean
 	liveLineHistorySize: number
 	livePosition: number | null
@@ -127,7 +126,6 @@ export function SourceLayer(props: ISourceLayerProps): JSX.Element {
 									partDuration={props.duration}
 									partExpectedDuration={props.expectedDuration}
 									timeScale={props.timeScale}
-									relative={props.relative}
 									autoNextPart={props.autoNextPart}
 									liveLinePadding={props.liveLinePadding}
 									scrollLeft={props.scrollLeft}

--- a/meteor/client/ui/SegmentTimeline/SegmentTimeline.scss
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimeline.scss
@@ -60,12 +60,7 @@ $timeline-layer-height: 1em;
 		right: 0;
 		bottom: 0;
 
-		display: flex;
 		width: 100%;
-		flex-flow: row nowrap;
-		align-items: flex-start;
-		align-content: flex-start;
-		justify-content: flex-start;
 
 		contain: layout style;
 	}
@@ -92,9 +87,12 @@ $timeline-layer-height: 1em;
 	}
 }
 .segment-timeline__small-parts-flag-hoist {
-	position: relative;
+	position: absolute;
 	flex: 0 0;
 	max-width: 0;
+	z-index: 1001;
+	top: var(--segment-timeline-padding-top);
+	bottom: 0;
 }
 .segment-timeline__small-parts-flag {
 	position: absolute;

--- a/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
@@ -688,7 +688,6 @@ export class SegmentTimelineClass extends React.Component<Translated<WithTiming<
 
 	private renderTimeline() {
 		const { smallParts } = this.state
-		const { t } = this.props
 		let livePart: PartExtended | null = null
 		let anyPriorPartWasLive = false
 		let partIsLive = false
@@ -727,10 +726,10 @@ export class SegmentTimelineClass extends React.Component<Translated<WithTiming<
 				<React.Fragment key={unprotectString(part.instance._id)}>
 					{emitSmallPartsInFlag && !emitSmallPartsInFlagAtEnd && (
 						<SegmentTimelineSmallPartFlag
-							t={t}
 							parts={emitSmallPartsInFlag}
 							pieces={this.props.pieces}
 							followingPart={part}
+							firstPartInSegmentId={firstPartInSegment.partId}
 							sourceLayers={this.props.segment.sourceLayers}
 							timeScale={this.props.timeScale}
 							autoNextPart={this.props.autoNextPart}
@@ -785,10 +784,10 @@ export class SegmentTimelineClass extends React.Component<Translated<WithTiming<
 					/>
 					{emitSmallPartsInFlag && emitSmallPartsInFlagAtEnd && (
 						<SegmentTimelineSmallPartFlag
-							t={t}
 							parts={emitSmallPartsInFlag}
 							pieces={this.props.pieces}
 							followingPart={undefined}
+							firstPartInSegmentId={firstPartInSegment.partId}
 							sourceLayers={this.props.segment.sourceLayers}
 							timeScale={this.props.timeScale}
 							autoNextPart={this.props.autoNextPart}

--- a/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
@@ -734,9 +734,10 @@ export class SegmentTimelineClass extends React.Component<Translated<WithTiming<
 							parts={emitSmallPartsInFlag}
 							pieces={this.props.pieces}
 							followingPart={part}
+							livePosition={this.props.livePosition}
 							firstPartInSegmentId={firstPartInSegment.partId}
 							sourceLayers={this.props.segment.sourceLayers}
-							timeScale={this.props.timeScale}
+							timeToPixelRatio={this.props.timeScale}
 							autoNextPart={this.props.autoNextPart}
 							collapsedOutputs={this.props.collapsedOutputs}
 							playlist={this.props.playlist}
@@ -747,6 +748,10 @@ export class SegmentTimelineClass extends React.Component<Translated<WithTiming<
 							isLastInSegment={false}
 							timelineWidth={this.state.timelineWidth}
 							showDurationSourceLayers={this.props.showDurationSourceLayers}
+							isLiveSegment={this.props.isLiveSegment}
+							anyPriorPartWasLive={anyPriorPartWasLive}
+							livePartStartsAt={livePartStartsAt}
+							livePartDisplayDuration={livePartDisplayDuration}
 						/>
 					)}
 					<SegmentTimelinePart
@@ -791,9 +796,10 @@ export class SegmentTimelineClass extends React.Component<Translated<WithTiming<
 							parts={emitSmallPartsInFlag}
 							pieces={this.props.pieces}
 							followingPart={undefined}
+							livePosition={this.props.livePosition}
 							firstPartInSegmentId={firstPartInSegment.partId}
 							sourceLayers={this.props.segment.sourceLayers}
-							timeScale={this.props.timeScale}
+							timeToPixelRatio={this.props.timeScale}
 							autoNextPart={this.props.autoNextPart}
 							collapsedOutputs={this.props.collapsedOutputs}
 							playlist={this.props.playlist}
@@ -804,6 +810,10 @@ export class SegmentTimelineClass extends React.Component<Translated<WithTiming<
 							isLastInSegment={true}
 							timelineWidth={this.state.timelineWidth}
 							showDurationSourceLayers={this.props.showDurationSourceLayers}
+							isLiveSegment={this.props.isLiveSegment}
+							anyPriorPartWasLive={anyPriorPartWasLive}
+							livePartStartsAt={livePartStartsAt}
+							livePartDisplayDuration={livePartDisplayDuration}
 						/>
 					)}
 				</React.Fragment>

--- a/meteor/client/ui/SegmentTimeline/SmallParts/SegmentTimelinePartHoverPreview.tsx
+++ b/meteor/client/ui/SegmentTimeline/SmallParts/SegmentTimelinePartHoverPreview.tsx
@@ -1,5 +1,5 @@
 import React, { useLayoutEffect, useState } from 'react'
-import { TFunction } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 import { RundownPlaylist } from '../../../../lib/collections/RundownPlaylists'
 import { unprotectString } from '../../../../lib/lib'
 import { RundownUtils } from '../../../lib/rundown'
@@ -11,7 +11,6 @@ import { PartId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { CalculateTimingsPiece } from '@sofie-automation/corelib/dist/playout/timings'
 
 export const SegmentTimelinePartHoverPreview = ({
-	t,
 	showMiniInspector,
 	parts,
 	pieces,
@@ -28,7 +27,6 @@ export const SegmentTimelinePartHoverPreview = ({
 	parentTimeScale,
 	showDurationSourceLayers,
 }: {
-	t: TFunction
 	showMiniInspector: boolean
 	parts: PartUi[]
 	pieces: Map<PartId, CalculateTimingsPiece[]>
@@ -48,6 +46,7 @@ export const SegmentTimelinePartHoverPreview = ({
 	parentTimeScale: number
 	showDurationSourceLayers?: Set<ISourceLayer['_id']>
 }): JSX.Element | null => {
+	const { t } = useTranslation()
 	const [miniInspectorEl, setMiniInnspectorEl] = useState<HTMLDivElement | null>(null)
 	const [containOffset, setContainOffset] = useState(0)
 	const followingPartPreviewDuration = 0.15 * totalSegmentDuration

--- a/meteor/client/ui/SegmentTimeline/SmallParts/SegmentTimelinePartHoverPreview.tsx
+++ b/meteor/client/ui/SegmentTimeline/SmallParts/SegmentTimelinePartHoverPreview.tsx
@@ -60,8 +60,6 @@ export const SegmentTimelinePartHoverPreview = ({
 
 		const { width } = inspectorRef.getBoundingClientRect()
 
-		console.log(previewWindowDuration, width)
-
 		setTimeToPixelRatio(width / previewWindowDuration)
 	}, [inspectorRef, previewWindowDuration])
 

--- a/meteor/client/ui/SegmentTimeline/SmallParts/SegmentTimelineSmallPartFlag.tsx
+++ b/meteor/client/ui/SegmentTimeline/SmallParts/SegmentTimelineSmallPartFlag.tsx
@@ -14,7 +14,7 @@ import { TimingDataResolution, TimingTickResolution, withTiming } from '../../Ru
 
 export const SegmentTimelineSmallPartFlag = withTiming<
 	{
-		parts: [PartUi, number][]
+		parts: [PartUi, number, number][]
 		pieces: Map<PartId, CalculateTimingsPiece[]>
 		followingPart: PartUi | undefined
 		firstPartInSegmentId: PartId
@@ -101,9 +101,11 @@ export const SegmentTimelineSmallPartFlag = withTiming<
 			[pixelOffsetPosition]
 		)
 
-		let partDurations = 0
-		const partFlags = parts.map(([part, duration]) => {
-			partDurations += duration
+		let partDisplayDurations = 0
+		let partActualDurations = 0
+		const partFlags = parts.map(([part, displayDuration, actualDuration]) => {
+			partDisplayDurations += displayDuration
+			partActualDurations += actualDuration
 			return (
 				<SegmentTimelineSmallPartFlagIcon
 					key={unprotectString(part.instance._id)}
@@ -130,7 +132,7 @@ export const SegmentTimelineSmallPartFlag = withTiming<
 					onMouseEnter={onMouseEnter}
 					onMouseLeave={onMouseLeave}
 					style={{
-						transform: `translateX(${(partDurations * timeScale) / 2}px)`,
+						transform: `translateX(${(partDisplayDurations * timeScale) / 2}px)`,
 					}}
 				>
 					<SmallPartFlag className="segment-timeline__small-parts-flag-pointer" />
@@ -149,7 +151,8 @@ export const SegmentTimelineSmallPartFlag = withTiming<
 					liveLineHistorySize={liveLineHistorySize}
 					isLastSegment={isLastSegment}
 					isLastInSegment={isLastInSegment}
-					totalSegmentDuration={partDurations}
+					totalSegmentDisplayDuration={partDisplayDurations}
+					actualPartsDuration={partActualDurations}
 					parentTimeScale={timeScale}
 					showDurationSourceLayers={showDurationSourceLayers}
 				/>

--- a/meteor/client/ui/SegmentTimeline/SmallParts/SegmentTimelineSmallPartFlag.tsx
+++ b/meteor/client/ui/SegmentTimeline/SmallParts/SegmentTimelineSmallPartFlag.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react'
+import React, { CSSProperties, useMemo, useRef, useState } from 'react'
 import { SmallPartFlag } from '../../../lib/ui/icons/segment'
 import { ISourceLayer } from '@sofie-automation/blueprints-integration'
 import { SegmentTimelineSmallPartFlagIcon } from './SegmentTimelineSmallPartFlagIcon'
@@ -6,123 +6,154 @@ import { protectString, unprotectString } from '../../../../lib/lib'
 import { PartUi, SegmentUi } from '../SegmentTimelineContainer'
 import { RundownPlaylist } from '../../../../lib/collections/RundownPlaylists'
 import { SegmentTimelinePartHoverPreview } from './SegmentTimelinePartHoverPreview'
-import { TFunction } from 'i18next'
 import RundownViewEventBus, { RundownViewEvents } from '../../../../lib/api/triggers/RundownViewEventBus'
 import { UIStudio } from '../../../../lib/api/studios'
 import { CalculateTimingsPiece } from '@sofie-automation/corelib/dist/playout/timings'
 import { PartId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { TimingDataResolution, TimingTickResolution, withTiming } from '../../RundownView/RundownTiming/withTiming'
 
-export const SegmentTimelineSmallPartFlag = ({
-	t,
-	parts,
-	pieces,
-	followingPart,
-	sourceLayers,
-	timeScale,
-
-	segment,
-	playlist,
-	studio,
-	collapsedOutputs,
-	autoNextPart,
-	liveLineHistorySize,
-	isLastSegment,
-	isLastInSegment,
-	showDurationSourceLayers,
-}: {
-	t: TFunction
-	parts: [PartUi, number][]
-	pieces: Map<PartId, CalculateTimingsPiece[]>
-	followingPart: PartUi | undefined
-	sourceLayers: {
-		[key: string]: ISourceLayer
-	}
-	timeScale: number
-
-	segment: SegmentUi
-	playlist: RundownPlaylist
-	studio: UIStudio
-	collapsedOutputs: {
-		[key: string]: boolean
-	}
-	autoNextPart: boolean
-	liveLineHistorySize: number
-	isLastSegment: boolean
-	isLastInSegment: boolean
-	timelineWidth: number
-	showDurationSourceLayers?: Set<ISourceLayer['_id']>
-}): JSX.Element => {
-	const flagRef = useRef<HTMLDivElement>(null)
-
-	const [isHover, setHover] = useState(false)
-	const onMouseEnter = () => {
-		setHover(true)
-	}
-	const onMouseLeave = () => {
-		setHover(false)
-	}
-
-	const onClickFlagIcon = (e: React.MouseEvent<HTMLDivElement>) => {
-		const partInstanceId = e.currentTarget.dataset['partInstanceId'] // note this needs to match the contents of the data prop in SegmentTimelineSmallPartFlagIcon
-		if (partInstanceId) {
-			RundownViewEventBus.emit(RundownViewEvents.GO_TO_PART_INSTANCE, {
-				segmentId: segment._id,
-				partInstanceId: protectString(partInstanceId),
-				zoomInToFit: true,
-				context: e,
-			})
+export const SegmentTimelineSmallPartFlag = withTiming<
+	{
+		parts: [PartUi, number][]
+		pieces: Map<PartId, CalculateTimingsPiece[]>
+		followingPart: PartUi | undefined
+		firstPartInSegmentId: PartId
+		sourceLayers: {
+			[key: string]: ISourceLayer
 		}
-	}
+		timeScale: number
 
-	let partDurations = 0
-	const partFlags = parts.map(([part, duration]) => {
-		partDurations += duration
-		return (
-			<SegmentTimelineSmallPartFlagIcon
-				key={unprotectString(part.instance._id)}
-				partInstance={part}
-				sourceLayers={sourceLayers}
-				isNext={playlist.nextPartInfo?.partInstanceId === part.instance._id}
-				isLive={playlist.currentPartInfo?.partInstanceId === part.instance._id}
-				onClick={onClickFlagIcon}
-				data={{
-					'data-part-instance-id': unprotectString(part.instance._id), // this needs to match with onFlagClick handler
-				}}
-			/>
+		segment: SegmentUi
+		playlist: RundownPlaylist
+		studio: UIStudio
+		collapsedOutputs: {
+			[key: string]: boolean
+		}
+		autoNextPart: boolean
+		liveLineHistorySize: number
+		isLastSegment: boolean
+		isLastInSegment: boolean
+		timelineWidth: number
+		showDurationSourceLayers?: Set<ISourceLayer['_id']>
+	},
+	{}
+>((props) => ({
+	dataResolution: TimingDataResolution.High,
+	tickResolution: TimingTickResolution.High,
+	filter: (timings) => [
+		timings?.partDisplayStartsAt?.[unprotectString(props.firstPartInSegmentId)],
+		timings?.partDisplayStartsAt?.[unprotectString(props.parts[0][0].partId)],
+	],
+}))(
+	({
+		parts,
+		pieces,
+		followingPart,
+		sourceLayers,
+		timeScale,
+		firstPartInSegmentId,
+
+		segment,
+		playlist,
+		studio,
+		collapsedOutputs,
+		autoNextPart,
+		liveLineHistorySize,
+		isLastSegment,
+		isLastInSegment,
+		showDurationSourceLayers,
+
+		timingDurations,
+	}): JSX.Element => {
+		const flagRef = useRef<HTMLDivElement>(null)
+
+		const firstPartDisplayStartsAt =
+			(timingDurations.partDisplayStartsAt?.[unprotectString(parts[0][0].partId)] ?? 0) -
+			(timingDurations.partDisplayStartsAt?.[unprotectString(firstPartInSegmentId)] ?? 0)
+
+		const pixelOffsetPosition = firstPartDisplayStartsAt * timeScale
+
+		const [isHover, setHover] = useState(false)
+		const onMouseEnter = () => {
+			setHover(true)
+		}
+		const onMouseLeave = () => {
+			setHover(false)
+		}
+
+		const onClickFlagIcon = (e: React.MouseEvent<HTMLDivElement>) => {
+			const partInstanceId = e.currentTarget.dataset['partInstanceId'] // note this needs to match the contents of the data prop in SegmentTimelineSmallPartFlagIcon
+			if (partInstanceId) {
+				RundownViewEventBus.emit(RundownViewEvents.GO_TO_PART_INSTANCE, {
+					segmentId: segment._id,
+					partInstanceId: protectString(partInstanceId),
+					zoomInToFit: true,
+					context: e,
+				})
+			}
+		}
+
+		const flagHoistStyle = useMemo<CSSProperties>(
+			() => ({
+				transform: `translateX(${pixelOffsetPosition}px)`,
+				willChange: 'transform',
+			}),
+			[pixelOffsetPosition]
 		)
-	})
-	return (
-		<div className="segment-timeline__small-parts-flag-hoist">
+
+		let partDurations = 0
+		const partFlags = parts.map(([part, duration]) => {
+			partDurations += duration
+			return (
+				<SegmentTimelineSmallPartFlagIcon
+					key={unprotectString(part.instance._id)}
+					partInstance={part}
+					sourceLayers={sourceLayers}
+					isNext={playlist.nextPartInfo?.partInstanceId === part.instance._id}
+					isLive={playlist.currentPartInfo?.partInstanceId === part.instance._id}
+					onClick={onClickFlagIcon}
+					data={{
+						'data-part-instance-id': unprotectString(part.instance._id), // this needs to match with onFlagClick handler
+					}}
+				/>
+			)
+		})
+		return (
 			<div
-				className="segment-timeline__small-parts-flag"
-				ref={flagRef}
-				onMouseEnter={onMouseEnter}
-				onMouseLeave={onMouseLeave}
-				style={{
-					transform: `translateX(${(partDurations * timeScale) / -2}px)`,
-				}}
+				className="segment-timeline__small-parts-flag-hoist"
+				style={flagHoistStyle}
+				data-test={`translateX(${pixelOffsetPosition})`}
 			>
-				<SmallPartFlag className="segment-timeline__small-parts-flag-pointer" />
-				{partFlags}
+				<div
+					className="segment-timeline__small-parts-flag"
+					ref={flagRef}
+					onMouseEnter={onMouseEnter}
+					onMouseLeave={onMouseLeave}
+					style={{
+						transform: `translateX(${(partDurations * timeScale) / 2}px)`,
+					}}
+				>
+					<SmallPartFlag className="segment-timeline__small-parts-flag-pointer" />
+					{partFlags}
+				</div>
+				<SegmentTimelinePartHoverPreview
+					autoNextPart={autoNextPart}
+					collapsedOutputs={collapsedOutputs}
+					studio={studio}
+					showMiniInspector={isHover}
+					followingPart={followingPart}
+					parts={parts.map(([part]) => part)}
+					pieces={pieces}
+					segment={segment}
+					playlist={playlist}
+					liveLineHistorySize={liveLineHistorySize}
+					isLastSegment={isLastSegment}
+					isLastInSegment={isLastInSegment}
+					totalSegmentDuration={partDurations}
+					parentTimeScale={timeScale}
+					showDurationSourceLayers={showDurationSourceLayers}
+				/>
 			</div>
-			<SegmentTimelinePartHoverPreview
-				t={t}
-				autoNextPart={autoNextPart}
-				collapsedOutputs={collapsedOutputs}
-				studio={studio}
-				showMiniInspector={isHover}
-				followingPart={followingPart}
-				parts={parts.map(([part]) => part)}
-				pieces={pieces}
-				segment={segment}
-				playlist={playlist}
-				liveLineHistorySize={liveLineHistorySize}
-				isLastSegment={isLastSegment}
-				isLastInSegment={isLastInSegment}
-				totalSegmentDuration={partDurations}
-				parentTimeScale={timeScale}
-				showDurationSourceLayers={showDurationSourceLayers}
-			/>
-		</div>
-	)
-}
+		)
+	}
+)

--- a/meteor/client/ui/SegmentTimeline/SourceLayerItem.tsx
+++ b/meteor/client/ui/SegmentTimeline/SourceLayerItem.tsx
@@ -198,6 +198,7 @@ export const SourceLayerItem = withTranslation()(
 								liveLineHistoryWithMargin.toString() +
 								'px, 0) ' +
 								'translate(-100%, 0)',
+							willChange: 'transform',
 						}
 					} else if (
 						this.state.rightAnchoredWidth < elementWidth &&
@@ -227,6 +228,7 @@ export const SourceLayerItem = withTranslation()(
 								liveLineHistoryWithMargin.toString() +
 								'px, 0) ' +
 								'translate3d(-100%, 0)',
+							willChange: 'transform',
 						}
 					} else {
 						return {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

There are some problems with rendering Small Parts in the Timeline view after #903 was merged.

Before:

![What the bug looks like](https://github.com/nrkno/sofie-core/assets/3635991/8eb6b549-7afa-496f-b59c-7f7f1b84040e)

As it's visible, the Small Parts overlay is not correctly aligned (it's not in the correct position of the timeline), the flags are incorrectly placed, etc. Also, the "Parts duration" counter incorrectly shows the "display duration" instead of the actual "expected duration" sum of the Parts.

* **What is the new behavior (if this is a feature change)?**

There should be no problems with Small Parts. Also, the "relative" rendering mode for Parts was removed, because the only place that used it was the Small Parts component, it just made all the rendering more complicated, and the Small Parts could be implemented differently anyway.

After:

![What it's supposed to look like](https://github.com/nrkno/sofie-core/assets/3635991/07bfc56a-25cc-4244-8233-f6a23bdb9a42)


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
