### PR TITLE
fix: seek time for hoverscrub while playing

### DIFF
--- a/meteor/client/ui/SegmentTimeline/SourceLayerItem.tsx
+++ b/meteor/client/ui/SegmentTimeline/SourceLayerItem.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import * as _ from 'underscore'
 import { ISourceLayerUi, IOutputLayerUi, PartUi, PieceUi } from './SegmentTimelineContainer'
 import { SourceLayerType, PieceLifespan, IBlueprintPieceType } from '@sofie-automation/blueprints-integration'
 import { RundownUtils } from '../../lib/rundown'
@@ -104,6 +103,8 @@ interface ISourceLayerItemState {
 }
 export const SourceLayerItem = withTranslation()(
 	class SourceLayerItem extends React.Component<ISourceLayerItemProps & WithTranslation, ISourceLayerItemState> {
+		animFrameHandle: number
+
 		constructor(props) {
 			super(props)
 			this.state = {
@@ -486,40 +487,40 @@ export const SourceLayerItem = withTranslation()(
 		toggleMiniInspector = (e: MouseEvent | any, v: boolean) => {
 			this.setState({
 				showMiniInspector: v,
-			})
-			const elementPos = getElementDocumentOffset(this.state.itemElement) || {
-				top: 0,
-				left: 0,
-			}
-
-			const cursorPosition = {
-				left: e.clientX - elementPos.left,
-				top: e.clientY - elementPos.top,
-			}
-
-			const cursorTimePosition = Math.max(cursorPosition.left, 0) / this.props.timeScale
-
-			this.setState({
-				elementPosition: elementPos,
-				cursorPosition,
-				cursorTimePosition,
 				cursorRawPosition: {
 					clientX: e.clientX,
 					clientY: e.clientY,
 				},
 			})
+
+			if (v) {
+				const updatePos = () => {
+					const elementPos = getElementDocumentOffset(this.state.itemElement) || {
+						top: 0,
+						left: 0,
+					}
+					const cursorPosition = {
+						left: this.state.cursorRawPosition.clientX - elementPos.left,
+						top: this.state.cursorRawPosition.clientY - elementPos.top,
+					}
+
+					const cursorTimePosition = Math.max(cursorPosition.left, 0) / this.props.timeScale
+
+					this.setState({
+						elementPosition: elementPos,
+						cursorPosition,
+						cursorTimePosition,
+					})
+					this.animFrameHandle = requestAnimationFrame(updatePos)
+				}
+				this.animFrameHandle = requestAnimationFrame(updatePos)
+			} else {
+				cancelAnimationFrame(this.animFrameHandle)
+			}
 		}
 
 		moveMiniInspector = (e: MouseEvent | any) => {
-			const cursorPosition = {
-				left: e.clientX - this.state.elementPosition.left,
-				top: e.clientY - this.state.elementPosition.top,
-			}
-			const cursorTimePosition = Math.max(cursorPosition.left, 0) / this.props.timeScale
-
 			this.setState({
-				cursorPosition: _.extend(this.state.cursorPosition, cursorPosition),
-				cursorTimePosition,
 				cursorRawPosition: {
 					clientX: e.clientX,
 					clientY: e.clientY,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Changes the timing of the hoverscrub to be calculated every frame.

* **What is the current behavior?** (You can also link to an open issue here)

When hovering over a moving part without moving the mouse, the hoverscrub will be paused even though the piece is moving underneath the mouse.

* **What is the new behavior (if this is a feature change)?**

Hoverscrub accurately reflects the position of the mouse, regardless of whether it is being moved.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
