### PR TITLE
feat: allow nested config tables

### DIFF
--- a/meteor/client/lib/forms/SchemaFormTable/ArrayTable.tsx
+++ b/meteor/client/lib/forms/SchemaFormTable/ArrayTable.tsx
@@ -109,9 +109,9 @@ export const SchemaFormArrayTable = ({
 	const title = schema[SchemaFormUIField.Title]
 
 	return (
-		<>
+		<div className="settings-config-table">
 			{title && <h2 className="mhn">{translateStringIfHasNamespaces(title, translationNamespaces)}</h2>}
-			<table className={'expando setings-config-table table'}>
+			<table className={'expando table'}>
 				<thead>
 					<tr className="hl">
 						{summaryFields.map((col) => {
@@ -156,6 +156,6 @@ export const SchemaFormArrayTable = ({
 					</button>
 				)}
 			</div>
-		</>
+		</div>
 	)
 }

--- a/meteor/client/lib/forms/SchemaFormTable/ObjectTable.scss
+++ b/meteor/client/lib/forms/SchemaFormTable/ObjectTable.scss
@@ -9,7 +9,7 @@
 .settings-config-table .settings-config-table,
 .settings-config-table .settings-config-table td,
 .settings-config-table .settings-config-table th {
-	background-color: #ebebeb !important;
+	background-color: #f0f0f0 !important;
 }
 
 .settings-config-table .settings-config-table .settings-config-table,
@@ -21,7 +21,7 @@
 .settings-config-table .settings-config-table .settings-config-table .settings-config-table,
 .settings-config-table .settings-config-table .settings-config-table .settings-config-table td,
 .settings-config-table .settings-config-table .settings-config-table .settings-config-table tr {
-	background-color: #ebebeb !important;
+	background-color: #f0f0f0 !important;
 
 	input: {
 		background-color: white;

--- a/meteor/client/lib/forms/SchemaFormTable/ObjectTable.scss
+++ b/meteor/client/lib/forms/SchemaFormTable/ObjectTable.scss
@@ -1,0 +1,29 @@
+.settings-config-table input {
+	background-color: white;
+}
+
+.settings-config-table .settings-config-table {
+	margin-left: 10px;
+}
+
+.settings-config-table .settings-config-table,
+.settings-config-table .settings-config-table td,
+.settings-config-table .settings-config-table th {
+	background-color: #ebebeb !important;
+}
+
+.settings-config-table .settings-config-table .settings-config-table,
+.settings-config-table .settings-config-table .settings-config-table td,
+.settings-config-table .settings-config-table .settings-config-table tr {
+	background-color: white !important;
+}
+
+.settings-config-table .settings-config-table .settings-config-table .settings-config-table,
+.settings-config-table .settings-config-table .settings-config-table .settings-config-table td,
+.settings-config-table .settings-config-table .settings-config-table .settings-config-table tr {
+	background-color: #ebebeb !important;
+
+	input: {
+		background-color: white;
+	}
+}

--- a/meteor/client/lib/forms/SchemaFormTable/ObjectTable.tsx
+++ b/meteor/client/lib/forms/SchemaFormTable/ObjectTable.tsx
@@ -150,9 +150,9 @@ export const SchemaFormObjectTable = ({
 		)
 	} else {
 		return (
-			<>
+			<div className="settings-config-table">
 				{titleElement}
-				<table className={'expando setings-config-table table'}>
+				<table className={'expando table'}>
 					<thead>
 						<tr className="hl">
 							{summaryFields.map((col) => {
@@ -204,7 +204,7 @@ export const SchemaFormObjectTable = ({
 						<FontAwesomeIcon icon={faPlus} />
 					</button>
 				</div>
-			</>
+			</div>
 		)
 	}
 }

--- a/meteor/client/lib/forms/SchemaFormTable/TableEditRow.tsx
+++ b/meteor/client/lib/forms/SchemaFormTable/TableEditRow.tsx
@@ -43,7 +43,7 @@ export function SchemaFormTableEditRow({
 								attr={id}
 								overrideHelper={overrideHelper}
 								translationNamespaces={translationNamespaces}
-								allowTables={false}
+								allowTables
 							/>
 						) : (
 							''


### PR DESCRIPTION
This PR is being opened on behalf of TV 2 Norge.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

Nested config tables are not allowed.

* **What is the new behavior (if this is a feature change)?**

Nested config tables are allowed.

* **Other information**:

Nested tables have alternating white and light gray background colors, as well as cumulative 10px left indents per each level. Only tables up to 4 levels deep will be styled. If someone actually needs more than that, we can amend the CSS.

![image](https://github.com/nrkno/sofie-core/assets/873012/a0fb0ec7-f472-4ede-a945-d720b1482caf)

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
