### PR TITLE
fix(Timing): expectedDuration=0 members of displayDuration groups countdown don't inherit displayDurationGroup duration

### DIFF
--- a/meteor/client/lib/rundownTiming.ts
+++ b/meteor/client/lib/rundownTiming.ts
@@ -276,15 +276,6 @@ export class RundownTimingCalculator {
 						(partInstance.timings?.plannedStoppedPlayback
 							? lastStartedPlayback - partInstance.timings?.plannedStoppedPlayback
 							: undefined)
-					currentRemaining = Math.max(
-						0,
-						(duration ||
-							(memberOfDisplayDurationGroup
-								? displayDurationFromGroup
-								: calculatePartInstanceExpectedDurationWithPreroll(partInstance, piecesForPart)) ||
-							0) -
-							(now - lastStartedPlayback)
-					)
 					partDuration =
 						Math.max(
 							duration ||
@@ -318,7 +309,7 @@ export class RundownTimingCalculator {
 					} else {
 						currentRemaining = Math.max(
 							0,
-							(partInstance.timings?.duration ||
+							(duration ||
 								(memberOfDisplayDurationGroup
 									? displayDurationFromGroup
 									: calculatePartInstanceExpectedDurationWithPreroll(partInstance, piecesForPart)) ||
@@ -620,9 +611,12 @@ export class RundownTimingCalculator {
 				currentLivePartInstance.timings?.duration ||
 				calculatePartInstanceExpectedDurationWithPreroll(currentLivePartInstance, piecesForPart) ||
 				0
-			if (currentLivePart.displayDurationGroup) {
+			if (
+				currentLivePart.displayDurationGroup &&
+				(currentLivePart.expectedDuration === undefined || currentLivePart.expectedDuration === 0)
+			) {
 				onAirPartDuration =
-					this.partExpectedDurations[unprotectString(currentLivePart._id)] || onAirPartDuration
+					this.partDisplayDurationsNoPlayback[unprotectString(currentLivePart._id)] || onAirPartDuration
 			}
 
 			remainingTimeOnCurrentPart =

--- a/meteor/client/ui/SegmentList/LinePartTimeline.tsx
+++ b/meteor/client/ui/SegmentList/LinePartTimeline.tsx
@@ -83,10 +83,12 @@ export const LinePartTimeline: React.FC<IProps> = function LinePartTimeline({
 	const transitionPiece = useMemo(() => findTransitionPiece(part.pieces), [part.pieces])
 	const timedGraphics = useMemo(() => findTimedGraphics(part.pieces), [part.pieces])
 
-	const partDuration = part.renderedDuration
+	const timings = part.instance.partPlayoutTimings
+	const toPartDelay = (timings?.toPartDelay ?? 0) - ((timings?.fromPartRemaining ?? 0) - (timings?.toPartDelay ?? 0))
+	const renderedPartDuration = part.renderedDuration + toPartDelay
 	const mainPieceSourceDuration = mainPiece?.instance.piece.content.sourceDuration
 	const mainPieceInPoint = mainPiece?.renderedInPoint
-	const maxDuration = Math.max((mainPieceInPoint ?? 0) + (mainPieceSourceDuration ?? 0), partDuration)
+	const maxDuration = Math.max((mainPieceInPoint ?? 0) + (mainPieceSourceDuration ?? 0), renderedPartDuration)
 	const timelineBase = Math.max(TIMELINE_DEFAULT_BASE, maxDuration)
 
 	const willAutoNextIntoThisPart = isNext ? currentPartWillAutonext : part.willProbablyAutoNext
@@ -110,7 +112,7 @@ export const LinePartTimeline: React.FC<IProps> = function LinePartTimeline({
 					key={unprotectString(piece.instance._id)}
 					piece={piece}
 					timelineBase={timelineBase}
-					partDuration={partDuration}
+					partDuration={renderedPartDuration}
 					onClick={onPieceClick}
 					onDoubleClick={onPieceDoubleClick}
 				/>
@@ -124,7 +126,7 @@ export const LinePartTimeline: React.FC<IProps> = function LinePartTimeline({
 							partInstanceId={part.instance._id}
 							studio={studio}
 							timelineBase={timelineBase}
-							partDuration={partDuration}
+							partDuration={renderedPartDuration}
 							capToPartDuration={part.instance.part.autoNext ?? false}
 							isLive={isLive}
 						/>
@@ -141,16 +143,16 @@ export const LinePartTimeline: React.FC<IProps> = function LinePartTimeline({
 					partId={part.instance.part._id}
 					timelineBase={timelineBase}
 					maxDuration={maxDuration}
-					mainSourceEnd={mainSourceEnd ?? partDuration}
+					mainSourceEnd={mainSourceEnd ?? renderedPartDuration}
 					endsInFreeze={endsInFreeze}
 					isPartZeroBudget={isPartZeroBudget}
-					partRenderedDuration={partDuration}
+					partRenderedDuration={renderedPartDuration}
 					partActualDuration={part.instance.timings?.duration}
 					isLive={isLive}
 					hasAlreadyPlayed={hasAlreadyPlayed}
 				/>
 			)}
-			{willAutoNextOut && <PartAutoNextMarker partDuration={partDuration} timelineBase={timelineBase} />}
+			{willAutoNextOut && <PartAutoNextMarker partDuration={renderedPartDuration} timelineBase={timelineBase} />}
 			{isLive && (
 				<OnAirLine
 					partInstance={part.instance}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bugfix

* **What is the current behavior?** (You can also link to an open issue here)

If a Part has `expectedDuration: 0` the countdown to the end of that Part, next to the "onAir" line, always counts from "0:00" and up.

* **What is the new behavior (if this is a feature change)?**

If a Part has `expectedDuration: 0` and is a member of a displayDurationGroup, the countdown will start at whetever is left in that displayDurationGroup and count down "through" "0:00" and up.

* **Other information**:

Also, some duplicated code was removed in the rundown timing calculator.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
