### PR TITLE
fix: Expose OAuth credentials to peripheral device

### DIFF
--- a/meteor/server/publications/peripheralDeviceForDevice.ts
+++ b/meteor/server/publications/peripheralDeviceForDevice.ts
@@ -30,12 +30,13 @@ const studioFieldsSpecifier = literal<IncludeAllMongoFieldSpecifier<StudioFields
 	peripheralDeviceSettings: 1,
 })
 
-type PeripheralDeviceFields = '_id' | 'category' | 'studioId' | 'settings'
+type PeripheralDeviceFields = '_id' | 'category' | 'studioId' | 'settings' | 'secretSettings'
 const peripheralDeviceFieldsSpecifier = literal<IncludeAllMongoFieldSpecifier<PeripheralDeviceFields>>({
 	_id: 1,
 	category: 1,
 	studioId: 1,
 	settings: 1,
+	secretSettings: 1,
 })
 
 export function convertPeripheralDeviceForGateway(
@@ -97,6 +98,7 @@ export function convertPeripheralDeviceForGateway(
 		studioId: peripheralDevice.studioId,
 
 		deviceSettings: peripheralDevice.settings,
+		secretSettings: peripheralDevice.secretSettings,
 
 		playoutDevices,
 		ingestDevices,

--- a/packages/shared-lib/src/core/model/peripheralDevice.ts
+++ b/packages/shared-lib/src/core/model/peripheralDevice.ts
@@ -45,6 +45,11 @@ export interface PeripheralDeviceForDevice {
 	deviceSettings: unknown
 
 	/**
+	 * Contains, for example, OAuth access tokens.
+	 */
+	secretSettings?: IngestDeviceSecretSettings | { [key: string]: any }
+
+	/**
 	 * Settings for any playout subdevices
 	 */
 	playoutDevices: Record<string, TSR.DeviceOptionsAny>


### PR DESCRIPTION
This PR has been opened by SuperFly.tv on behalf of EVS Broadcast Equipment.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug/regression fix.


**What is the current behavior?** (You can also link to an open issue here)
Previously, gateways such as the Spreadsheet Gateway would be able to retrieve OAuth settings from Core, but this data is currently unavailable.


**What is the new behavior (if this is a feature change)?**
The missing OAuth information has been added to the `PeripheralDeviceForDevice` custom publication.


**Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
