### PR TITLE
fix: on some terminals, hasColors is undefined

### DIFF
--- a/scripts/install-and-build.mjs
+++ b/scripts/install-and-build.mjs
@@ -4,7 +4,7 @@ import { EXTRA_PACKAGES, config } from "./lib.js";
 
 function hr() {
 	// write regular dashes if this is a "simple" output stream ()
-	if (!process.stdout.hasColors())
+	if (!process.stdout.hasColors || !process.stdout.hasColors())
 		return '-'.repeat(process.stdout.columns ?? 40)
 	return '─'.repeat(process.stdout.columns ?? 40)
 }

--- a/scripts/run.mjs
+++ b/scripts/run.mjs
@@ -49,8 +49,8 @@ function watchMeteor() {
 
 function hr() {
 	// write regular dashes if this is a "simple" output stream ()
-	if (!process.stdout.hasColors())
-		return '-'.repeat(process.stdout.columns ?? 40)
+	if (!process.stdout.hasColors || !process.stdout.hasColors())
+		return "-".repeat(process.stdout.columns ?? 40);
 	return '─'.repeat(process.stdout.columns ?? 40)
 }
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Sofie fails to start on certain environments, such as within the [`pm2`](https://pm2.keymetrics.io/) process manager.

* **What is the new behavior (if this is a feature change)?**

Sofie starts in these environments.

* **Other information**:

I'm surprised that this isn't better documented or that it isn't in the types, but the entire `hasColors` function can be _missing_ under certain execution conditions. This PR checks for it before attempting to use it.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
