### PR TITLE
feat: allow getting the Source and Output layers from the ShowStyle context

### DIFF
--- a/packages/blueprints-integration/src/context.ts
+++ b/packages/blueprints-integration/src/context.ts
@@ -17,6 +17,7 @@ import { BlueprintMappings } from './studio'
 import { TSR, OnGenerateTimelineObj } from './timeline'
 import { PeripheralDeviceId } from '@sofie-automation/shared-lib/dist/core/model/Ids'
 import { IBlueprintPlayoutDevice } from './lib'
+import { ISourceLayer, IOutputLayer } from './showStyle'
 
 /** Common */
 
@@ -118,6 +119,10 @@ export interface IShowStyleContext extends ICommonContext, IStudioContext {
 	getShowStyleConfig: () => unknown
 	/** Returns a reference to a showStyle config value, that can later be resolved in Core */
 	getShowStyleConfigRef(configKey: string): string
+	/** Get source layers for the ShowStyle  */
+	getShowStyleSourceLayers(): Record<string, ISourceLayer | undefined>
+	/** Get output layers for the ShowStyle  */
+	getShowStyleOutputLayers(): Record<string, IOutputLayer | undefined>
 }
 
 export interface IShowStyleUserContext extends IUserNotesContext, IShowStyleContext, IPackageInfoContext {}

--- a/packages/job-worker/src/blueprints/context/ShowStyleContext.ts
+++ b/packages/job-worker/src/blueprints/context/ShowStyleContext.ts
@@ -1,4 +1,4 @@
-import { IShowStyleContext } from '@sofie-automation/blueprints-integration'
+import { IOutputLayer, IShowStyleContext, ISourceLayer } from '@sofie-automation/blueprints-integration'
 import { ReadonlyDeep } from 'type-fest'
 import { DBStudio } from '@sofie-automation/corelib/dist/dataModel/Studio'
 import { getShowStyleConfigRef, ProcessedStudioConfig, ProcessedShowStyleConfig } from '../config'
@@ -24,5 +24,11 @@ export class ShowStyleContext extends StudioContext implements IShowStyleContext
 	}
 	getShowStyleConfigRef(configKey: string): string {
 		return getShowStyleConfigRef(this.showStyleCompound.showStyleVariantId, configKey)
+	}
+	getShowStyleSourceLayers(): Record<string, ISourceLayer | undefined> {
+		return this.showStyleCompound.sourceLayers
+	}
+	getShowStyleOutputLayers(): Record<string, IOutputLayer | undefined> {
+		return this.showStyleCompound.outputLayers
 	}
 }


### PR DESCRIPTION
This PR is being opened on behalf of TV 2 Norge.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

It is not possible for blueprints to get the full, dynamic list of Source and Output layers from the ShowStyle.

* **What is the new behavior (if this is a feature change)?**

The above operations are now possible.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
