### PR TITLE
fix: Allow JSON objects in config presets

### DIFF
--- a/packages/blueprints-integration/src/common.ts
+++ b/packages/blueprints-integration/src/common.ts
@@ -10,4 +10,4 @@ export type TableConfigItemValue = {
 	_id: string
 	[key: string]: BasicConfigItemValue
 }[]
-export type BasicConfigItemValue = string | number | boolean | string[]
+export type BasicConfigItemValue = string | number | boolean | string[] | object


### PR DESCRIPTION
This PR has been opened by SuperFly.tv on behalf of EVS Broadcast Equipment.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

**What is the current behavior?** (You can also link to an open issue here)
JSON config values are stored in the database as JSON objects, but the config presets can't provide objects as defaults in all cases (notably within tables).

**What is the new behavior (if this is a feature change)?**
Presets can provide an arbitrary object as a config value for use with JSON config types.

**Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
