### PR TITLE
fix: hide countdown and icicles on looping media

### DIFF
--- a/meteor/client/ui/SegmentList/LinePartTimeline.tsx
+++ b/meteor/client/ui/SegmentList/LinePartTimeline.tsx
@@ -1,4 +1,4 @@
-import { PieceLifespan, SourceLayerType } from '@sofie-automation/blueprints-integration'
+import { PieceLifespan, SourceLayerType, VTContent } from '@sofie-automation/blueprints-integration'
 import React, { useMemo } from 'react'
 import { PartExtended, PieceExtended } from '../../../lib/Rundown'
 import { findPieceExtendedToShowFromOrderedResolvedInstances } from '../PieceIcons/utils'
@@ -94,7 +94,8 @@ export const LinePartTimeline: React.FC<IProps> = function LinePartTimeline({
 
 	const isInvalid = !!part.instance.part.invalid
 
-	const endsInFreeze = !part.instance.part.autoNext && !!mainPiece?.instance.piece.content.sourceDuration
+	const loop = !(mainPiece?.instance.piece.content as VTContent).loop
+	const endsInFreeze = !part.instance.part.autoNext && !loop && !!mainPiece?.instance.piece.content.sourceDuration
 	const mainSourceEnd = mainPiece?.instance.piece.content.sourceDuration
 		? (mainPieceInPoint ?? 0) + mainPiece?.instance.piece.content.sourceDuration
 		: null

--- a/meteor/client/ui/SegmentTimeline/Renderers/CustomLayerItemRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/CustomLayerItemRenderer.tsx
@@ -150,6 +150,7 @@ export class CustomLayerItemRenderer<
 		const postrollDuration = vtContent && vtContent.postrollDuration ? vtContent.postrollDuration : 0
 		if (
 			vtContent &&
+			!vtContent.loop &&
 			vtContent.sourceDuration !== undefined &&
 			vtContent.sourceDuration !== 0 &&
 			(this.props.piece.renderedInPoint || 0) + (vtContent.sourceDuration - seek) < (this.props.partDuration || 0)

--- a/meteor/client/ui/SegmentTimeline/Renderers/VTSourceRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/VTSourceRenderer.tsx
@@ -496,6 +496,7 @@ export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithT
 			livePositionInPart < (uiPiece.renderedInPoint || 0) + (uiPiece.renderedDuration || Number.POSITIVE_INFINITY) &&
 			vtContent &&
 			vtContent.sourceDuration !== undefined &&
+			!vtContent.loop &&
 			((part.instance.part.autoNext &&
 				(uiPiece.renderedInPoint || 0) + (vtContent.sourceDuration - seek) < (this.props.partDuration || 0)) ||
 				(!part.instance.part.autoNext &&


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

The rundown view shows a countdown-to-freeze and freeze frame icicles for looping media.

* **What is the new behavior (if this is a feature change)?**

These things are no longer shown for looping media.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
