### PR TITLE
fix: timeline and storyboard view break

### DIFF
--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -43,6 +43,7 @@ $segment-layer-separator-color: transparentize(#000, 0.5);
 :root {
 	--popdown: 2rem;
 }
+$break-width: 35rem;
 
 // A utility mix-in, to add an interactive collapse triangle on an item
 @mixin collapse-triangle {
@@ -449,8 +450,15 @@ svg.icon {
 	display: grid;
 	grid-column-gap: 0;
 	grid-row-gap: 0;
+
 	grid-template-columns: [segment-name] ($segment-header-width / 2) [duration-onAirIn-split] ($segment-header-width / 2) [segment-group-controls] $segment-group-controls-width [timeline] auto [end]; // 120px [future-timeline-end]
 	grid-template-rows: [header] $segment-header-height [main-view] auto [zoom-area] auto [end];
+
+	@media screen and (max-width: $break-width) {
+		grid-template-columns: [start] $segment-group-controls-width [timeline] auto [toggle-view] 30px [end];
+		grid-template-rows: [header] $segment-header-height [title] auto [timeline-header] $segment-header-height [output-layers] auto [zoom-area] auto [end];
+	}
+
 	overflow: hidden;
 	user-select: none;
 	-moz-user-select: none;
@@ -487,6 +495,10 @@ svg.icon {
 
 		grid-column: segment-name / segment-group-controls;
 		grid-row: main-view / end;
+		@media screen and (max-width: $break-width) {
+			grid-column: start / end;
+			grid-row: title / timeline-header;
+		}
 
 		transition: $output-layer-group-collapse-animation-duration opacity,
 			$output-layer-group-collapse-animation-duration visibility 0s;
@@ -663,6 +675,10 @@ svg.icon {
 
 		grid-column: segment-name / duration-onAirIn-split;
 		grid-row: header / main-view;
+		@media screen and (max-width: $break-width) {
+			grid-column: start / timeline;
+			grid-row: header / title;
+		}
 
 		padding-right: 0px;
 		margin-right: 0em;
@@ -706,6 +722,10 @@ svg.icon {
 
 	.segment-timeline__timeUntil {
 		grid-column: duration-onAirIn-split / segment-group-controls;
+		@media screen and (max-width: $break-width) {
+			grid-column: timeline / toggle-view;
+		}
+
 		color: #888;
 		cursor: pointer;
 	}
@@ -729,6 +749,11 @@ svg.icon {
 .segment-timeline__switch-view-mode-button {
 	grid-row: header / main-view;
 	grid-column: timeline / end;
+	@media screen and (max-width: $break-width) {
+		grid-column: toggle-view / end;
+		grid-row: header / title;
+	}
+
 	justify-self: end;
 	align-self: start;
 	z-index: 1;
@@ -769,8 +794,15 @@ svg.icon {
 	.segment-timeline__timeline-zoom-buttons {
 		position: relative;
 		display: grid;
+
 		grid-column: segment-group-controls / timeline;
 		grid-row: header / end;
+
+		@media screen and (max-width: $break-width) {
+			grid-column: start / timeline;
+			grid-row: zoom-area / end;
+		}
+
 		align-self: end;
 		grid-template-columns: 1fr 1fr 1fr;
 		padding: 0 1.2em 0.05em;
@@ -854,6 +886,10 @@ svg.icon {
 	.segment-timeline__zoom-area-container {
 		grid-column: timeline / end;
 		grid-row: zoom-area / end;
+		@media screen and (max-width: $break-width) {
+			grid-column: timeline / end;
+			grid-row: zoom-area / end;
+		}
 
 		transition: 1s opacity, 0s visibility;
 
@@ -1040,6 +1076,11 @@ svg.icon {
 	.segment-timeline__timeline-background {
 		grid-column: timeline / end;
 		grid-row: main-view / zoom-area;
+		@media screen and (max-width: $break-width) {
+			grid-column: timeline / end;
+			grid-row: output-layers / zoom-area;
+		}
+
 		min-width: 0;
 		overflow: hidden;
 		background: $segment-timeline-background-color;
@@ -1054,6 +1095,11 @@ svg.icon {
 	.segment-timeline__timeline-grid {
 		grid-column: timeline / end;
 		grid-row: header / zoom-area;
+		@media screen and (max-width: $break-width) {
+			grid-column: timeline / end;
+			grid-row: timeline-header / zoom-area;
+		}
+
 		min-width: 0;
 		overflow: hidden;
 		margin-bottom: 1.15em;
@@ -1077,6 +1123,11 @@ svg.icon {
 	.segment-timeline__timeline-container {
 		grid-column: timeline / end;
 		grid-row: header / zoom-area;
+		@media screen and (max-width: $break-width) {
+			grid-column: timeline / end;
+			grid-row: timeline-header / zoom-area;
+		}
+
 		min-width: 0;
 		min-height: 0;
 
@@ -2220,6 +2271,10 @@ svg.icon {
 	.segment-timeline__output-layers {
 		grid-column: segment-group-controls / timeline;
 		grid-row: header / zoom-area;
+		@media screen and (max-width: $break-width) {
+			grid-column: start / timeline;
+			grid-row: timeline-header / zoom-area;
+		}
 
 		transition: $output-layer-group-collapse-animation-duration padding ease-in-out;
 

--- a/meteor/client/ui/SegmentStoryboard/SegmentStoryboard.scss
+++ b/meteor/client/ui/SegmentStoryboard/SegmentStoryboard.scss
@@ -6,12 +6,19 @@
 $part-left-padding: 6px;
 $part-right-padding: 5px;
 
+$break-width: 35rem;
+
 .segment-storyboard {
 	> .segment-storyboard__part-list__container {
 		position: relative;
 		overflow: hidden;
+
 		grid-column: timeline / end;
 		grid-row: header / end;
+		@media screen and (max-width: $break-width) {
+			grid-column: timeline / end;
+			grid-row: timeline-header / zoom-area;
+		}
 
 		contain: content style;
 		touch-action: pan-y;
@@ -127,6 +134,11 @@ $part-right-padding: 5px;
 	> .segment-timeline__source-layers {
 		grid-column: segment-group-controls / timeline;
 		grid-row: main-view / zoom-area;
+		@media screen and (max-width: $break-width) {
+			grid-column: start / timeline;
+			grid-row: output-layers / zoom-area;
+		}
+
 		margin: $segment-storyboard-thumbnail-height 0.3em 0;
 
 		> .segment-timeline__output-group {
@@ -205,7 +217,9 @@ $part-right-padding: 5px;
 			right: -2px;
 		}
 
-		&:not(.segment-storyboard__part__next-line--autonext):not(.segment-storyboard__part__next-line--live):not(.segment-storyboard__part__next-line--invalid) {
+		&:not(.segment-storyboard__part__next-line--autonext):not(.segment-storyboard__part__next-line--live):not(
+				.segment-storyboard__part__next-line--invalid
+			) {
 			&::before {
 				@include take-arrow();
 				top: -3px;
@@ -307,7 +321,9 @@ $part-right-padding: 5px;
 			}
 		}
 
-		&:not(.segment-storyboard__part__next-line-label--next):not(.segment-storyboard__part__next-line-label--live).segment-storyboard__part__next-line-label--autonext,
+		&:not(.segment-storyboard__part__next-line-label--next):not(
+				.segment-storyboard__part__next-line-label--live
+			).segment-storyboard__part__next-line-label--autonext,
 		&.segment-storyboard__part__next-line-label--opposite {
 			font-weight: 400;
 			top: 5px;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.


* **What is the current behavior?** (You can also link to an open issue here)
Currently, Timeline and Storyboard segment views on the Rundown page won't break in case the viewport size is too small (narrow).


* **What is the new behavior (if this is a feature change)?**
With these changes, both Timeline and Storyboard segments will break the same as the List segment breaks.


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
