### PR TITLE
fix: custom publications overly reactive

### DIFF
--- a/meteor/server/publications/packageManager/expectedPackages/contentCache.ts
+++ b/meteor/server/publications/packageManager/expectedPackages/contentCache.ts
@@ -1,5 +1,3 @@
-import { Meteor } from 'meteor/meteor'
-import _ from 'underscore'
 import { ReactiveCacheCollection } from '../../lib/ReactiveCacheCollection'
 import { literal } from '@sofie-automation/corelib/dist/lib'
 import { MongoFieldSpecifierOnesStrict } from '@sofie-automation/corelib/dist/mongo'
@@ -36,31 +34,12 @@ export interface ExpectedPackagesContentCache {
 	PieceInstances: ReactiveCacheCollection<PieceInstanceCompact>
 }
 
-type ReactionWithCache = (cache: ExpectedPackagesContentCache) => void
-
-export function createReactiveContentCache(
-	reaction: ReactionWithCache,
-	reactivityDebounce: number
-): { cache: ExpectedPackagesContentCache; cancel: () => void } {
-	let isCancelled = false
-	const innerReaction = _.debounce(
-		Meteor.bindEnvironment(() => {
-			if (!isCancelled) reaction(cache)
-		}),
-		reactivityDebounce
-	)
-	const cancel = () => {
-		isCancelled = true
-		innerReaction.cancel()
-	}
-
+export function createReactiveContentCache(): ExpectedPackagesContentCache {
 	const cache: ExpectedPackagesContentCache = {
-		ExpectedPackages: new ReactiveCacheCollection<ExpectedPackageDB>('expectedPackages', innerReaction),
-		RundownPlaylists: new ReactiveCacheCollection<RundownPlaylistCompact>('rundownPlaylists', innerReaction),
-		PieceInstances: new ReactiveCacheCollection<PieceInstanceCompact>('pieceInstances', innerReaction),
+		ExpectedPackages: new ReactiveCacheCollection<ExpectedPackageDB>('expectedPackages'),
+		RundownPlaylists: new ReactiveCacheCollection<RundownPlaylistCompact>('rundownPlaylists'),
+		PieceInstances: new ReactiveCacheCollection<PieceInstanceCompact>('pieceInstances'),
 	}
 
-	innerReaction()
-
-	return { cache, cancel }
+	return cache
 }

--- a/meteor/server/publications/pieceContentStatusUI/bucket/bucketContentCache.ts
+++ b/meteor/server/publications/pieceContentStatusUI/bucket/bucketContentCache.ts
@@ -1,5 +1,3 @@
-import { Meteor } from 'meteor/meteor'
-import _ from 'underscore'
 import { ReactiveCacheCollection } from '../../lib/ReactiveCacheCollection'
 import { DBShowStyleBase, SourceLayers } from '@sofie-automation/corelib/dist/dataModel/ShowStyleBase'
 import { ProtectedString } from '@sofie-automation/corelib/dist/protectedString'
@@ -63,34 +61,14 @@ export interface BucketContentCache {
 	ShowStyleSourceLayers: ReactiveCacheCollection<SourceLayersDoc>
 }
 
-type ReactionWithCache = (cache: BucketContentCache) => void
-
-export function createReactiveContentCache(
-	reaction: ReactionWithCache,
-	reactivityDebounce: number
-): { cache: BucketContentCache; cancel: () => void } {
-	let isCancelled = false
-	const innerReaction = _.debounce(
-		Meteor.bindEnvironment(() => {
-			if (!isCancelled) reaction(cache)
-		}),
-		reactivityDebounce
-	)
-	const cancel = () => {
-		isCancelled = true
-		innerReaction.cancel()
-	}
-
+export function createReactiveContentCache(): BucketContentCache {
 	const cache: BucketContentCache = {
-		BucketAdLibs: new ReactiveCacheCollection<Pick<BucketAdLib, BucketAdLibFields>>('bucketAdlibs', innerReaction),
+		BucketAdLibs: new ReactiveCacheCollection<Pick<BucketAdLib, BucketAdLibFields>>('bucketAdlibs'),
 		BucketAdLibActions: new ReactiveCacheCollection<Pick<BucketAdLibAction, BucketActionFields>>(
-			'bucketAdlibActions',
-			innerReaction
+			'bucketAdlibActions'
 		),
-		ShowStyleSourceLayers: new ReactiveCacheCollection<SourceLayersDoc>('sourceLayers', innerReaction),
+		ShowStyleSourceLayers: new ReactiveCacheCollection<SourceLayersDoc>('sourceLayers'),
 	}
 
-	innerReaction()
-
-	return { cache, cancel }
+	return cache
 }

--- a/meteor/server/publications/pieceContentStatusUI/bucket/bucketContentObserver.ts
+++ b/meteor/server/publications/pieceContentStatusUI/bucket/bucketContentObserver.ts
@@ -5,7 +5,6 @@ import {
 	bucketActionFieldSpecifier,
 	bucketAdlibFieldSpecifier,
 	BucketContentCache,
-	createReactiveContentCache,
 	ShowStyleBaseFields,
 	showStyleBaseFieldSpecifier,
 	SourceLayersDoc,
@@ -19,8 +18,6 @@ import _ from 'underscore'
 
 const REACTIVITY_DEBOUNCE = 20
 
-type ChangedHandler = (cache: BucketContentCache) => () => void
-
 function convertShowStyleBase(doc: Pick<DBShowStyleBase, ShowStyleBaseFields>): Omit<SourceLayersDoc, '_id'> {
 	return {
 		blueprintId: doc.blueprintId,
@@ -31,20 +28,13 @@ function convertShowStyleBase(doc: Pick<DBShowStyleBase, ShowStyleBaseFields>): 
 export class BucketContentObserver implements Meteor.LiveQueryHandle {
 	#observers: Meteor.LiveQueryHandle[] = []
 	#cache: BucketContentCache
-	#cancelCache: () => void
-	#cleanup: () => void
 
 	#showStyleBaseIds: ShowStyleBaseId[] = []
 	#showStyleBaseIdObserver: ReactiveMongoObserverGroupHandle
 
-	constructor(bucketId: BucketId, onChanged: ChangedHandler) {
+	constructor(bucketId: BucketId, cache: BucketContentCache) {
 		logger.silly(`Creating BucketContentObserver for "${bucketId}"`)
-		const { cache, cancel: cancelCache } = createReactiveContentCache((cache) => {
-			this.#cleanup = onChanged(cache)
-		}, REACTIVITY_DEBOUNCE)
-
 		this.#cache = cache
-		this.#cancelCache = cancelCache
 
 		// Run the ShowStyleBase query in a ReactiveMongoObserverGroup, so that it can be restarted whenever
 		this.#showStyleBaseIdObserver = waitForPromise(
@@ -136,8 +126,6 @@ export class BucketContentObserver implements Meteor.LiveQueryHandle {
 	}
 
 	public stop = (): void => {
-		this.#cancelCache()
 		this.#observers.forEach((observer) => observer.stop())
-		this.#cleanup()
 	}
 }

--- a/meteor/server/publications/pieceContentStatusUI/rundown/publication.ts
+++ b/meteor/server/publications/pieceContentStatusUI/rundown/publication.ts
@@ -469,7 +469,7 @@ meteorCustomPublish(
 				setupUIPieceContentStatusesPublicationObservers,
 				manipulateUIPieceContentStatusesPublicationData,
 				pub,
-				500
+				100
 			)
 		} else {
 			logger.warn(`Pub.${CustomCollectionName.UIPieceContentStatuses}: Not allowed: "${rundownPlaylistId}"`)

--- a/meteor/server/publications/pieceContentStatusUI/rundown/publication.ts
+++ b/meteor/server/publications/pieceContentStatusUI/rundown/publication.ts
@@ -33,7 +33,7 @@ import { logger } from '../../../logging'
 import { resolveCredentials } from '../../../security/lib/credentials'
 import { NoSecurityReadAccess } from '../../../security/noSecurity'
 import { RundownPlaylistReadAccess } from '../../../security/rundownPlaylist'
-import { ContentCache } from './reactiveContentCache'
+import { ContentCache, createReactiveContentCache } from './reactiveContentCache'
 import { RundownContentObserver } from './rundownContentObserver'
 import { RundownsObserver } from '../../lib/rundownsObserver'
 import { LiveQueryHandle } from '../../../lib/lib'
@@ -121,72 +121,72 @@ async function setupUIPieceContentStatusesPublicationObservers(
 
 	const rundownsObserver = new RundownsObserver(playlist.studioId, playlist._id, (rundownIds) => {
 		logger.silly(`Creating new RundownContentObserver`)
-		const obs1 = new RundownContentObserver(rundownIds, (cache) => {
-			// Push update
-			triggerUpdate({ newCache: cache })
 
-			const innerQueries = [
-				cache.Segments.find({}).observeChanges({
-					added: (id) => triggerUpdate({ updatedSegmentIds: [protectString(id)] }),
-					changed: (id) => triggerUpdate({ updatedSegmentIds: [protectString(id)] }),
-					removed: (id) => triggerUpdate({ updatedSegmentIds: [protectString(id)] }),
-				}),
-				cache.Parts.find({}).observeChanges({
-					added: (id) => triggerUpdate({ updatedPartIds: [protectString(id)] }),
-					changed: (id) => triggerUpdate({ updatedPartIds: [protectString(id)] }),
-					removed: (id) => triggerUpdate({ updatedSegmentIds: [protectString(id)] }),
-				}),
-				cache.Pieces.find({}).observeChanges({
-					added: (id) => triggerUpdate({ updatedPieceIds: [protectString(id)] }),
-					changed: (id) => triggerUpdate({ updatedPieceIds: [protectString(id)] }),
-					removed: (id) => triggerUpdate({ updatedPieceIds: [protectString(id)] }),
-				}),
-				cache.PieceInstances.find({}).observeChanges({
-					added: (id) => triggerUpdate({ updatedPieceInstanceIds: [protectString(id)] }),
-					changed: (id) => triggerUpdate({ updatedPieceInstanceIds: [protectString(id)] }),
-					removed: (id) => triggerUpdate({ updatedPieceInstanceIds: [protectString(id)] }),
-				}),
-				cache.AdLibPieces.find({}).observeChanges({
-					added: (id) => triggerUpdate({ updatedAdlibPieceIds: [protectString(id)] }),
-					changed: (id) => triggerUpdate({ updatedAdlibPieceIds: [protectString(id)] }),
-					removed: (id) => triggerUpdate({ updatedAdlibPieceIds: [protectString(id)] }),
-				}),
-				cache.AdLibActions.find({}).observeChanges({
-					added: (id) => triggerUpdate({ updatedAdlibActionIds: [protectString(id)] }),
-					changed: (id) => triggerUpdate({ updatedAdlibActionIds: [protectString(id)] }),
-					removed: (id) => triggerUpdate({ updatedAdlibActionIds: [protectString(id)] }),
-				}),
-				cache.BaselineAdLibPieces.find({}).observeChanges({
-					added: (id) => triggerUpdate({ updatedBaselineAdlibPieceIds: [protectString(id)] }),
-					changed: (id) => triggerUpdate({ updatedBaselineAdlibPieceIds: [protectString(id)] }),
-					removed: (id) => triggerUpdate({ updatedBaselineAdlibPieceIds: [protectString(id)] }),
-				}),
-				cache.BaselineAdLibActions.find({}).observeChanges({
-					added: (id) => triggerUpdate({ updatedBaselineAdlibActionIds: [protectString(id)] }),
-					changed: (id) => triggerUpdate({ updatedBaselineAdlibActionIds: [protectString(id)] }),
-					removed: (id) => triggerUpdate({ updatedBaselineAdlibActionIds: [protectString(id)] }),
-				}),
-				cache.Rundowns.find({}).observeChanges({
-					added: () => triggerUpdate({ invalidateAll: true }),
-					changed: () => triggerUpdate({ invalidateAll: true }),
-					removed: () => triggerUpdate({ invalidateAll: true }),
-				}),
-				cache.ShowStyleSourceLayers.find({}).observeChanges({
-					added: () => triggerUpdate({ invalidateAll: true }),
-					changed: () => triggerUpdate({ invalidateAll: true }),
-					removed: () => triggerUpdate({ invalidateAll: true }),
-				}),
-			]
+		// TODO - can this be done cheaper?
+		const contentCache = createReactiveContentCache()
+		triggerUpdate({ newCache: contentCache })
 
-			return () => {
-				for (const query of innerQueries) {
-					query.stop()
-				}
-			}
-		})
+		const obs1 = new RundownContentObserver(rundownIds, contentCache)
+
+		const innerQueries = [
+			contentCache.Segments.find({}).observeChanges({
+				added: (id) => triggerUpdate({ updatedSegmentIds: [protectString(id)] }),
+				changed: (id) => triggerUpdate({ updatedSegmentIds: [protectString(id)] }),
+				removed: (id) => triggerUpdate({ updatedSegmentIds: [protectString(id)] }),
+			}),
+			contentCache.Parts.find({}).observeChanges({
+				added: (id) => triggerUpdate({ updatedPartIds: [protectString(id)] }),
+				changed: (id) => triggerUpdate({ updatedPartIds: [protectString(id)] }),
+				removed: (id) => triggerUpdate({ updatedSegmentIds: [protectString(id)] }),
+			}),
+			contentCache.Pieces.find({}).observeChanges({
+				added: (id) => triggerUpdate({ updatedPieceIds: [protectString(id)] }),
+				changed: (id) => triggerUpdate({ updatedPieceIds: [protectString(id)] }),
+				removed: (id) => triggerUpdate({ updatedPieceIds: [protectString(id)] }),
+			}),
+			contentCache.PieceInstances.find({}).observeChanges({
+				added: (id) => triggerUpdate({ updatedPieceInstanceIds: [protectString(id)] }),
+				changed: (id) => triggerUpdate({ updatedPieceInstanceIds: [protectString(id)] }),
+				removed: (id) => triggerUpdate({ updatedPieceInstanceIds: [protectString(id)] }),
+			}),
+			contentCache.AdLibPieces.find({}).observeChanges({
+				added: (id) => triggerUpdate({ updatedAdlibPieceIds: [protectString(id)] }),
+				changed: (id) => triggerUpdate({ updatedAdlibPieceIds: [protectString(id)] }),
+				removed: (id) => triggerUpdate({ updatedAdlibPieceIds: [protectString(id)] }),
+			}),
+			contentCache.AdLibActions.find({}).observeChanges({
+				added: (id) => triggerUpdate({ updatedAdlibActionIds: [protectString(id)] }),
+				changed: (id) => triggerUpdate({ updatedAdlibActionIds: [protectString(id)] }),
+				removed: (id) => triggerUpdate({ updatedAdlibActionIds: [protectString(id)] }),
+			}),
+			contentCache.BaselineAdLibPieces.find({}).observeChanges({
+				added: (id) => triggerUpdate({ updatedBaselineAdlibPieceIds: [protectString(id)] }),
+				changed: (id) => triggerUpdate({ updatedBaselineAdlibPieceIds: [protectString(id)] }),
+				removed: (id) => triggerUpdate({ updatedBaselineAdlibPieceIds: [protectString(id)] }),
+			}),
+			contentCache.BaselineAdLibActions.find({}).observeChanges({
+				added: (id) => triggerUpdate({ updatedBaselineAdlibActionIds: [protectString(id)] }),
+				changed: (id) => triggerUpdate({ updatedBaselineAdlibActionIds: [protectString(id)] }),
+				removed: (id) => triggerUpdate({ updatedBaselineAdlibActionIds: [protectString(id)] }),
+			}),
+			contentCache.Rundowns.find({}).observeChanges({
+				added: () => triggerUpdate({ invalidateAll: true }),
+				changed: () => triggerUpdate({ invalidateAll: true }),
+				removed: () => triggerUpdate({ invalidateAll: true }),
+			}),
+			contentCache.ShowStyleSourceLayers.find({}).observeChanges({
+				added: () => triggerUpdate({ invalidateAll: true }),
+				changed: () => triggerUpdate({ invalidateAll: true }),
+				removed: () => triggerUpdate({ invalidateAll: true }),
+			}),
+		]
 
 		return () => {
 			obs1.dispose()
+
+			for (const query of innerQueries) {
+				query.stop()
+			}
 		}
 	})
 
@@ -469,7 +469,7 @@ meteorCustomPublish(
 				setupUIPieceContentStatusesPublicationObservers,
 				manipulateUIPieceContentStatusesPublicationData,
 				pub,
-				100
+				500
 			)
 		} else {
 			logger.warn(`Pub.${CustomCollectionName.UIPieceContentStatuses}: Not allowed: "${rundownPlaylistId}"`)

--- a/meteor/server/publications/pieceContentStatusUI/rundown/reactiveContentCache.ts
+++ b/meteor/server/publications/pieceContentStatusUI/rundown/reactiveContentCache.ts
@@ -1,5 +1,3 @@
-import { Meteor } from 'meteor/meteor'
-import _ from 'underscore'
 import { DBPart } from '@sofie-automation/corelib/dist/dataModel/Part'
 import { DBSegment } from '@sofie-automation/corelib/dist/dataModel/Segment'
 import { Piece } from '@sofie-automation/corelib/dist/dataModel/Piece'
@@ -120,47 +118,21 @@ export interface ContentCache {
 	ShowStyleSourceLayers: ReactiveCacheCollection<SourceLayersDoc>
 }
 
-type ReactionWithCache = (cache: ContentCache) => void
-
-export function createReactiveContentCache(
-	reaction: ReactionWithCache,
-	reactivityDebounce: number
-): { cache: ContentCache; cancel: () => void } {
-	let isCancelled = false
-	const innerReaction = _.debounce(
-		Meteor.bindEnvironment(() => {
-			if (!isCancelled) reaction(cache)
-		}),
-		reactivityDebounce
-	)
-	const cancel = () => {
-		isCancelled = true
-		innerReaction.cancel()
-	}
-
+export function createReactiveContentCache(): ContentCache {
 	const cache: ContentCache = {
-		Rundowns: new ReactiveCacheCollection<Pick<Rundown, RundownFields>>('rundowns', innerReaction),
-		Segments: new ReactiveCacheCollection<Pick<DBSegment, SegmentFields>>('segments', innerReaction),
-		Parts: new ReactiveCacheCollection<Pick<DBPart, PartFields>>('parts', innerReaction),
-		Pieces: new ReactiveCacheCollection<Pick<Piece, PieceFields>>('pieces', innerReaction),
-		PieceInstances: new ReactiveCacheCollection<Pick<PieceInstance, PieceInstanceFields>>(
-			'pieceInstances',
-			innerReaction
-		),
-		AdLibPieces: new ReactiveCacheCollection<Pick<AdLibPiece, AdLibPieceFields>>('adlibPieces', innerReaction),
-		AdLibActions: new ReactiveCacheCollection<Pick<AdLibAction, AdLibActionFields>>('adlibActions', innerReaction),
-		BaselineAdLibPieces: new ReactiveCacheCollection<Pick<AdLibPiece, AdLibPieceFields>>(
-			'baselineAdlibPieces',
-			innerReaction
-		),
+		Rundowns: new ReactiveCacheCollection<Pick<Rundown, RundownFields>>('rundowns'),
+		Segments: new ReactiveCacheCollection<Pick<DBSegment, SegmentFields>>('segments'),
+		Parts: new ReactiveCacheCollection<Pick<DBPart, PartFields>>('parts'),
+		Pieces: new ReactiveCacheCollection<Pick<Piece, PieceFields>>('pieces'),
+		PieceInstances: new ReactiveCacheCollection<Pick<PieceInstance, PieceInstanceFields>>('pieceInstances'),
+		AdLibPieces: new ReactiveCacheCollection<Pick<AdLibPiece, AdLibPieceFields>>('adlibPieces'),
+		AdLibActions: new ReactiveCacheCollection<Pick<AdLibAction, AdLibActionFields>>('adlibActions'),
+		BaselineAdLibPieces: new ReactiveCacheCollection<Pick<AdLibPiece, AdLibPieceFields>>('baselineAdlibPieces'),
 		BaselineAdLibActions: new ReactiveCacheCollection<Pick<RundownBaselineAdLibAction, AdLibActionFields>>(
-			'baselineAdlibActions',
-			innerReaction
+			'baselineAdlibActions'
 		),
-		ShowStyleSourceLayers: new ReactiveCacheCollection<SourceLayersDoc>('sourceLayers', innerReaction),
+		ShowStyleSourceLayers: new ReactiveCacheCollection<SourceLayersDoc>('sourceLayers'),
 	}
 
-	innerReaction()
-
-	return { cache, cancel }
+	return cache
 }

--- a/meteor/server/publications/segmentPartNotesUI/publication.ts
+++ b/meteor/server/publications/segmentPartNotesUI/publication.ts
@@ -69,6 +69,7 @@ async function setupUISegmentPartNotesPublicationObservers(
 	const rundownsObserver = new RundownsObserver(playlist.studioId, playlist._id, (rundownIds) => {
 		logger.silly(`Creating new RundownContentObserver`)
 
+		// TODO - can this be done cheaper?
 		const cache = createReactiveContentCache()
 
 		// Push update
@@ -100,11 +101,11 @@ async function setupUISegmentPartNotesPublicationObservers(
 		]
 
 		return () => {
+			obs1.dispose()
+
 			for (const query of innerQueries) {
 				query.stop()
 			}
-
-			obs1.dispose()
 		}
 	})
 

--- a/meteor/server/publications/segmentPartNotesUI/reactiveContentCache.ts
+++ b/meteor/server/publications/segmentPartNotesUI/reactiveContentCache.ts
@@ -1,5 +1,3 @@
-import { Meteor } from 'meteor/meteor'
-import _ from 'underscore'
 import { DBPart } from '@sofie-automation/corelib/dist/dataModel/Part'
 import { DBSegment } from '@sofie-automation/corelib/dist/dataModel/Segment'
 import { ReactiveCacheCollection } from '../lib/ReactiveCacheCollection'
@@ -57,35 +55,15 @@ export interface ContentCache {
 	DeletedPartInstances: ReactiveCacheCollection<Pick<PartInstance, PartInstanceFields>>
 }
 
-type ReactionWithCache = (cache: ContentCache) => void
-
-export function createReactiveContentCache(
-	reaction: ReactionWithCache,
-	reactivityDebounce: number
-): { cache: ContentCache; cancel: () => void } {
-	let isCancelled = false
-	const innerReaction = _.debounce(
-		Meteor.bindEnvironment(() => {
-			if (!isCancelled) reaction(cache)
-		}),
-		reactivityDebounce
-	)
-	const cancel = () => {
-		isCancelled = true
-		innerReaction.cancel()
-	}
-
+export function createReactiveContentCache(): ContentCache {
 	const cache: ContentCache = {
-		Rundowns: new ReactiveCacheCollection<Pick<Rundown, RundownFields>>('rundowns', innerReaction),
-		Segments: new ReactiveCacheCollection<Pick<DBSegment, SegmentFields>>('segments', innerReaction),
-		Parts: new ReactiveCacheCollection<Pick<DBPart, PartFields>>('parts', innerReaction),
+		Rundowns: new ReactiveCacheCollection<Pick<Rundown, RundownFields>>('rundowns'),
+		Segments: new ReactiveCacheCollection<Pick<DBSegment, SegmentFields>>('segments'),
+		Parts: new ReactiveCacheCollection<Pick<DBPart, PartFields>>('parts'),
 		DeletedPartInstances: new ReactiveCacheCollection<Pick<PartInstance, PartInstanceFields>>(
-			'deletedPartInstances',
-			innerReaction
+			'deletedPartInstances'
 		),
 	}
 
-	innerReaction()
-
-	return { cache, cancel }
+	return cache
 }

--- a/meteor/server/publications/segmentPartNotesUI/rundownContentObserver.ts
+++ b/meteor/server/publications/segmentPartNotesUI/rundownContentObserver.ts
@@ -3,7 +3,6 @@ import { RundownId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { logger } from '../../logging'
 import {
 	ContentCache,
-	createReactiveContentCache,
 	partFieldSpecifier,
 	partInstanceFieldSpecifier,
 	rundownFieldSpecifier,
@@ -11,24 +10,13 @@ import {
 } from './reactiveContentCache'
 import { PartInstances, Parts, Rundowns, Segments } from '../../collections'
 
-const REACTIVITY_DEBOUNCE = 20
-
-type ChangedHandler = (cache: ContentCache) => () => void
-
 export class RundownContentObserver {
 	#observers: Meteor.LiveQueryHandle[] = []
 	#cache: ContentCache
-	#cancelCache: () => void
-	#cleanup: () => void
 
-	constructor(rundownIds: RundownId[], onChanged: ChangedHandler) {
+	constructor(rundownIds: RundownId[], cache: ContentCache) {
 		logger.silly(`Creating RundownContentObserver for rundowns "${rundownIds.join(',')}"`)
-		const { cache, cancel: cancelCache } = createReactiveContentCache(() => {
-			this.#cleanup = onChanged(cache)
-		}, REACTIVITY_DEBOUNCE)
-
 		this.#cache = cache
-		this.#cancelCache = cancelCache
 
 		this.#observers = [
 			Rundowns.observe(
@@ -77,8 +65,6 @@ export class RundownContentObserver {
 	}
 
 	public dispose = (): void => {
-		this.#cancelCache()
 		this.#observers.forEach((observer) => observer.stop())
-		this.#cleanup()
 	}
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bug fix

* **What is the current behavior?** (You can also link to an open issue here)

### Background

The custom publications are based around watching (observing) changes to mongo collections, and triggering the publication to be re-evaluated when this happens. The granularity to these re-evaluations varies depending on the publication and what changed.
Due to the nature of our data model, and how the subscriptions are setup, some of these observers and invalidations are more complex than others. In some cases we have observers which depend on the documents that match other observers.  

For example the `UISegmentPartNotes` publication is subscribed to for a `RundownPlaylist`. We are then watching the segments and parts inside of that playlist, but have to do so via the ids of the Rundowns contained. So we need to reactively change the segment and parts observers whenever the list of rundown ids changes. 

Having this multiple layers of reactivity makes for complex code, with multiple flows of invalidation depending on what triggered the change. 

### The bug

What we were seeing, was that when re-ingesting long rundowns, the `UIPieceContentStatuses` publication was being triggered a lot. With some debug logging, my machine got over a million before I gave up on letting it finish. Because of the pace of these updates, this meant that the [deepmerge to combine the updates](https://github.com/nrkno/sofie-core/blob/6f0567de958cede745e918529bae660305ceb66e/meteor/server/lib/customPublication/optimizedObserverBase.ts#L204-L216) was having to deep merge arrays which were hundreds of thousands of strings long. This made it get slower and slower as all of the triggers were run, but if left long enough it would eventually complete it and recover.

This number felt high, but was it unusually high? A 160 segment rundown would have some thousands of pieces and expectedpackages and hundreds of parts, with many of these being invalidated for each segment ingested. It feels high, but we don't know what a good level is (fixing the bug concludes a few thousand calls)  
Additionally, a rundown of half the length took a quarter of the time when left to complete. (presumably a quarter of the number of invalidations)

### The cause

It was caused by this block: https://github.com/nrkno/sofie-core/blob/e0eac196161b8964479e715d6569002e294b4297/meteor/server/publications/pieceContentStatusUI/rundown/rundownContentObserver.ts#L58-L60
At a glance, it seems fine. Reacting to the cache changing is precisely what we are wanting to do here.
But digging into that, the `onChanged` is being called every time one of the collections inside the cache changes. Which we are already doing with more granularity at https://github.com/nrkno/sofie-core/blob/e0eac196161b8964479e715d6569002e294b4297/meteor/server/publications/pieceContentStatusUI/rundown/publication.ts#L129-L178

Which means that every time one of the collections changes, we get a new cache, which causes us to destroy and recreate our observers on those collections.
When an observer is created on a collection, the added callback is called for every matching document.
So for every document changed in this cache, we would end up firing the trigger for every document contained in the cache, explaining the non-linear growth.

As for why it is this way, this RundownContentObserver is modelled on a flow started by Jan for the deviceTriggers publication for input-gateway. In that code it is not setting up the observers on each collection, and is instead using this 'global' reactivity hook. So when I copied that concept of the cache object, I added the separate observers to get finer level reactivity, and I should have removed this layer of shared reactivity.

As it slows down non-linearly, it is not surprising that I didn't notice during my testing with NRK rundowns which are 1/10th the size of the one that uncovered this. There is also not sufficient logging in place to get an understanding of what the publications are doing, they are very much running on their own in the background. This is something that should be worked on as a follow up, so that it would have been easier to detect this. It is likely that a new publication will make mistakes in reactivity, while it shouldnt have this much impact it will result in unnecessary cpu load (for example https://github.com/nrkno/sofie-core/commit/e0eac196161b8964479e715d6569002e294b4297)

A majority of the other custom publications make the same reactivity mistake. They were saved by observing a lot less documents, so while they had the same bug the time to recover would have been much lower, making the slowdown unnoticable.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
