### PR TITLE
feat: add `prompterTitle` property SOFIE-2404

### DIFF
--- a/meteor/client/ui/Prompter/prompter.ts
+++ b/meteor/client/ui/Prompter/prompter.ts
@@ -184,7 +184,7 @@ export namespace PrompterAPI {
 				const partInstance = partInstances[partIndex]
 				const partData: PrompterDataPart = {
 					id: partInstance._id,
-					title: partInstance.part.title,
+					title: partInstance.part.prompterTitle || partInstance.part.title,
 					pieces: [],
 				}
 

--- a/packages/blueprints-integration/src/documents/part.ts
+++ b/packages/blueprints-integration/src/documents/part.ts
@@ -26,6 +26,12 @@ export enum PartHoldMode {
 export interface IBlueprintMutatablePart<TMetadata = unknown> {
 	/** The story title */
 	title: string
+	/**
+	 * The story title to show in the prompter
+	 * If unset, `title` is used instead
+	 */
+	prompterTitle?: string
+
 	/** Arbitrary data storage for plugins */
 	metaData?: TMetadata
 

--- a/packages/job-worker/src/blueprints/context/lib.ts
+++ b/packages/job-worker/src/blueprints/context/lib.ts
@@ -79,6 +79,7 @@ export const IBlueprintPieceObjectsSampleKeys = allKeysOfObject<IBlueprintPiece>
 // Compile a list of the keys which are allowed to be set
 export const IBlueprintMutatablePartSampleKeys = allKeysOfObject<IBlueprintMutatablePart>({
 	title: true,
+	prompterTitle: true,
 	metaData: true,
 	autoNext: true,
 	autoNextOverlap: true,
@@ -233,6 +234,7 @@ export function convertPartToBlueprints(part: DBPart): IBlueprintPartDB {
 		floated: part.floated,
 		gap: part.gap,
 		title: part.title,
+		prompterTitle: part.prompterTitle,
 		metaData: clone(part.metaData),
 		autoNext: part.autoNext,
 		autoNextOverlap: part.autoNextOverlap,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

* **What is the new behavior (if this is a feature change)?**

The same part title is used for the prompter, countdown and rundown views.

However, in the prompter we don't have any more information about the part other than the title (elsewhere we have at least the type).  

This lets the blueprints specify a part title specifically for the prompter. This can be as detailed or not as they wish. If unset, the normal title property is used, so this will have no impact unless explicitly set.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
