### PR TITLE
fix: add fallback for unknown package statues SOFIE-2468

### DIFF
--- a/meteor/lib/mediaObjects.ts
+++ b/meteor/lib/mediaObjects.ts
@@ -320,6 +320,13 @@ export function checkPieceContentStatus(
 							})
 						} else {
 							assertNever(packageOnPackageContainer.status.status)
+							messages.push({
+								status: PieceStatusCode.SOURCE_MISSING,
+								message: t('{{sourceLayer}} has an unknown state "{{status}}", may not be playable', {
+									sourceLayer: sourceLayer.name,
+									status: packageOnPackageContainer.status.status,
+								}),
+							})
 						}
 					}
 				}

--- a/meteor/lib/mediaObjects.ts
+++ b/meteor/lib/mediaObjects.ts
@@ -320,6 +320,8 @@ export function checkPieceContentStatus(
 							})
 						} else {
 							assertNever(packageOnPackageContainer.status.status)
+							// NOTE: This is a temporary workaround for a bug that meant that an unknown status would
+							// produce a "no-zebra" state
 							messages.push({
 								status: PieceStatusCode.SOURCE_MISSING,
 								message: t('{{sourceLayer}} has an unknown state "{{status}}", may not be playable', {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

If Package Manager produces a Package Status with a value unknown to Core, the Piece will be shown without zebras, as that will register as an "UNKNOWN" state.

* **What is the new behavior (if this is a feature change)?**

An unknown Package Status will be translated to a `SOURCE_MISSING` Piece status.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
