### PR TITLE
feat: make the minimum take span configurable on a per-studio basis

### DIFF
--- a/meteor/__mocks__/defaultCollectionObjects.ts
+++ b/meteor/__mocks__/defaultCollectionObjects.ts
@@ -26,6 +26,7 @@ import {
 	ShowStyleVariantId,
 	StudioId,
 } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { DEFAULT_MINIMUM_TAKE_SPAN } from '@sofie-automation/shared-lib/dist/core/constants'
 
 export function defaultRundownPlaylist(_id: RundownPlaylistId, studioId: StudioId): DBRundownPlaylist {
 	return {
@@ -101,7 +102,7 @@ export function defaultStudio(_id: StudioId): DBStudio {
 		settings: {
 			frameRate: 25,
 			mediaPreviewsUrl: '',
-			minimumTakeSpan: 1000,
+			minimumTakeSpan: DEFAULT_MINIMUM_TAKE_SPAN,
 		},
 		_rundownVersionHash: '',
 		routeSets: {},

--- a/meteor/__mocks__/defaultCollectionObjects.ts
+++ b/meteor/__mocks__/defaultCollectionObjects.ts
@@ -101,6 +101,7 @@ export function defaultStudio(_id: StudioId): DBStudio {
 		settings: {
 			frameRate: 25,
 			mediaPreviewsUrl: '',
+			minimumTakeSpan: 1000,
 		},
 		_rundownVersionHash: '',
 		routeSets: {},

--- a/meteor/client/ui/Settings/Studio/Generic.tsx
+++ b/meteor/client/ui/Settings/Studio/Generic.tsx
@@ -111,6 +111,20 @@ export const StudioGenericProperties = withTranslation()(
 						</div>
 					</label>
 					<label className="field">
+						<LabelActual label={t('Minimum Take Span')} />
+						<div className="mdi">
+							<EditAttribute
+								modifiedClassName="bghl"
+								attribute="settings.minimumTakeSpan"
+								obj={this.props.studio}
+								type="int"
+								collection={Studios}
+								className="mdinput"
+							/>
+							<span className="mdfx"></span>
+						</div>
+					</label>
+					<label className="field">
 						<LabelActual label={t('Enable "Play from Anywhere"')} />
 						<EditAttribute
 							modifiedClassName="bghl"

--- a/meteor/lib/api/rest.ts
+++ b/meteor/lib/api/rest.ts
@@ -759,6 +759,7 @@ export interface APIStudioSettings {
 	preserveUnsyncedPlayingSegmentContents?: boolean
 	allowRundownResetOnAir?: boolean
 	preserveOrphanedSegmentPositionInRundown?: boolean
+	minimumTakeSpan: number
 }
 
 export interface PendingMigrationStep {

--- a/meteor/lib/api/rest.ts
+++ b/meteor/lib/api/rest.ts
@@ -759,7 +759,7 @@ export interface APIStudioSettings {
 	preserveUnsyncedPlayingSegmentContents?: boolean
 	allowRundownResetOnAir?: boolean
 	preserveOrphanedSegmentPositionInRundown?: boolean
-	minimumTakeSpan: number
+	minimumTakeSpan?: number
 }
 
 export interface PendingMigrationStep {

--- a/meteor/server/api/playout/DOCS.md
+++ b/meteor/server/api/playout/DOCS.md
@@ -67,7 +67,7 @@ _Prerequisites: rundown playlist is active and there is no current hold_
 
 ### How does Sofie execute a take?
 
-_Prerequisites: previous take must be over 1000ms (MINIMUM_TAKE_SPAN) ago, playlist must be active, there must be a next part instance, any transitions in the current part must be finished, any autonext must be over 1000ms ahead, current time is after blockTakeUntil from the current part_
+_Prerequisites: previous take must be over 1000ms (configurable on a per-studio basis) ago, playlist must be active, there must be a next part instance, any transitions in the current part must be finished, any autonext must be over 1000ms ahead, current time is after blockTakeUntil from the current part_
 
 *   Load the showstyle blueprints
 *   If hold state is COMPLETE, then clear the hold state (set to NONE)

--- a/meteor/server/api/rest/v1/typeConversion.ts
+++ b/meteor/server/api/rest/v1/typeConversion.ts
@@ -303,6 +303,7 @@ export function studioSettingsFrom(apiStudioSettings: APIStudioSettings): IStudi
 		preserveUnsyncedPlayingSegmentContents: apiStudioSettings.preserveUnsyncedPlayingSegmentContents,
 		allowRundownResetOnAir: apiStudioSettings.allowRundownResetOnAir,
 		preserveOrphanedSegmentPositionInRundown: apiStudioSettings.preserveOrphanedSegmentPositionInRundown,
+		minimumTakeSpan: apiStudioSettings.minimumTakeSpan,
 	}
 }
 
@@ -319,6 +320,7 @@ export function APIStudioSettingsFrom(settings: IStudioSettings): APIStudioSetti
 		preserveUnsyncedPlayingSegmentContents: settings.preserveUnsyncedPlayingSegmentContents,
 		allowRundownResetOnAir: settings.allowRundownResetOnAir,
 		preserveOrphanedSegmentPositionInRundown: settings.preserveOrphanedSegmentPositionInRundown,
+		minimumTakeSpan: settings.minimumTakeSpan,
 	}
 }
 

--- a/meteor/server/api/rest/v1/typeConversion.ts
+++ b/meteor/server/api/rest/v1/typeConversion.ts
@@ -32,6 +32,7 @@ import { DBShowStyleBase, ShowStyleBase } from '../../../../lib/collections/Show
 import { ShowStyleVariant } from '../../../../lib/collections/ShowStyleVariants'
 import { Studio } from '../../../../lib/collections/Studios'
 import { Blueprints, ShowStyleBases, Studios } from '../../../collections'
+import { DEFAULT_MINIMUM_TAKE_SPAN } from '@sofie-automation/shared-lib/dist/core/constants'
 
 /*
 This file contains functions that convert between the internal Sofie-Core types and types exposed to the external API.
@@ -303,7 +304,7 @@ export function studioSettingsFrom(apiStudioSettings: APIStudioSettings): IStudi
 		preserveUnsyncedPlayingSegmentContents: apiStudioSettings.preserveUnsyncedPlayingSegmentContents,
 		allowRundownResetOnAir: apiStudioSettings.allowRundownResetOnAir,
 		preserveOrphanedSegmentPositionInRundown: apiStudioSettings.preserveOrphanedSegmentPositionInRundown,
-		minimumTakeSpan: apiStudioSettings.minimumTakeSpan,
+		minimumTakeSpan: apiStudioSettings.minimumTakeSpan ?? DEFAULT_MINIMUM_TAKE_SPAN,
 	}
 }
 

--- a/meteor/server/api/studio/api.ts
+++ b/meteor/server/api/studio/api.ts
@@ -23,6 +23,7 @@ import { Credentials } from '../../security/lib/credentials'
 import { wrapDefaultObject } from '@sofie-automation/corelib/dist/settings/objectWithOverrides'
 import { OrganizationId, StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { logger } from '../../logging'
+import { DEFAULT_MINIMUM_TAKE_SPAN } from '@sofie-automation/shared-lib/dist/core/constants'
 
 async function insertStudio(context: MethodContext | Credentials, newId?: StudioId): Promise<StudioId> {
 	if (newId) check(newId, String)
@@ -44,7 +45,7 @@ export async function insertStudioInner(organizationId: OrganizationId | null, n
 			settings: {
 				frameRate: 25,
 				mediaPreviewsUrl: '',
-				minimumTakeSpan: 1000,
+				minimumTakeSpan: DEFAULT_MINIMUM_TAKE_SPAN,
 			},
 			_rundownVersionHash: '',
 			routeSets: {},

--- a/meteor/server/api/studio/api.ts
+++ b/meteor/server/api/studio/api.ts
@@ -44,6 +44,7 @@ export async function insertStudioInner(organizationId: OrganizationId | null, n
 			settings: {
 				frameRate: 25,
 				mediaPreviewsUrl: '',
+				minimumTakeSpan: 1000,
 			},
 			_rundownVersionHash: '',
 			routeSets: {},

--- a/meteor/server/migration/0_1_0.ts
+++ b/meteor/server/migration/0_1_0.ts
@@ -439,6 +439,7 @@ export const addSteps = addMigrationSteps('0.1.0', [
 				settings: {
 					frameRate: 25,
 					mediaPreviewsUrl: '',
+					minimumTakeSpan: 1000,
 				},
 				mappingsWithOverrides: wrapDefaultObject({}),
 				blueprintConfigWithOverrides: wrapDefaultObject({}),

--- a/meteor/server/migration/0_1_0.ts
+++ b/meteor/server/migration/0_1_0.ts
@@ -10,6 +10,7 @@ import {
 	TriggerType,
 	PlayoutActions,
 } from '@sofie-automation/blueprints-integration'
+import { DEFAULT_MINIMUM_TAKE_SPAN } from '@sofie-automation/shared-lib/dist/core/constants'
 
 /**
  * This file contains system specific migration steps.
@@ -439,7 +440,7 @@ export const addSteps = addMigrationSteps('0.1.0', [
 				settings: {
 					frameRate: 25,
 					mediaPreviewsUrl: '',
-					minimumTakeSpan: 1000,
+					minimumTakeSpan: DEFAULT_MINIMUM_TAKE_SPAN,
 				},
 				mappingsWithOverrides: wrapDefaultObject({}),
 				blueprintConfigWithOverrides: wrapDefaultObject({}),

--- a/meteor/server/migration/X_X_X.ts
+++ b/meteor/server/migration/X_X_X.ts
@@ -720,6 +720,34 @@ export const addSteps = addMigrationSteps(CURRENT_SYSTEM_VERSION, [
 			}
 		},
 	},
+
+	{
+		id: `Studio.settings.minimumTakeSpan`,
+		canBeRunAutomatically: true,
+		validate: async () => {
+			const count = await Studios.countDocuments({
+				'settings.minimumTakeSpan': {
+					$exists: false,
+				},
+			})
+			if (count > 0) return `${count} studios need to be updated`
+			return false
+		},
+		migrate: async () => {
+			await Studios.updateAsync(
+				{
+					'settings.minimumTakeSpan': {
+						$exists: false,
+					},
+				},
+				{
+					$set: {
+						'settings.minimumTakeSpan': 1000,
+					},
+				}
+			)
+		},
+	},
 ])
 
 function updatePlayoutDeviceTypeInOverride(op: SomeObjectOverrideOp): ObjectOverrideSetOp | undefined {

--- a/meteor/server/migration/X_X_X.ts
+++ b/meteor/server/migration/X_X_X.ts
@@ -21,6 +21,7 @@ import {
 	SomeObjectOverrideOp,
 } from '@sofie-automation/corelib/dist/settings/objectWithOverrides'
 import { JSONBlobStringify, JSONSchema, TSR } from '@sofie-automation/blueprints-integration'
+import { DEFAULT_MINIMUM_TAKE_SPAN } from '@sofie-automation/shared-lib/dist/core/constants'
 
 /*
  * **************************************************************************************
@@ -742,7 +743,7 @@ export const addSteps = addMigrationSteps(CURRENT_SYSTEM_VERSION, [
 				},
 				{
 					$set: {
-						'settings.minimumTakeSpan': 1000,
+						'settings.minimumTakeSpan': DEFAULT_MINIMUM_TAKE_SPAN,
 					},
 				}
 			)

--- a/meteor/server/migration/__tests__/migrations.test.ts
+++ b/meteor/server/migration/__tests__/migrations.test.ts
@@ -125,6 +125,7 @@ describe('Migrations', () => {
 						settings: {
 							mediaPreviewsUrl: '',
 							frameRate: 25,
+							minimumTakeSpan: 1000,
 						},
 						mappingsWithOverrides: wrapDefaultObject({}),
 						blueprintConfigWithOverrides: wrapDefaultObject({}),
@@ -161,6 +162,7 @@ describe('Migrations', () => {
 						settings: {
 							mediaPreviewsUrl: '',
 							frameRate: 25,
+							minimumTakeSpan: 1000,
 						},
 						mappingsWithOverrides: wrapDefaultObject({}),
 						blueprintConfigWithOverrides: wrapDefaultObject({}),
@@ -197,6 +199,7 @@ describe('Migrations', () => {
 						settings: {
 							mediaPreviewsUrl: '',
 							frameRate: 25,
+							minimumTakeSpan: 1000,
 						},
 						mappingsWithOverrides: wrapDefaultObject({}),
 						blueprintConfigWithOverrides: wrapDefaultObject({}),

--- a/meteor/server/migration/__tests__/migrations.test.ts
+++ b/meteor/server/migration/__tests__/migrations.test.ts
@@ -22,6 +22,7 @@ import { MeteorCall } from '../../../lib/api/methods'
 import { wrapDefaultObject } from '@sofie-automation/corelib/dist/settings/objectWithOverrides'
 import { Blueprints, ShowStyleBases, ShowStyleVariants, Studios } from '../../collections'
 import { getCoreSystemAsync } from '../../coreSystem/collection'
+import { DEFAULT_MINIMUM_TAKE_SPAN } from '@sofie-automation/shared-lib/dist/core/constants'
 
 require('../../api/peripheralDevice.ts') // include in order to create the Meteor methods needed
 require('../api') // include in order to create the Meteor methods needed
@@ -125,7 +126,7 @@ describe('Migrations', () => {
 						settings: {
 							mediaPreviewsUrl: '',
 							frameRate: 25,
-							minimumTakeSpan: 1000,
+							minimumTakeSpan: DEFAULT_MINIMUM_TAKE_SPAN,
 						},
 						mappingsWithOverrides: wrapDefaultObject({}),
 						blueprintConfigWithOverrides: wrapDefaultObject({}),
@@ -162,7 +163,7 @@ describe('Migrations', () => {
 						settings: {
 							mediaPreviewsUrl: '',
 							frameRate: 25,
-							minimumTakeSpan: 1000,
+							minimumTakeSpan: DEFAULT_MINIMUM_TAKE_SPAN,
 						},
 						mappingsWithOverrides: wrapDefaultObject({}),
 						blueprintConfigWithOverrides: wrapDefaultObject({}),
@@ -199,7 +200,7 @@ describe('Migrations', () => {
 						settings: {
 							mediaPreviewsUrl: '',
 							frameRate: 25,
-							minimumTakeSpan: 1000,
+							minimumTakeSpan: DEFAULT_MINIMUM_TAKE_SPAN,
 						},
 						mappingsWithOverrides: wrapDefaultObject({}),
 						blueprintConfigWithOverrides: wrapDefaultObject({}),

--- a/meteor/server/publications/pieceContentStatusUI/__tests__/checkPieceContentStatus.test.ts
+++ b/meteor/server/publications/pieceContentStatusUI/__tests__/checkPieceContentStatus.test.ts
@@ -87,6 +87,7 @@ describe('lib/mediaObjects', () => {
 			supportedMediaFormats: '1920x1080i5000, 1280x720, i5000, i5000tff',
 			mediaPreviewsUrl: '',
 			frameRate: 25,
+			minimumTakeSpan: 1000,
 		})
 		expect(acceptedFormats).toEqual([
 			['1920', '1080', 'i', '5000', undefined],
@@ -168,6 +169,7 @@ describe('lib/mediaObjects', () => {
 			mediaPreviewsUrl: '',
 			supportedAudioStreams: '4',
 			frameRate: 25,
+			minimumTakeSpan: 1000,
 		}
 
 		const mockDefaultStudio = defaultStudio(protectString('studio0'))

--- a/meteor/server/publications/pieceContentStatusUI/__tests__/checkPieceContentStatus.test.ts
+++ b/meteor/server/publications/pieceContentStatusUI/__tests__/checkPieceContentStatus.test.ts
@@ -37,6 +37,7 @@ import { testInFiber } from '../../../../__mocks__/helpers/jest'
 import { MediaObjects } from '../../../collections'
 import { PieceDependencies } from '../common'
 import { Studio } from '../../../../lib/collections/Studios'
+import { DEFAULT_MINIMUM_TAKE_SPAN } from '@sofie-automation/shared-lib/dist/core/constants'
 
 const mockMediaObjectsCollection = MongoMock.getInnerMockCollection<MediaObject>(MediaObjects)
 
@@ -87,7 +88,7 @@ describe('lib/mediaObjects', () => {
 			supportedMediaFormats: '1920x1080i5000, 1280x720, i5000, i5000tff',
 			mediaPreviewsUrl: '',
 			frameRate: 25,
-			minimumTakeSpan: 1000,
+			minimumTakeSpan: DEFAULT_MINIMUM_TAKE_SPAN,
 		})
 		expect(acceptedFormats).toEqual([
 			['1920', '1080', 'i', '5000', undefined],
@@ -169,7 +170,7 @@ describe('lib/mediaObjects', () => {
 			mediaPreviewsUrl: '',
 			supportedAudioStreams: '4',
 			frameRate: 25,
-			minimumTakeSpan: 1000,
+			minimumTakeSpan: DEFAULT_MINIMUM_TAKE_SPAN,
 		}
 
 		const mockDefaultStudio = defaultStudio(protectString('studio0'))

--- a/packages/corelib/src/dataModel/Studio.ts
+++ b/packages/corelib/src/dataModel/Studio.ts
@@ -43,6 +43,12 @@ export interface IStudioSettings {
 
 	/** Preserve unsynced segments psoition in the rundown, relative to the other segments */
 	preserveOrphanedSegmentPositionInRundown?: boolean
+
+	/**
+	 * The minimum amount of time, in milliseconds, that must pass after a take before another take may be performed.
+	 * Default: 1000
+	 */
+	minimumTakeSpan: number
 }
 
 export type StudioLight = Omit<DBStudio, 'mappingsWithOverrides' | 'blueprintConfigWithOverrides'>

--- a/packages/job-worker/src/__mocks__/defaultCollectionObjects.ts
+++ b/packages/job-worker/src/__mocks__/defaultCollectionObjects.ts
@@ -98,6 +98,7 @@ export function defaultStudio(_id: StudioId): DBStudio {
 		settings: {
 			frameRate: 25,
 			mediaPreviewsUrl: '',
+			minimumTakeSpan: 1000,
 		},
 		routeSets: {},
 		routeSetExclusivityGroups: {},

--- a/packages/job-worker/src/__mocks__/defaultCollectionObjects.ts
+++ b/packages/job-worker/src/__mocks__/defaultCollectionObjects.ts
@@ -21,6 +21,7 @@ import { getRundownId } from '../ingest/lib'
 import { getCurrentTime } from '../lib'
 import { IBlueprintPieceType, PieceLifespan, PlaylistTimingType } from '@sofie-automation/blueprints-integration'
 import { wrapDefaultObject } from '@sofie-automation/corelib/dist/settings/objectWithOverrides'
+import { DEFAULT_MINIMUM_TAKE_SPAN } from '@sofie-automation/shared-lib/dist/core/constants'
 
 export function defaultRundownPlaylist(_id: RundownPlaylistId, studioId: StudioId): DBRundownPlaylist {
 	return {
@@ -98,7 +99,7 @@ export function defaultStudio(_id: StudioId): DBStudio {
 		settings: {
 			frameRate: 25,
 			mediaPreviewsUrl: '',
-			minimumTakeSpan: 1000,
+			minimumTakeSpan: DEFAULT_MINIMUM_TAKE_SPAN,
 		},
 		routeSets: {},
 		routeSetExclusivityGroups: {},

--- a/packages/job-worker/src/blueprints/__tests__/config.test.ts
+++ b/packages/job-worker/src/blueprints/__tests__/config.test.ts
@@ -17,6 +17,7 @@ describe('Test blueprint config', () => {
 			settings: {
 				mediaPreviewsUrl: '',
 				frameRate: 25,
+				minimumTakeSpan: 1000,
 			},
 			blueprintConfigWithOverrides: wrapDefaultObject({ sdfsdf: 'one', another: 5 }),
 		})
@@ -39,6 +40,7 @@ describe('Test blueprint config', () => {
 			settings: {
 				mediaPreviewsUrl: '',
 				frameRate: 25,
+				minimumTakeSpan: 1000,
 			},
 			blueprintConfigWithOverrides: wrapDefaultObject({ sdfsdf: 'one', another: 5 }),
 		})
@@ -57,6 +59,7 @@ describe('Test blueprint config', () => {
 			core: {
 				hostUrl: 'https://sofie-in-jest:3000',
 				frameRate: 25,
+				// Some settings are omitted here because we currently don't bother exposing them to blueprints.
 			},
 			studio: {
 				sdfsdf: 'one',

--- a/packages/job-worker/src/blueprints/__tests__/config.test.ts
+++ b/packages/job-worker/src/blueprints/__tests__/config.test.ts
@@ -8,6 +8,7 @@ import {
 	retrieveBlueprintConfigRefs,
 } from '../config'
 import { wrapDefaultObject } from '@sofie-automation/corelib/dist/settings/objectWithOverrides'
+import { DEFAULT_MINIMUM_TAKE_SPAN } from '@sofie-automation/shared-lib/dist/core/constants'
 
 describe('Test blueprint config', () => {
 	test('compileStudioConfig', () => {
@@ -17,7 +18,7 @@ describe('Test blueprint config', () => {
 			settings: {
 				mediaPreviewsUrl: '',
 				frameRate: 25,
-				minimumTakeSpan: 1000,
+				minimumTakeSpan: DEFAULT_MINIMUM_TAKE_SPAN,
 			},
 			blueprintConfigWithOverrides: wrapDefaultObject({ sdfsdf: 'one', another: 5 }),
 		})
@@ -40,7 +41,7 @@ describe('Test blueprint config', () => {
 			settings: {
 				mediaPreviewsUrl: '',
 				frameRate: 25,
-				minimumTakeSpan: 1000,
+				minimumTakeSpan: DEFAULT_MINIMUM_TAKE_SPAN,
 			},
 			blueprintConfigWithOverrides: wrapDefaultObject({ sdfsdf: 'one', another: 5 }),
 		})

--- a/packages/job-worker/src/ingest/__tests__/ingest.test.ts
+++ b/packages/job-worker/src/ingest/__tests__/ingest.test.ts
@@ -35,7 +35,7 @@ import {
 	handleUpdatedSegment,
 	handleUpdatedSegmentRanks,
 } from '../../ingest/ingestSegmentJobs'
-import { setMinimumTakeSpan, handleTakeNextPart } from '../../playout/take'
+import { handleTakeNextPart } from '../../playout/take'
 import { handleActivateRundownPlaylist } from '../../playout/activePlaylistJobs'
 import { PartInstanceId, SegmentId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { getSelectedPartInstances } from '../../playout/__tests__/lib'
@@ -64,6 +64,10 @@ describe('Test ingest actions for rundowns and segments', () => {
 
 		context.setStudio({
 			...context.studio,
+			settings: {
+				...context.studio.settings,
+				minimumTakeSpan: 0,
+			},
 			supportedShowStyleBase: [showStyleCompound._id],
 		})
 
@@ -82,8 +86,6 @@ describe('Test ingest actions for rundowns and segments', () => {
 		)
 
 		jest.clearAllMocks()
-
-		setMinimumTakeSpan(0)
 	})
 
 	beforeEach(async () => {

--- a/packages/job-worker/src/playout/__tests__/playout.test.ts
+++ b/packages/job-worker/src/playout/__tests__/playout.test.ts
@@ -14,7 +14,7 @@ import { PartInstanceId, RundownId, RundownPlaylistId } from '@sofie-automation/
 import { fixSnapshot } from '../../__mocks__/helpers/snapshot'
 import { sortPartsInSortedSegments, sortSegmentsInRundowns } from '@sofie-automation/corelib/dist/playout/playlist'
 import { handleSetNextPart, handleMoveNextPart, handleSetNextSegment } from '../setNextJobs'
-import { setMinimumTakeSpan, handleTakeNextPart } from '../take'
+import { handleTakeNextPart } from '../take'
 import {
 	handleActivateRundownPlaylist,
 	handleDeactivateRundownPlaylist,
@@ -97,6 +97,14 @@ describe('Playout API', () => {
 	beforeEach(async () => {
 		context = setupDefaultJobEnvironment()
 
+		context.setStudio({
+			...context.studio,
+			settings: {
+				...context.studio.settings,
+				minimumTakeSpan: 0,
+			},
+		})
+
 		// Ignore event jobs
 		jest.spyOn(context, 'queueEventJob').mockImplementation(async () => Promise.resolve())
 
@@ -110,8 +118,6 @@ describe('Playout API', () => {
 		)
 
 		jest.clearAllMocks()
-
-		setMinimumTakeSpan(0)
 	})
 	afterEach(() => {
 		// mockGetCurrentTime.mockClear()

--- a/packages/job-worker/src/playout/take.ts
+++ b/packages/job-worker/src/playout/take.ts
@@ -33,12 +33,6 @@ import { processAndPrunePieceInstanceTimings } from '@sofie-automation/corelib/d
 import { TakeNextPartProps } from '@sofie-automation/corelib/dist/worker/studio'
 import { runJobWithPlayoutCache } from './lock'
 
-let MINIMUM_TAKE_SPAN = 1000
-export function setMinimumTakeSpan(span: number): void {
-	// Used in tests
-	MINIMUM_TAKE_SPAN = span
-}
-
 /**
  * Take the currently Next:ed Part (start playing it)
  */
@@ -76,13 +70,15 @@ export async function handleTakeNextPart(context: JobContext, data: TakeNextPart
 				}
 			}
 
-			if (lastTakeTime && now - lastTakeTime < MINIMUM_TAKE_SPAN) {
+			if (lastTakeTime && now - lastTakeTime < context.studio.settings.minimumTakeSpan) {
 				logger.debug(
-					`Time since last take is shorter than ${MINIMUM_TAKE_SPAN} for ${
+					`Time since last take is shorter than ${context.studio.settings.minimumTakeSpan} for ${
 						playlist.currentPartInfo?.partInstanceId
 					}: ${now - lastTakeTime}`
 				)
-				throw UserError.create(UserErrorMessage.TakeRateLimit, { duration: MINIMUM_TAKE_SPAN })
+				throw UserError.create(UserErrorMessage.TakeRateLimit, {
+					duration: context.studio.settings.minimumTakeSpan,
+				})
 			}
 
 			return performTakeToNextedPart(context, cache, now)

--- a/packages/shared-lib/src/core/constants.ts
+++ b/packages/shared-lib/src/core/constants.ts
@@ -15,3 +15,6 @@ export const DEFAULT_NRCS_TIMEOUT_TIME = 10 * 1000
 
 /** After this time, actions executed by the TSR are considered to have timed out */
 export const DEFAULT_TSR_ACTION_TIMEOUT_TIME = 5 * 1000
+
+/** How much time must pass, in milliseconds, after a take before another take is allowed */
+export const DEFAULT_MINIMUM_TAKE_SPAN = 1000


### PR DESCRIPTION
This PR is being opened on behalf of TV 2 Norge.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

The minimum take span is hardcoded to 1000ms.

* **What is the new behavior (if this is a feature change)?**

The minimum take span may now be configured on a per-studio basis:
![image](https://github.com/nrkno/sofie-core/assets/873012/bbfe06f3-d995-4c04-b579-75fd8dffee4b)

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
