### PR TITLE
fix: gateway subscription leaking SOFIE-2442

### DIFF
--- a/meteor/server/lib/customPublication/optimizedObserverBase.ts
+++ b/meteor/server/lib/customPublication/optimizedObserverBase.ts
@@ -76,6 +76,9 @@ export async function setUpOptimizedObserverInner<
 			const i2 = thisObserverWrapper.newSubscribers.indexOf(receiver)
 			if (i2 !== -1) thisObserverWrapper.newSubscribers.splice(i2, 1)
 
+			const subCount = thisObserverWrapper.activeSubscribers.length + thisObserverWrapper.newSubscribers.length
+			logger.debug(`Remove subscriber from ${identifier} ${subCount} are left`)
+
 			// clean up if empty:
 			if (
 				!thisObserverWrapper.activeSubscribers.length &&
@@ -94,6 +97,9 @@ export async function setUpOptimizedObserverInner<
 		thisObserverWrapper.newSubscribers.push(receiver)
 		receiver.onStop(() => removeReceiver())
 
+		const subCount = thisObserverWrapper.activeSubscribers.length + thisObserverWrapper.newSubscribers.length
+		logger.debug(`Adding subscriber to ${identifier} ${subCount} are joined`)
+
 		// If the optimizedObserver is setup, we can notify it that we need data
 		if (thisObserverWrapper.subscribersChanged) thisObserverWrapper.subscribersChanged()
 
@@ -110,6 +116,8 @@ export async function setUpOptimizedObserverInner<
 			worker: resultingOptimizedObserver,
 		}
 		receiver.onStop(() => removeReceiver())
