### PR TITLE
feat: single-use tokens for heavy/dangerous operations

### DIFF
--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -879,7 +879,20 @@ const RundownHeader = withTranslation()(
 					t,
 					e,
 					UserAction.CREATE_SNAPSHOT_FOR_DEBUG,
-					(e, ts) => MeteorCall.userAction.storeRundownSnapshot(e, ts, this.props.playlist._id, 'Taken by user', false),
+					(e, ts) =>
+						MeteorCall.userAction.generateSingleUseToken(e, ts).then((tokenResponse) => {
+							if (ClientAPI.isClientResponseError(tokenResponse) || !tokenResponse.result) {
+								throw tokenResponse
+							}
+							return MeteorCall.userAction.storeRundownSnapshot(
+								e,
+								ts,
+								tokenResponse.result,
+								this.props.playlist._id,
+								'Taken by user',
+								false
+							)
+						}),
 					() => {
 						NotificationCenter.push(
 							new Notification(
@@ -2715,13 +2728,19 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 				e,
 				UserAction.CREATE_SNAPSHOT_FOR_DEBUG,
 				(e, ts) =>
-					MeteorCall.userAction.storeRundownSnapshot(
-						e,
-						ts,
-						playlistId,
-						'User requested log at' + getCurrentTime(),
-						false
-					),
+					MeteorCall.userAction.generateSingleUseToken(e, ts).then((tokenResponse) => {
+						if (ClientAPI.isClientResponseError(tokenResponse) || !tokenResponse.result) {
+							throw tokenResponse
+						}
+						return MeteorCall.userAction.storeRundownSnapshot(
+							e,
+							ts,
+							tokenResponse.result,
+							playlistId,
+							'User requested log at' + getCurrentTime(),
+							false
+						)
+					}),
 				() => {
 					NotificationCenter.push(
 						new Notification(

--- a/meteor/client/ui/Settings/SnapshotsView.tsx
+++ b/meteor/client/ui/Settings/SnapshotsView.tsx
@@ -17,6 +17,7 @@ import { PubSub } from '../../../lib/api/pubsub'
 import { MeteorCall } from '../../../lib/api/methods'
 import { SnapshotId, StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { Snapshots, Studios } from '../../collections'
+import { ClientAPI } from '../../../lib/api/client'
 
 interface IProps {
 	match: {
@@ -161,30 +162,46 @@ export default translateWithTracker<IProps, IState, ITrackedProps>(() => {
 			}
 		}
 		takeSystemSnapshot = (studioId: StudioId | null) => {
-			MeteorCall.snapshot.storeSystemSnapshot(studioId, `Requested by user`).catch((err) => {
-				logger.error(err)
-				doModalDialog({
-					title: 'Restore Snapshot',
-					message: `Error: ${err.toString()}`,
-					acceptOnly: true,
-					onAccept: () => {
-						// nothing
-					},
+			MeteorCall.userAction
+				.generateSingleUseToken('takeSystemSnapshot', getCurrentTime())
+				.then((tokenResponse) => {
+					if (ClientAPI.isClientResponseError(tokenResponse) || !tokenResponse.result) {
+						throw tokenResponse
+					}
+					return MeteorCall.snapshot.storeSystemSnapshot(tokenResponse.result, studioId, `Requested by user`)
 				})
-			})
+				.catch((err) => {
+					logger.error(err)
+					doModalDialog({
+						title: 'Restore Snapshot',
+						message: `Error: ${err.toString()}`,
+						acceptOnly: true,
+						onAccept: () => {
+							// nothing
+						},
+					})
+				})
 		}
 		takeDebugSnapshot = (studioId: StudioId) => {
-			MeteorCall.snapshot.storeDebugSnapshot(studioId, `Requested by user`).catch((err) => {
-				logger.error(err)
-				doModalDialog({
-					title: 'Restore Snapshot',
-					message: `Error: ${err.toString()}`,
-					acceptOnly: true,
-					onAccept: () => {
-						// nothing
-					},
+			MeteorCall.userAction
+				.generateSingleUseToken('takeSystemSnapshot', getCurrentTime())
+				.then((tokenResponse) => {
+					if (ClientAPI.isClientResponseError(tokenResponse) || !tokenResponse.result) {
+						throw tokenResponse
+					}
+					return MeteorCall.snapshot.storeDebugSnapshot(tokenResponse.result, studioId, `Requested by user`)
 				})
-			})
+				.catch((err) => {
+					logger.error(err)
+					doModalDialog({
+						title: 'Restore Snapshot',
+						message: `Error: ${err.toString()}`,
+						acceptOnly: true,
+						onAccept: () => {
+							// nothing
+						},
+					})
+				})
 		}
 		editSnapshot = (snapshotId) => {
 			if (this.state.editSnapshotId === snapshotId) {

--- a/meteor/client/ui/Status/SystemStatus.tsx
+++ b/meteor/client/ui/Status/SystemStatus.tsx
@@ -26,7 +26,7 @@ import { ICoreSystem } from '../../../lib/collections/CoreSystem'
 import { StatusResponse } from '../../../lib/api/systemStatus'
 import { doUserAction, UserAction } from '../../../lib/clientUserAction'
 import { MeteorCall } from '../../../lib/api/methods'
-import { RESTART_SALT } from '../../../lib/api/userActions'
+import { SINGLE_USE_TOKEN_SALT } from '../../../lib/api/userActions'
 import { DEFAULT_TSR_ACTION_TIMEOUT_TIME } from '@sofie-automation/shared-lib/dist/core/constants'
 import { SubdeviceAction } from '@sofie-automation/shared-lib/dist/core/deviceConfigManifest'
 import { StatusCodePill } from './StatusCodePill'
@@ -436,7 +436,7 @@ export const CoreItem = reacti18next.withTranslation()(
 													t,
 													e,
 													UserAction.GENERATE_RESTART_TOKEN,
-													(e, ts) => MeteorCall.userAction.generateRestartToken(e, ts),
+													(e, ts) => MeteorCall.userAction.generateSingleUseToken(e, ts),
 													(err, token) => {
 														if (err || !token) {
 															NotificationCenter.push(
@@ -449,7 +449,7 @@ export const CoreItem = reacti18next.withTranslation()(
 															)
 															return
 														}
-														const restartToken = getHash(RESTART_SALT + token)
+														const restartToken = getHash(SINGLE_USE_TOKEN_SALT + token)
 														doUserAction(
 															t,
 															{},

--- a/meteor/lib/api/shapshot.ts
+++ b/meteor/lib/api/shapshot.ts
@@ -1,9 +1,14 @@
 import { RundownPlaylistId, SnapshotId, StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 
 export interface NewSnapshotAPI {
-	storeSystemSnapshot(studioId: StudioId | null, reason: string): Promise<SnapshotId>
-	storeRundownPlaylist(playlistId: RundownPlaylistId, reason: string, full?: boolean): Promise<SnapshotId>
-	storeDebugSnapshot(studioId: StudioId, reason: string): Promise<SnapshotId>
+	storeSystemSnapshot(hashedToken: string, studioId: StudioId | null, reason: string): Promise<SnapshotId>
+	storeRundownPlaylist(
+		hashedToken: string,
+		playlistId: RundownPlaylistId,
+		reason: string,
+		full?: boolean
+	): Promise<SnapshotId>
+	storeDebugSnapshot(hashedToken: string, studioId: StudioId, reason: string): Promise<SnapshotId>
 	restoreSnapshot(snapshotId: SnapshotId): Promise<void>
 	removeSnapshot(snapshotId: SnapshotId): Promise<void>
 }

--- a/meteor/lib/api/userActions.ts
+++ b/meteor/lib/api/userActions.ts
@@ -175,6 +175,7 @@ export interface NewUserActionAPI extends MethodContext {
 	storeRundownSnapshot(
 		userEvent: string,
 		eventTime: Time,
+		token: string,
 		playlistId: RundownPlaylistId,
 		reason: string,
 		full: boolean
@@ -246,7 +247,7 @@ export interface NewUserActionAPI extends MethodContext {
 		eventTime: Time,
 		playlistId: RundownPlaylistId
 	): Promise<ClientAPI.ClientResponse<void>>
-	generateRestartToken(userEvent: string, eventTime: Time): Promise<ClientAPI.ClientResponse<string>>
+	generateSingleUseToken(userEvent: string, eventTime: Time): Promise<ClientAPI.ClientResponse<string>>
 	restartCore(userEvent: string, eventTime: Time, token: string): Promise<ClientAPI.ClientResponse<string>>
 	guiFocused(userEvent: string, eventTime: Time, viewInfo?: any[]): Promise<ClientAPI.ClientResponse<void>>
 	guiBlurred(userEvent: string, eventTime: Time, viewInfo?: any[]): Promise<ClientAPI.ClientResponse<void>>
@@ -385,7 +386,7 @@ export enum UserActionAPIMethods {
 
 	'regenerateRundownPlaylist' = 'userAction.ingest.regenerateRundownPlaylist',
 
-	'generateRestartToken' = 'userAction.system.generateRestartToken',
+	'generateSingleUseToken' = 'userAction.system.generateSingleUseToken',
 	'restartCore' = 'userAction.system.restartCore',
 
 	'guiFocused' = 'userAction.focused',
@@ -412,4 +413,4 @@ export enum TriggerReloadDataResponse {
 	MISSING = 'missing',
 }
 
-export const RESTART_SALT = 'clientRestart_'
+export const SINGLE_USE_TOKEN_SALT = 'token_'

--- a/meteor/server/api/__tests__/userActions/general.test.ts
+++ b/meteor/server/api/__tests__/userActions/general.test.ts
@@ -1,7 +1,7 @@
 import '../../../../__mocks__/_extendJest'
 import { testInFiber } from '../../../../__mocks__/helpers/jest'
 import { setupDefaultStudioEnvironment } from '../../../../__mocks__/helpers/database'
-import { RESTART_SALT } from '../../../../lib/api/userActions'
+import { SINGLE_USE_TOKEN_SALT } from '../../../../lib/api/userActions'
 import { getCurrentTime, getHash } from '../../../../lib/lib'
 import { MeteorCall } from '../../../../lib/api/methods'
 import { ClientAPI } from '../../../../lib/api/client'
@@ -19,7 +19,7 @@ describe('User Actions - General', () => {
 		jest.useFakeTimers()
 
 		// Generate restart token
-		const res = (await MeteorCall.userAction.generateRestartToken(
+		const res = (await MeteorCall.userAction.generateSingleUseToken(
 			'e',
 			getCurrentTime()
 		)) as ClientAPI.ClientResponseSuccess<string>
@@ -34,7 +34,7 @@ describe('User Actions - General', () => {
 		).resolves.toMatchUserRawError(/Restart token is invalid/)
 
 		await expect(
-			MeteorCall.userAction.restartCore('e', getCurrentTime(), getHash(RESTART_SALT + res.result))
+			MeteorCall.userAction.restartCore('e', getCurrentTime(), getHash(SINGLE_USE_TOKEN_SALT + res.result))
 		).resolves.toMatchObject({
 			success: 200,
 		})

--- a/meteor/server/api/singleUseTokens.ts
+++ b/meteor/server/api/singleUseTokens.ts
@@ -1,0 +1,89 @@
+import { createHmac, randomBytes } from 'crypto'
+import { Time } from '@sofie-automation/blueprints-integration'
+import { getCurrentTime, getHash } from '../../lib/lib'
+import { SINGLE_USE_TOKEN_SALT } from '../../lib/api/userActions'
+
+// The following code is taken from an NPM pacakage called "@sunknudsen/totp", but copied here, instead
+// of used as a dependency so that it's not vulnerable to a supply chain attack
+
+const VALIDITY_PERIOD = 30 // seconds
+
+export function generateToken(secret: string = TOKEN_SECRET, timestamp = getCurrentTime()): string {
+	const message = Buffer.from(
+		`0000000000000000${Math.floor(Math.round(timestamp / 1000) / VALIDITY_PERIOD).toString(16)}`.slice(-16),
+		'hex'
+	)
+	const key = Buffer.from(base32ToHex(secret.toUpperCase()), 'hex')
+	const hmac = createHmac('sha1', key)
+	hmac.setEncoding('hex')
+	hmac.update(message)
+	hmac.end()
+	const data = hmac.read()
+	return (parseInt(data.substr(parseInt(data.slice(-1), 16) * 2, 8), 16) & 2147483647).toString().slice(-6)
+}
+
+export function verifyHashedToken(token: string, secret: string = TOKEN_SECRET, timestamp = getCurrentTime()): boolean {
+	// the token has already been used
+	if (usedTokensShortTermMemory.has(token)) {
+		return false
+	}
+
+	if (token === getHash(SINGLE_USE_TOKEN_SALT + generateToken(secret, timestamp))) {
+		usedTokensShortTermMemory.set(token, timestamp)
+		// we can forget that the token has been used after the validity window has passed, because it will be invalid anyway
+		setTimeout(() => {
+			usedTokensShortTermMemory.delete(token)
+		}, 3 * VALIDITY_PERIOD)
+		return true
+	}
+	return false
+}
+
+const usedTokensShortTermMemory = new Map<string, Time>()
+
+/**
+ * An automatically generated secret, regenerated on every restart, so that tokens can't be re-used between restarts
+ */
+const TOKEN_SECRET = randomBytes(length)
+	.map((value) => CHARSET.charCodeAt(Math.floor((value * CHARSET.length) / 256)))
+	.toString()
+
+const CHARSET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'
+
+function base32ToHex(base32: string): string {
+	let bits = ''
+	let hex = ''
+	for (let index = 0; index < base32.length; index++) {
+		const value = CHARSET.indexOf(base32.charAt(index))
+		bits += `00000${value.toString(2)}`.slice(-5)
+	}
+	for (let index = 0; index < bits.length - 3; index += 4) {
+		const chunk = bits.substring(index, index + 4)
+		hex = hex + parseInt(chunk, 2).toString(16)
+	}
+	return hex
+}
+
+/**
+MIT License
+
+Copyright (c) 2022 - present Sun Knudsen and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/

--- a/meteor/server/api/snapshot.ts
+++ b/meteor/server/api/snapshot.ts
@@ -94,6 +94,7 @@ import {
 } from '../collections'
 import { getCoreSystemAsync } from '../coreSystem/collection'
 import { executePeripheralDeviceFunction } from './peripheralDevice/executeFunction'
+import { verifyHashedToken } from './singleUseTokens'
 
 interface RundownPlaylistSnapshot extends CoreRundownPlaylistSnapshot {
 	versionExtended: string | undefined
@@ -612,10 +613,16 @@ async function restoreFromSystemSnapshot(snapshot: SystemSnapshot): Promise<void
 /** Take and store a system snapshot */
 export async function storeSystemSnapshot(
 	context: MethodContext,
+	hashedToken: string,
 	studioId: StudioId | null,
 	reason: string
 ): Promise<SnapshotId> {
+	check(hashedToken, String)
 	if (!_.isNull(studioId)) check(studioId, String)
+	if (verifyHashedToken(hashedToken)) {
+		throw new Meteor.Error(401, `Restart token is invalid or has expired`)
+	}
+
 	const { organizationId, cred } = await OrganizationContentWriteAccess.snapshot(context)
 	if (Settings.enableUserAccounts && isResolvedCredentials(cred)) {
 		if (cred.user && !cred.user.superAdmin) throw new Meteor.Error(401, 'Only Super Admins can store Snapshots')
@@ -635,9 +642,15 @@ export async function internalStoreSystemSnapshot(
 }
 export async function storeRundownPlaylistSnapshot(
 	access: VerifiedRundownPlaylistContentAccess,
+	hashedToken: string,
 	reason: string,
 	full?: boolean
 ): Promise<SnapshotId> {
+	check(hashedToken, String)
+	if (verifyHashedToken(hashedToken)) {
+		throw new Meteor.Error(401, `Restart token is invalid or has expired`)
+	}
+
 	const s = await createRundownPlaylistSnapshot(access.playlist, full)
 	return storeSnaphot(s, access.organizationId, reason)
 }
@@ -651,10 +664,16 @@ export async function internalStoreRundownPlaylistSnapshot(
 }
 export async function storeDebugSnapshot(
 	context: MethodContext,
+	hashedToken: string,
 	studioId: StudioId,
 	reason: string
 ): Promise<SnapshotId> {
 	check(studioId, String)
+	check(hashedToken, String)
+	if (verifyHashedToken(hashedToken)) {
+		throw new Meteor.Error(401, `Restart token is invalid or has expired`)
+	}
+
 	const { organizationId, cred } = await OrganizationContentWriteAccess.snapshot(context)
 	if (Settings.enableUserAccounts && isResolvedCredentials(cred)) {
 		if (cred.user && !cred.user.superAdmin) throw new Meteor.Error(401, 'Only Super Admins can store Snapshots')
@@ -799,16 +818,16 @@ PickerGET.route(
 )
 
 class ServerSnapshotAPI extends MethodContextAPI implements NewSnapshotAPI {
-	async storeSystemSnapshot(studioId: StudioId | null, reason: string) {
-		return storeSystemSnapshot(this, studioId, reason)
+	async storeSystemSnapshot(hashedToken: string, studioId: StudioId | null, reason: string) {
+		return storeSystemSnapshot(this, hashedToken, studioId, reason)
 	}
-	async storeRundownPlaylist(playlistId: RundownPlaylistId, reason: string) {
+	async storeRundownPlaylist(hashedToken: string, playlistId: RundownPlaylistId, reason: string) {
 		check(playlistId, String)
 		const access = await checkAccessToPlaylist(this, playlistId)
-		return storeRundownPlaylistSnapshot(access, reason)
+		return storeRundownPlaylistSnapshot(access, hashedToken, reason)
 	}
-	async storeDebugSnapshot(studioId: StudioId, reason: string) {
-		return storeDebugSnapshot(this, studioId, reason)
+	async storeDebugSnapshot(hashedToken: string, studioId: StudioId, reason: string) {
+		return storeDebugSnapshot(this, hashedToken, studioId, reason)
 	}
 	async restoreSnapshot(snapshotId: SnapshotId) {
 		return restoreSnapshot(this, snapshotId)

--- a/meteor/server/api/userActions.ts
+++ b/meteor/server/api/userActions.ts
@@ -1,9 +1,9 @@
 import { check, Match } from '../../lib/check'
 import { Meteor } from 'meteor/meteor'
 import { ClientAPI } from '../../lib/api/client'
-import { getCurrentTime, getHash, Time } from '../../lib/lib'
+import { getCurrentTime, Time } from '../../lib/lib'
 import { ServerPlayoutAPI } from './playout/playout'
-import { NewUserActionAPI, RESTART_SALT, UserActionAPIMethods } from '../../lib/api/userActions'
+import { NewUserActionAPI, UserActionAPIMethods } from '../../lib/api/userActions'
 import { EvaluationBase } from '../../lib/collections/Evaluations'
 import { IngestPart, IngestAdlib, ActionUserData } from '@sofie-automation/blueprints-integration'
 import { storeRundownPlaylistSnapshot } from './snapshot'
@@ -47,6 +47,7 @@ import {
 } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { IngestDataCache, Parts, Pieces, Rundowns } from '../collections'
 import { IngestCacheType } from '@sofie-automation/corelib/dist/dataModel/IngestDataCache'
+import { generateToken, verifyHashedToken } from './singleUseTokens'
 
 async function pieceSetInOutPoints(
 	access: VerifiedRundownPlaylistContentAccess,
@@ -84,7 +85,7 @@ async function pieceSetInOutPoints(
 	) // MOS data is in seconds
 }
 
-let restartToken: string | undefined = undefined
+let lastTokenTimestamp: Time | undefined = undefined
 
 class ServerUserActionAPI
 	extends MethodContextAPI
@@ -604,6 +605,7 @@ class ServerUserActionAPI
 	async storeRundownSnapshot(
 		userEvent: string,
 		eventTime: Time,
+		hashedToken: string,
 		playlistId: RundownPlaylistId,
 		reason: string,
 		full: boolean
@@ -620,7 +622,7 @@ class ServerUserActionAPI
 			'storeRundownSnapshot',
 			[playlistId, reason, full],
 			async (access) => {
-				return storeRundownPlaylistSnapshot(access, reason, full)
+				return storeRundownPlaylistSnapshot(access, hashedToken, reason, full)
 			}
 		)
 	}
@@ -885,28 +887,40 @@ class ServerUserActionAPI
 			}
 		)
 	}
-	async generateRestartToken(userEvent: string, eventTime: Time) {
-		return ServerClientAPI.runUserActionInLog(this, userEvent, eventTime, 'generateRestartToken', [], async () => {
-			await SystemWriteAccess.systemActions(this)
+	async generateSingleUseToken(userEvent: string, eventTime: Time) {
+		return ServerClientAPI.runUserActionInLog(
+			this,
+			userEvent,
+			eventTime,
+			'generateSingleUseToken',
+			[],
+			async () => {
+				await SystemWriteAccess.systemActions(this)
 
-			restartToken = getHash('restart_' + getCurrentTime())
-			return restartToken
-		})
+				if (lastTokenTimestamp !== undefined && eventTime <= lastTokenTimestamp) {
+					throw new Meteor.Error(503, `Event times for single-use tokens need to be monotonic`)
+				}
+
+				lastTokenTimestamp = getCurrentTime()
+				const newToken = generateToken()
+				return newToken
+			}
+		)
 	}
-	async restartCore(userEvent: string, eventTime: Time, hashedRestartToken: string) {
+	async restartCore(userEvent: string, eventTime: Time, hashedToken: string) {
 		return ServerClientAPI.runUserActionInLog(
 			this,
 			userEvent,
 			eventTime,
 			'restartCore',
-			[hashedRestartToken],
+			[hashedToken],
 			async () => {
-				check(hashedRestartToken, String)
+				check(hashedToken, String)
 
 				await SystemWriteAccess.systemActions(this)
 
-				if (hashedRestartToken !== getHash(RESTART_SALT + restartToken)) {
-					throw new Meteor.Error(401, `Restart token is invalid`)
+				if (verifyHashedToken(hashedToken)) {
+					throw new Meteor.Error(401, `Restart token is invalid or has expired`)
 				}
 
 				setTimeout(() => {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

Only the restart method is protected against intentional or accidental abuse

* **What is the new behavior (if this is a feature change)?**

A concept of a single-use token (essentially a TOTP) is introduced. Heavy user-initiated operations (like Core restart, or snapshots) now require a single-use token. The single use-token has a limited viability window (30s) and can only be used once. This ensures that these API methods are idempotent and will just throw an error on subsequent calls using the same arguments.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
