### PR TITLE
feat: remove MediaObjects collection from client SOFIE-2402

### DIFF
--- a/meteor/client/collections/index.ts
+++ b/meteor/client/collections/index.ts
@@ -14,7 +14,6 @@ import { CollectionName } from '@sofie-automation/corelib/dist/dataModel/Collect
 import { ExpectedPackageWorkStatus } from '@sofie-automation/corelib/dist/dataModel/ExpectedPackageWorkStatuses'
 import { ExternalMessageQueueObj } from '@sofie-automation/corelib/dist/dataModel/ExternalMessageQueue'
 import { PackageContainerStatusDB } from '@sofie-automation/corelib/dist/dataModel/PackageContainerStatus'
-import { MediaObject } from '@sofie-automation/shared-lib/dist/core/model/MediaObjects'
 import { MediaWorkFlow } from '@sofie-automation/shared-lib/dist/core/model/MediaWorkFlows'
 import { MediaWorkFlowStep } from '@sofie-automation/shared-lib/dist/core/model/MediaWorkFlowSteps'
 import { Meteor } from 'meteor/meteor'
@@ -64,8 +63,6 @@ export const ExpectedPackageWorkStatuses = createSyncReadOnlyMongoCollection<Exp
 export const ExternalMessageQueue = createSyncReadOnlyMongoCollection<ExternalMessageQueueObj>(
 	CollectionName.ExternalMessageQueue
 )
-
-export const MediaObjects = createSyncReadOnlyMongoCollection<MediaObject>(CollectionName.MediaObjects)
 
 export const MediaWorkFlows = createSyncReadOnlyMongoCollection<MediaWorkFlow>(CollectionName.MediaWorkFlows)
 

