### PR TITLE
fix: don't error when flattening timeline group children

### DIFF
--- a/packages/job-worker/src/playout/timeline/generate.ts
+++ b/packages/job-worker/src/playout/timeline/generate.ts
@@ -458,7 +458,7 @@ function flattenAndProcessTimelineObjects(context: JobContext, timelineObjs: Arr
 
 				fixObjectChildren(childFixed)
 			}
-			delete o.children
+			o.children = []
 		}
 	}
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Adding children to a timeline object group causes an error saying there are no children in the timeline object group.

* **What is the new behavior (if this is a feature change)?**

Instead of deleting the `children` array after flattening its children out, this instead replaces it with an empty one, to make `superfly-timeline` happy and prevent it from throwing in `validateTimeline`.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