+
+		logger.debug(`Starting publication ${identifier}`)
 
 		// Start the optimizedObserver
 		try {

--- a/packages/mos-gateway/src/coreHandler.ts
+++ b/packages/mos-gateway/src/coreHandler.ts
@@ -1,4 +1,4 @@
-import { CoreConnection, CoreOptions, DDPConnectorOptions } from '@sofie-automation/server-core-integration'
+import { CoreConnection, CoreOptions, DDPConnectorOptions, Observer } from '@sofie-automation/server-core-integration'
 import * as Winston from 'winston'
 import { Process } from './process'
 
@@ -92,11 +92,11 @@ export interface IStoryItemChange {
  */
 export class CoreMosDeviceHandler {
 	core: CoreConnection
-	public _observers: Array<any> = []
+	public _observers: Array<Observer> = []
 	public _mosDevice: IMOSDevice
 	private _coreParentHandler: CoreHandler
 	private _mosHandler: MosHandler
-	private _subscriptions: Array<any> = []
+	private _subscriptions: Array<string> = []
 
 	private _pendingStoryItemChanges: Array<IStoryItemChange> = []
 	private _pendingChangeTimeout: number = 60 * 1000
@@ -115,14 +115,8 @@ export class CoreMosDeviceHandler {
 		})
 	}
 	async init(): Promise<void> {
-		return this.core
-			.init(this._coreParentHandler.core)
-			.then(() => {
-				return this.setupSubscriptionsAndObservers()
-			})
-			.then(() => {
-				return
-			})
+		await this.core.init(this._coreParentHandler.core)
+		this.setupSubscriptionsAndObservers()
 	}
 	setupSubscriptionsAndObservers(): void {
 		// console.log('setupObservers', this.core.deviceId)
@@ -144,9 +138,6 @@ export class CoreMosDeviceHandler {
 		Promise.all([this.core.autoSubscribe('peripheralDeviceCommands', this.core.deviceId)])
 			.then((subs) => {
 				this._subscriptions = this._subscriptions.concat(subs)
-			})
-			.then(() => {
-				return
 			})
 			.catch((e) => {
 				this._coreParentHandler.logger.error(e)
@@ -469,6 +460,10 @@ export class CoreMosDeviceHandler {
 			obs.stop()
 		})
 
+		for (const subId of this._subscriptions) {
+			this.core.unsubscribe(subId)
+		}
+
 		return this.core
 			.setStatus({
 				statusCode: StatusCode.BAD,
@@ -549,11 +544,11 @@ export interface CoreConfig {
 export class CoreHandler {
 	core: CoreConnection | undefined
 	logger: Winston.Logger
-	public _observers: Array<any> = []
+	public _observers: Array<Observer> = []
 	private _deviceOptions: DeviceConfig
 	private _coreMosHandlers: Array<CoreMosDeviceHandler> = []
 	private _onConnected?: () => any
-	private _subscriptions: Array<any> = []
+	private _subscriptions: Array<string> = []
 	private _isInitialized = false
 	private _executedFunctions: { [id: string]: boolean } = {}
 	private _coreConfig?: CoreConfig
@@ -615,6 +610,10 @@ export class CoreHandler {
 	async dispose(): Promise<void> {
 		if (!this.core) {
 			throw Error('core is undefined!')
+		}
+
+		for (const subId of this._subscriptions) {
+			this.core.unsubscribe(subId)
 		}
 
 		return this.core
@@ -681,28 +680,22 @@ export class CoreHandler {
 		let foundI = -1
 		for (let i = 0; i < this._coreMosHandlers.length; i++) {
 			const cmh = this._coreMosHandlers[i]
-			if (cmh._mosDevice.idPrimary === mosDevice.idSecondary) {
+			if (
+				cmh._mosDevice.idPrimary === mosDevice.idPrimary ||
+				cmh._mosDevice.idSecondary === mosDevice.idSecondary
+			) {
 				foundI = i
 				break
 			}
 		}
 		const coreMosHandler = this._coreMosHandlers[foundI]
 		if (coreMosHandler) {
-			return coreMosHandler.dispose().then(() => {
-				this._coreMosHandlers.splice(foundI, 1)
-				return
-			})
+			this._coreMosHandlers.splice(foundI, 1)
+			await coreMosHandler.dispose()
 		}
-		return Promise.resolve()
 	}
 	onConnectionRestored(): void {
-		this.setupSubscriptionsAndObservers().catch((e) => {
-			this.logger.error(e)
-		})
 		if (this._onConnected) this._onConnected()
-		this._coreMosHandlers.forEach((cmh: CoreMosDeviceHandler) => {
-			cmh.setupSubscriptionsAndObservers()
-		})
 	}
 	onConnected(fcn: () => any): void {
 		this._onConnected = fcn
@@ -716,7 +709,6 @@ export class CoreHandler {
 			})
 			this._observers = []
 		}
-		this._subscriptions = []
 
 		if (!this.core) {
 			throw Error('core is undefined!')
@@ -730,7 +722,7 @@ export class CoreHandler {
 			this.core.autoSubscribe('peripheralDeviceCommands', this.core.deviceId),
 		])
 			.then((subs) => {
-				this._subscriptions = this._subscriptions.concat(subs)
+				this._subscriptions.push(...subs)
 			})
 			.then(() => {
 				this.setupObserverForPeripheralDeviceCommands(this)

--- a/packages/mos-gateway/src/mosHandler.ts
+++ b/packages/mos-gateway/src/mosHandler.ts
@@ -23,7 +23,7 @@ import {
 } from 'mos-connection'
 import * as Winston from 'winston'
 import { CoreHandler, CoreMosDeviceHandler } from './coreHandler'
-import { CollectionObj } from '@sofie-automation/server-core-integration'
+import { CollectionObj, Observer } from '@sofie-automation/server-core-integration'
 import {
 	DEFAULT_MOS_TIMEOUT_TIME,
 	DEFAULT_MOS_HEARTBEAT_INTERVAL,
@@ -62,7 +62,7 @@ export class MosHandler {
 	private _disposed = false
 	private _settings?: MosDeviceSettings
 	private _coreHandler: CoreHandler | undefined
-	private _observers: Array<any> = []
+	private _observers: Array<Observer> = []
 	private _triggerupdateDevicesTimeout: any = null
 
 	constructor(logger: Winston.Logger) {
@@ -531,23 +531,21 @@ export class MosHandler {
 
 		delete this._ownMosDevices[deviceId]
 		if (mosDevice) {
+			if (!this._coreHandler) throw Error('_coreHandler is undefined!')
+			await this._coreHandler.unRegisterMosDevice(mosDevice)
+
 			if (!this.mos) {
 				throw Error('mos is undefined!')
 			}
 
+			// TODO - why are we finding `mosDevice0`, and not using `mosDevice`?
 			const mosDevice0 =
 				this.mos.getDevice(mosDevice.idPrimary) ||
 				(mosDevice.idSecondary && this.mos.getDevice(mosDevice.idSecondary))
 
 			if (mosDevice0) {
+				// TODO - does this need running for both primary and secondary?
 				await this.mos.disposeMosDevice(mosDevice)
-				if (!this._coreHandler) throw Error('_coreHandler is undefined!')
-				await this._coreHandler.unRegisterMosDevice(mosDevice)
-
-				delete this._ownMosDevices[mosDevice.idPrimary]
-				if (mosDevice.idSecondary) delete this._ownMosDevices[mosDevice.idSecondary]
-			} else {
-				// device not found in mosConnection
 			}
 		} else {
 			// no device found

--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -28,7 +28,7 @@ import * as crypto from 'crypto'
 import * as cp from 'child_process'
 
 import * as _ from 'underscore'
-import { CoreConnection } from '@sofie-automation/server-core-integration'
+import { CoreConnection, Observer } from '@sofie-automation/server-core-integration'
 import { TimelineObjectCoreExt } from '@sofie-automation/blueprints-integration'
 import { Logger } from 'winston'
 import { disableAtemUpload } from './config'
@@ -154,7 +154,7 @@ export class TSRHandler {
 	private _coreHandler!: CoreHandler
 	private _triggerupdateExpectedPlayoutItemsTimeout: any = null
 	private _coreTsrHandlers: { [deviceId: string]: CoreTSRDeviceHandler } = {}
-	private _observers: Array<any> = []
+	private _observers: Array<Observer> = []
 	private _cachedStudioId = ''
 
 	private _initialized = false
@@ -357,6 +357,14 @@ export class TSRHandler {
 		})
 	}
 	async destroy(): Promise<void> {
+		if (this._observers.length) {
+			this.logger.debug('Clearing observers..')
+			this._observers.forEach((obs) => {
+				obs.stop()
+			})
+			this._observers = []
+		}
+
 		return this.tsr.destroy()
 	}
 	getTimeline(): RoutedTimeline | undefined {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bug fix

* **What is the current behavior?** (You can also link to an open issue here)

when reconnecting to core, playout and mos gateway are both manually restarting their subscriptions, as well as the subscriptions automatically restarting themselves. 

Additionally, it was found that each time a subdevice was started/restarted in playout-gateway it would start a new subscription to its `PeripheralDeviceCommands`, and would not stop subscriptions when stopping/restarting the subdevice, causing that number to grow. This is particularly problematic when the subdevice is crashing, or unable to connect for a while, as each restart attempt would result in an additional subscription.

In mos-gateway, when reconfiguring devices there was an issue with it not cleaning up correctly, resulting in similar subscription leaks.

In both there were also some cases of observers not being stopped, which would at best cause objects to be leaked and at worst could lead to other bugs with the old 'inactive' class handling `PeripheralDeviceCommands`.

* **Other information**:

When merging forward, we should make sure to review live-status-gateway in r50 in case it inherited the same bugs

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