--- a/meteor/client/ui/ClipTrimPanel/ClipTrimDialog.tsx
+++ b/meteor/client/ui/ClipTrimPanel/ClipTrimDialog.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react'
-import { withTranslation, WithTranslation } from 'react-i18next'
+import React, { useCallback, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { ClipTrimPanel } from './ClipTrimPanel'
-import { VTContent, VTEditableParameters } from '@sofie-automation/blueprints-integration'
-import { ModalDialog } from '../../lib/ModalDialog'
+import { VTContent } from '@sofie-automation/blueprints-integration'
+import { ModalDialog, SomeEvent } from '../../lib/ModalDialog'
 import { doUserAction, UserAction } from '../../../lib/clientUserAction'
 import { MeteorCall } from '../../../lib/api/methods'
 import { NotificationCenter, Notification, NoticeLevel } from '../../../lib/notifications/notifications'
@@ -27,143 +27,145 @@ interface IState {
 	duration: number
 }
 
-export const ClipTrimDialog = withTranslation()(
-	class ClipTrimDialog extends React.Component<IProps & WithTranslation, IState> {
-		constructor(props: IProps & WithTranslation) {
-			super(props)
+export function ClipTrimDialog({
+	playlistId,
+	rundown,
+	studio,
+	selectedPiece,
 
-			this.state = {
-				inPoint: ((this.props.selectedPiece.content as VTContent).editable as VTEditableParameters).editorialStart,
-				duration: ((this.props.selectedPiece.content as VTContent).editable as VTEditableParameters).editorialDuration,
-			}
-		}
-		handleChange = (inPoint: number, duration: number) => {
-			this.setState({
-				inPoint,
-				duration,
-			})
-		}
-		handleAccept = (e) => {
-			const { t, selectedPiece } = this.props
+	onClose,
+}: IProps): JSX.Element {
+	const { t } = useTranslation()
 
-			this.props.onClose && this.props.onClose()
-			doUserAction(
-				this.props.t,
-				e,
-				UserAction.SET_IN_OUT_POINTS,
-				(e, ts) =>
-					MeteorCall.userAction.setInOutPoints(
-						e,
-						ts,
-						this.props.playlistId,
-						selectedPiece.startPartId,
-						selectedPiece._id,
-						this.state.inPoint,
-						this.state.duration
-					),
-				(err) => {
-					clearTimeout(pendingInOutPoints)
+	const vtContent = selectedPiece.content as VTContent | undefined
 
-					if (
-						ClientAPI.isClientResponseError(err) &&
-						err.error.rawError &&
-						stringifyError(err.error.rawError).match(/timed out/)
-					) {
-						NotificationCenter.push(
-							new Notification(
-								undefined,
-								NoticeLevel.CRITICAL,
-								(
-									<>
-										<strong>{selectedPiece.name}</strong>:&ensp;
-										{t(
-											"Trimming this clip has timed out. It's possible that the story is currently locked for writing in {{nrcsName}} and will eventually be updated. Make sure that the story is not being edited by other users.",
-											{ nrcsName: (this.props.rundown && this.props.rundown.externalNRCSName) || 'NRCS' }
-										)}
-									</>
-								),
-								protectString('ClipTrimDialog')
-							)
+	const [state, setState] = useState<IState>(() => ({
+		inPoint: vtContent?.editable?.editorialStart ?? 0,
+		duration: vtContent?.editable?.editorialDuration ?? 0,
+	}))
+
+	const handleChange = useCallback((inPoint: number, duration: number) => {
+		setState({
+			inPoint,
+			duration,
+		})
+	}, [])
+
+	const handleAccept = useCallback((e: SomeEvent) => {
+		onClose && onClose()
+
+		doUserAction(
+			t,
+			e,
+			UserAction.SET_IN_OUT_POINTS,
+			(e, ts) =>
+				MeteorCall.userAction.setInOutPoints(
+					e,
+					ts,
+					playlistId,
+					selectedPiece.startPartId,
+					selectedPiece._id,
+					state.inPoint,
+					state.duration
+				),
+			(err) => {
+				clearTimeout(pendingInOutPoints)
+
+				if (
+					ClientAPI.isClientResponseError(err) &&
+					err.error.rawError &&
+					stringifyError(err.error.rawError).match(/timed out/)
+				) {
+					NotificationCenter.push(
+						new Notification(
+							undefined,
+							NoticeLevel.CRITICAL,
+							(
+								<>
+									<strong>{selectedPiece.name}</strong>:&ensp;
+									{t(
+										"Trimming this clip has timed out. It's possible that the story is currently locked for writing in {{nrcsName}} and will eventually be updated. Make sure that the story is not being edited by other users.",
+										{ nrcsName: rundown?.externalNRCSName || 'NRCS' }
+									)}
+								</>
+							),
+							protectString('ClipTrimDialog')
 						)
-					} else if (ClientAPI.isClientResponseError(err) || err) {
-						NotificationCenter.push(
-							new Notification(
-								undefined,
-								NoticeLevel.CRITICAL,
-								(
-									<>
-										<strong>{selectedPiece.name}</strong>:&ensp;
-										{t('Trimming this clip has failed due to an error: {{error}}.', {
-											error: err.message || err.error || err,
-										})}
-									</>
-								),
-								protectString('ClipTrimDialog')
-							)
-						)
-					} else {
-						NotificationCenter.push(
-							new Notification(
-								undefined,
-								NoticeLevel.NOTIFICATION,
-								(
-									<>
-										<strong>{selectedPiece.name}</strong>:&ensp;
-										{t('Trimmed succesfully.')}
-									</>
-								),
-								protectString('ClipTrimDialog')
-							)
-						)
-					}
-
-					return false // do not use default doUserAction failure handler
-				}
-			)
-			const pendingInOutPoints = setTimeout(() => {
-				NotificationCenter.push(
-					new Notification(
-						undefined,
-						NoticeLevel.WARNING,
-						(
-							<>
-								<strong>{selectedPiece.name}</strong>:&ensp;
-								{t(
-									"Trimming this clip is taking longer than expected. It's possible that the story is locked for writing in {{nrcsName}}.",
-									{ nrcsName: (this.props.rundown && this.props.rundown.externalNRCSName) || 'NRCS' }
-								)}
-							</>
-						),
-						protectString('ClipTrimDialog')
 					)
+				} else if (ClientAPI.isClientResponseError(err) || err) {
+					NotificationCenter.push(
+						new Notification(
+							undefined,
+							NoticeLevel.CRITICAL,
+							(
+								<>
+									<strong>{selectedPiece.name}</strong>:&ensp;
+									{t('Trimming this clip has failed due to an error: {{error}}.', {
+										error: err.message || err.error || err,
+									})}
+								</>
+							),
+							protectString('ClipTrimDialog')
+						)
+					)
+				} else {
+					NotificationCenter.push(
+						new Notification(
+							undefined,
+							NoticeLevel.NOTIFICATION,
+							(
+								<>
+									<strong>{selectedPiece.name}</strong>:&ensp;
+									{t('Trimmed succesfully.')}
+								</>
+							),
+							protectString('ClipTrimDialog')
+						)
+					)
+				}
+
+				return false // do not use default doUserAction failure handler
+			}
+		)
+		const pendingInOutPoints = setTimeout(() => {
+			NotificationCenter.push(
+				new Notification(
+					undefined,
+					NoticeLevel.WARNING,
+					(
+						<>
+							<strong>{selectedPiece.name}</strong>:&ensp;
+							{t(
+								"Trimming this clip is taking longer than expected. It's possible that the story is locked for writing in {{nrcsName}}.",
+								{ nrcsName: rundown?.externalNRCSName || 'NRCS' }
+							)}
+						</>
+					),
+					protectString('ClipTrimDialog')
 				)
-			}, 5 * 1000)
-		}
-		render(): JSX.Element {
-			const { t } = this.props
-			return (
-				<ModalDialog
-					title={t('Trim "{{name}}"', { name: this.props.selectedPiece.name })}
-					show={true}
-					acceptText={t('OK')}
-					secondaryText={t('Cancel')}
-					onAccept={this.handleAccept}
-					onDiscard={() => this.props.onClose && this.props.onClose()}
-					onSecondary={() => this.props.onClose && this.props.onClose()}
-					className="big"
-				>
-					<ClipTrimPanel
-						studioId={this.props.studio._id}
-						playlistId={this.props.playlistId}
-						rundownId={this.props.rundown._id}
-						pieceId={this.props.selectedPiece._id}
-						partId={this.props.selectedPiece.startPartId}
-						inPoint={this.state.inPoint}
-						duration={this.state.duration}
-						onChange={this.handleChange}
-					/>
-				</ModalDialog>
 			)
-		}
-	}
-)
+		}, 5 * 1000)
+	}, [])
+
+	return (
+		<ModalDialog
+			title={t('Trim "{{name}}"', { name: selectedPiece.name })}
+			show={true}
+			acceptText={t('OK')}
+			secondaryText={t('Cancel')}
+			onAccept={handleAccept}
+			onDiscard={onClose}
+			onSecondary={onClose}
+			className="big"
+		>
+			<ClipTrimPanel
+				studio={studio}
+				rundownId={rundown._id}
+				pieceId={selectedPiece._id}
+				inPoint={state.inPoint}
+				duration={state.duration}
+				onChange={handleChange}
+			/>
+		</ModalDialog>
+	)
+}

--- a/meteor/client/ui/SegmentTimeline/withMediaObjectStatus.tsx
+++ b/meteor/client/ui/SegmentTimeline/withMediaObjectStatus.tsx
@@ -9,10 +9,11 @@ import { BucketAdLibUi, BucketAdLibActionUi } from '../Shelf/RundownViewBuckets'
 import { AdLibPieceUi } from '../../lib/shelf'
 import { UIStudio } from '../../../lib/api/studios'
 import { UIBucketContentStatuses, UIPieceContentStatuses } from '../Collections'
-import { PieceStatusCode } from '@sofie-automation/corelib/dist/dataModel/Piece'
+import { Piece, PieceStatusCode } from '@sofie-automation/corelib/dist/dataModel/Piece'
 import { PieceContentStatusObj } from '../../../lib/mediaObjects'
 import { deepFreeze } from '@sofie-automation/corelib/dist/lib'
 import _ from 'underscore'
+import { useTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
 
 type AnyPiece = {
 	piece?: BucketAdLibUi | IAdLibListItem | AdLibPieceUi | PieceUi | BucketAdLibActionUi | undefined
@@ -151,4 +152,20 @@ export function withMediaObjectStatus<IProps extends AnyPiece, IState>(): (
 			}
 		}
 	}
+}
+
+export function useContentStatusForPiece(
+	piece: Pick<Piece, '_id' | 'startRundownId' | 'startSegmentId'> | undefined
+): PieceContentStatusObj | undefined {
+	return useTracker(
+		() =>
+			piece
+				? UIPieceContentStatuses.findOne({
+						pieceId: piece._id,
+						rundownId: piece.startRundownId || { $exists: false },
+						segmentId: piece.startSegmentId || { $exists: false },
+				  })?.status
+				: undefined,
+		[piece?._id, piece?.startRundownId, piece?.startSegmentId]
+	)
 }

--- a/meteor/lib/api/pubsub.ts
+++ b/meteor/lib/api/pubsub.ts
@@ -23,7 +23,6 @@ import { ExpectedPackageDB } from '@sofie-automation/corelib/dist/dataModel/Expe
 import { ExpectedPackageWorkStatus } from '@sofie-automation/corelib/dist/dataModel/ExpectedPackageWorkStatuses'
 import { ExpectedPlayoutItem } from '@sofie-automation/corelib/dist/dataModel/ExpectedPlayoutItem'
 import { ExternalMessageQueueObj } from '../collections/ExternalMessageQueue'
-import { MediaObject } from '@sofie-automation/shared-lib/dist/core/model/MediaObjects'
 import { MediaWorkFlow } from '@sofie-automation/shared-lib/dist/core/model/MediaWorkFlows'
 import { MediaWorkFlowStep } from '@sofie-automation/shared-lib/dist/core/model/MediaWorkFlowSteps'
 import { DBOrganization } from '../collections/Organization'
@@ -68,7 +67,6 @@ export enum PubSub {
 	expectedPlayoutItems = 'expectedPlayoutItems',
 	expectedMediaItems = 'expectedMediaItems',
 	externalMessageQueue = 'externalMessageQueue',
-	mediaObjects = 'mediaObjects',
 	peripheralDeviceCommands = 'peripheralDeviceCommands',
 	peripheralDevices = 'peripheralDevices',
 	peripheralDevicesAndSubDevices = ' peripheralDevicesAndSubDevices',
@@ -151,7 +149,6 @@ export interface PubSubTypes {
 		selector: MongoQuery<ExternalMessageQueueObj>,
 		token?: string
 	) => ExternalMessageQueueObj
-	[PubSub.mediaObjects]: (studioId: StudioId, selector: MongoQuery<MediaObject>, token?: string) => MediaObject
 	[PubSub.peripheralDeviceCommands]: (deviceId: PeripheralDeviceId, token?: string) => PeripheralDeviceCommand
 	[PubSub.peripheralDevices]: (selector: MongoQuery<PeripheralDevice>, token?: string) => PeripheralDevice
 	[PubSub.peripheralDevicesAndSubDevices]: (selector: MongoQuery<PeripheralDevice>) => PeripheralDevice

--- a/meteor/server/publications/studio.ts
+++ b/meteor/server/publications/studio.ts
@@ -5,7 +5,6 @@ import { CustomCollectionName, PubSub } from '../../lib/api/pubsub'
 import { DBStudio, getActiveRoutes, getRoutedMappings, RoutedMappings } from '../../lib/collections/Studios'
 import { PeripheralDeviceReadAccess } from '../security/peripheralDevice'
 import { ExternalMessageQueueObj } from '../../lib/collections/ExternalMessageQueue'
-import { MediaObject } from '@sofie-automation/shared-lib/dist/core/model/MediaObjects'
 import { StudioReadAccess } from '../security/studio'
 import { OrganizationReadAccess } from '../security/organization'
 import { NoSecurityReadAccess } from '../security/noSecurity'
@@ -26,7 +25,6 @@ import {
 	ExpectedPackages,
 	ExpectedPackageWorkStatuses,
 	ExternalMessageQueue,
-	MediaObjects,
 	PackageContainerStatuses,
 	PeripheralDevices,
 	Studios,
@@ -59,20 +57,6 @@ meteorPublish(PubSub.externalMessageQueue, async function (selector, token) {
 	return null
 })
 
-meteorPublish(PubSub.mediaObjects, async function (studioId, selector, token) {
-	if (!studioId) throw new Meteor.Error(400, 'studioId argument missing')
-	selector = selector || {}
-	check(studioId, String)
-	check(selector, Object)
-	const modifier: FindOptions<MediaObject> = {
-		fields: {},
-	}
-	selector.studioId = studioId
-	if (await StudioReadAccess.studioContent(selector.studioId, { userId: this.userId, token })) {
-		return MediaObjects.findWithCursor(selector, modifier)
-	}
-	return null
-})
 meteorPublish(PubSub.expectedPackages, async function (selector, token) {
 	// Note: This differs from the expected packages sent to the Package Manager, instead @see PubSub.expectedPackagesForDevice
 	if (!selector) throw new Meteor.Error(400, 'selector argument missing')


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

code cleanup 

* **What is the current behavior?** (You can also link to an open issue here)

This was used in an attempt to get the previewUrl of a piece. This would not work with package-manager, and involved more complexity than necessary.

* **What is the new behavior (if this is a feature change)?**

The previewurl is now taken from the piece content status publication.

To help achieve this, the component was rewritten to be functional.

The `MediaObjects` publication is now unused, so has been removed

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
