### PR TITLE
fix: Duration update while on air trips up autonext (Sofie 1599)

### DIFF
--- a/packages/job-worker/src/blueprints/context/SyncIngestUpdateToPartInstanceContext.ts
+++ b/packages/job-worker/src/blueprints/context/SyncIngestUpdateToPartInstanceContext.ts
@@ -221,6 +221,14 @@ export class SyncIngestUpdateToPartInstanceContext
 
 		if (!this.partInstance) throw new Error(`PartInstance has been removed`)
 
+		// for autoNext, the new expectedDuration cannot be shorter than the time a part has been on-air for
+		if (trimmedProps.expectedDuration && (trimmedProps.autoNext ?? this.partInstance.part.autoNext)) {
+			const onAir = this.partInstance.timings?.reportedStartedPlayback
+			if (onAir && Date.now() - onAir > trimmedProps.expectedDuration) {
+				trimmedProps.expectedDuration = Date.now() - onAir
+			}
+		}
+
 		this._partInstanceCache.updateOne(this.partInstance._id, (p) => {
 			return {
 				...p,

--- a/packages/job-worker/src/blueprints/context/SyncIngestUpdateToPartInstanceContext.ts
+++ b/packages/job-worker/src/blueprints/context/SyncIngestUpdateToPartInstanceContext.ts
@@ -35,6 +35,7 @@ import {
 	PieceTimelineObjectsBlob,
 	serializePieceTimelineObjectsBlob,
 } from '@sofie-automation/corelib/dist/dataModel/Piece'
+import { EXPECTED_INGEST_TO_PLAYOUT_TIME } from '@sofie-automation/shared-lib/dist/core/constants'
 
 export class SyncIngestUpdateToPartInstanceContext
 	extends RundownUserContext
@@ -224,8 +225,9 @@ export class SyncIngestUpdateToPartInstanceContext
 		// for autoNext, the new expectedDuration cannot be shorter than the time a part has been on-air for
 		if (trimmedProps.expectedDuration && (trimmedProps.autoNext ?? this.partInstance.part.autoNext)) {
 			const onAir = this.partInstance.timings?.reportedStartedPlayback
-			if (onAir && Date.now() - onAir > trimmedProps.expectedDuration) {
-				trimmedProps.expectedDuration = Date.now() - onAir
+			const minTime = Date.now() - (onAir ?? 0) + EXPECTED_INGEST_TO_PLAYOUT_TIME
+			if (onAir && minTime > trimmedProps.expectedDuration) {
+				trimmedProps.expectedDuration = minTime
 			}
 		}
 

--- a/packages/shared-lib/src/core/constants.ts
+++ b/packages/shared-lib/src/core/constants.ts
@@ -18,3 +18,6 @@ export const DEFAULT_TSR_ACTION_TIMEOUT_TIME = 5 * 1000
 
 /** How much time must pass, in milliseconds, after a take before another take is allowed */
 export const DEFAULT_MINIMUM_TAKE_SPAN = 1000
+
+/** The expected time it takes from an ingest operation to receiving a new timeline in the playout-gateway */
+export const EXPECTED_INGEST_TO_PLAYOUT_TIME = 500


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR makes sure a blueprint can not update the length of an autonext part instance to be shorter than the time it has been on-air for

* **What is the current behavior?** (You can also link to an open issue here)

Setting a shorter time is allowed and doing this will cause the playout-gateway to believe the next part should have been playing for x seconds already, which looks _quite_ ugly on air.

* **What is the new behavior (if this is a feature change)?**



* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
