### PR TITLE
feat: show waveform thumbnails for audio pieces, if available

### DIFF
--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -2963,7 +2963,8 @@ svg.icon {
 		}
 	}
 
-	&.segment-timeline__mini-inspector--video {
+	&.segment-timeline__mini-inspector--video,
+	&.segment-timeline__mini-inspector--audio {
 		padding: 0;
 		border: 1px solid #1f1f1f;
 		border-radius: 0px;

--- a/meteor/client/ui/FloatingInspectors/AudioFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/AudioFloatingInspector.tsx
@@ -1,0 +1,137 @@
+import React, { MutableRefObject, useRef } from 'react'
+import { TFunction, useTranslation } from 'react-i18next'
+
+import { CriticalIconSmall, WarningIconSmall } from '../../lib/ui/icons/notifications'
+import { FloatingInspector } from '../FloatingInspector'
+import { NoticeLevel } from '../../../lib/notifications/notifications'
+import { VTContent } from '@sofie-automation/blueprints-integration'
+import classNames from 'classnames'
+import { ITranslatableMessage, translateMessage } from '@sofie-automation/corelib/dist/TranslatableMessage'
+import { IFloatingInspectorPosition, useInspectorPosition } from './IFloatingInspectorPosition'
+import { ReadonlyDeep } from 'type-fest'
+import { PieceStatusCode } from '@sofie-automation/corelib/dist/dataModel/Piece'
+
+interface IProps {
+	status: PieceStatusCode | undefined
+	typeClass?: string
+	showMiniInspector: boolean
+	itemElement: HTMLDivElement | null
+	position: IFloatingInspectorPosition
+	content: VTContent | undefined
+	noticeLevel: NoticeLevel | null
+	noticeMessages: ReadonlyDeep<ITranslatableMessage[]> | null
+
+	displayOn?: 'document' | 'viewport'
+
+	hideThumbnail?: boolean
+	thumbnailUrl: string | undefined
+}
+
+function renderNotice(
+	t: TFunction,
+	noticeLevel: NoticeLevel,
+	noticeMessages: ReadonlyDeep<ITranslatableMessage[]> | null
+): JSX.Element {
+	const messagesStr = noticeMessages ? noticeMessages.map((msg) => translateMessage(msg, t)).join('; ') : ''
+	return (
+		<>
+			<div className="segment-timeline__mini-inspector__notice-header">
+				{noticeLevel === NoticeLevel.CRITICAL ? (
+					<CriticalIconSmall />
+				) : noticeLevel === NoticeLevel.WARNING ? (
+					<WarningIconSmall />
+				) : null}
+			</div>
+			<div className="segment-timeline__mini-inspector__notice">{messagesStr}</div>
+		</>
+	)
+}
+
+function shouldShowFloatingInspectorContent(status: PieceStatusCode, content: VTContent | undefined): boolean {
+	return status !== PieceStatusCode.SOURCE_NOT_SET && !!content?.fileName
+}
+
+const AudioThumbnailInspector = React.forwardRef<
+	HTMLDivElement,
+	React.PropsWithChildren<{
+		thumbnailUrl: string
+		floatingInspectorStyle: React.CSSProperties
+	}>
+>(function AudioThumbnailInspector({ thumbnailUrl, floatingInspectorStyle, children }, ref) {
+	return (
+		<div
+			className="segment-timeline__mini-inspector segment-timeline__mini-inspector--audio"
+			style={floatingInspectorStyle}
+			ref={ref as MutableRefObject<HTMLDivElement>}
+		>
+			<img src={thumbnailUrl} />
+			{children}
+		</div>
+	)
+})
+
+export const AudioFloatingInspector: React.FC<IProps> = ({
+	content,
+	hideThumbnail,
+	noticeLevel,
+	noticeMessages,
+	showMiniInspector,
+	itemElement,
+	position,
+	typeClass,
+	status,
+	thumbnailUrl,
+}: IProps) => {
+	const { t } = useTranslation()
+	const inspectorRef = useRef<HTMLDivElement>(null)
+
+	const showAudioThumbnailInspector = !hideThumbnail && thumbnailUrl
+	const showMiniInspectorClipData = shouldShowFloatingInspectorContent(status ?? PieceStatusCode.UNKNOWN, content)
+	const showMiniInspectorNotice = noticeLevel !== null
+	const showMiniInspectorData = showMiniInspectorNotice || showMiniInspectorClipData
+	const showAnyFloatingInspector = Boolean(showAudioThumbnailInspector) || showMiniInspectorData
+
+	const shown = showMiniInspector && itemElement !== undefined && showAnyFloatingInspector
+
+	const { style: floatingInspectorStyle, isFlipped } = useInspectorPosition(position, inspectorRef, shown)
+
+	if (!showAnyFloatingInspector || !floatingInspectorStyle) {
+		return null
+	}
+
+	const miniDataInspector = showMiniInspectorData && (
+		<div
+			className={classNames('segment-timeline__mini-inspector', typeClass, {
+				'segment-timeline__mini-inspector--sub-inspector': showAudioThumbnailInspector,
+				'segment-timeline__mini-inspector--sub-inspector-flipped': showAudioThumbnailInspector && isFlipped,
+				'segment-timeline__mini-inspector--notice notice-critical': noticeLevel === NoticeLevel.CRITICAL,
+				'segment-timeline__mini-inspector--notice notice-warning': noticeLevel === NoticeLevel.WARNING,
+			})}
+			style={!showAudioThumbnailInspector ? floatingInspectorStyle : undefined}
+			ref={!showAudioThumbnailInspector ? inspectorRef : undefined}
+		>
+			{showMiniInspectorNotice && noticeLevel && renderNotice(t, noticeLevel, noticeMessages)}
+			{showMiniInspectorClipData && (
+				<div className="segment-timeline__mini-inspector__properties">
+					<span className="mini-inspector__value">{content?.fileName}</span>
+				</div>
+			)}
+		</div>
+	)
+
+	return (
+		<FloatingInspector shown={shown} displayOn="viewport">
+			{showAudioThumbnailInspector ? (
+				<AudioThumbnailInspector
+					ref={inspectorRef}
+					thumbnailUrl={thumbnailUrl}
+					floatingInspectorStyle={floatingInspectorStyle}
+				>
+					{miniDataInspector}
+				</AudioThumbnailInspector>
+			) : (
+				miniDataInspector
+			)}
+		</FloatingInspector>
+	)
+}

--- a/meteor/client/ui/SegmentList/PieceHoverInspector.tsx
+++ b/meteor/client/ui/SegmentList/PieceHoverInspector.tsx
@@ -15,6 +15,7 @@ import { FloatingInspector } from '../FloatingInspector'
 import { L3rdFloatingInspector } from '../FloatingInspectors/L3rdFloatingInspector'
 import { VTFloatingInspector } from '../FloatingInspectors/VTFloatingInspector'
 import { PieceUi } from '../SegmentContainer/withResolvedSegment'
+import { AudioFloatingInspector } from '../FloatingInspectors/AudioFloatingInspector'
 
 export function PieceHoverInspector({
 	studio,
@@ -100,6 +101,25 @@ export function PieceHoverInspector({
 					noticeLevel={noticeLevel}
 					studio={studio}
 					previewUrl={pieceInstance.contentStatus?.previewUrl}
+				/>
+			)
+		case SourceLayerType.AUDIO:
+			return (
+				<AudioFloatingInspector
+					status={status || PieceStatusCode.UNKNOWN}
+					showMiniInspector={hovering}
+					content={vtContent}
+					position={{
+						top: originPosition.top,
+						left: originPosition.left + mousePosition,
+						anchor: 'start',
+						position: 'top-start',
+					}}
+					typeClass={layer && RundownUtils.getSourceLayerClassName(layer.type)}
+					itemElement={null}
+					noticeMessages={pieceInstance.contentStatus?.messages || null}
+					noticeLevel={noticeLevel}
+					thumbnailUrl={pieceInstance.contentStatus?.thumbnailUrl}
 				/>
 			)
 	}

--- a/meteor/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/Renderers/AudioRenderer.tsx
+++ b/meteor/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/Renderers/AudioRenderer.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { VTContent } from '@sofie-automation/blueprints-integration'
+import { IDefaultRendererProps } from './DefaultRenderer'
+import { getNoticeLevelForPieceStatus } from '../../../../../lib/notifications/notifications'
+import { PieceStatusCode } from '@sofie-automation/corelib/dist/dataModel/Piece'
+import { AudioFloatingInspector } from '../../../FloatingInspectors/AudioFloatingInspector'
+
+export function AudioRenderer({
+	piece: pieceInstance,
+	hovering,
+	elementOffset,
+	typeClass,
+}: IDefaultRendererProps): JSX.Element {
+	const status = pieceInstance.contentStatus?.status
+
+	const vtContent = pieceInstance.instance.piece.content as VTContent
+
+	return (
+		<>
+			<AudioFloatingInspector
+				status={status || PieceStatusCode.UNKNOWN}
+				showMiniInspector={!!hovering}
+				content={vtContent}
+				position={{
+					top: elementOffset?.top ?? 0,
+					left: elementOffset?.left ?? 0,
+					anchor: 'start',
+					position: 'top-start',
+				}}
+				typeClass={typeClass}
+				itemElement={null}
+				noticeMessages={pieceInstance.contentStatus?.messages || null}
+				noticeLevel={getNoticeLevelForPieceStatus(status)}
+				thumbnailUrl={pieceInstance.contentStatus?.thumbnailUrl}
+			/>
+			{pieceInstance.instance.piece.name}
+		</>
+	)
+}

--- a/meteor/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/StoryboardSecondaryPiece.tsx
+++ b/meteor/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/StoryboardSecondaryPiece.tsx
@@ -13,6 +13,7 @@ import { SplitsRenderer } from './Renderers/SplitsRenderer'
 import { PieceElement } from '../../SegmentContainer/PieceElement'
 import { UIStudio } from '../../../../lib/api/studios'
 import { PartId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { AudioRenderer } from './Renderers/AudioRenderer'
 
 interface IProps {
 	layer: ISourceLayer
@@ -44,6 +45,7 @@ function renderPieceInside(
 		case SourceLayerType.SPLITS:
 			return SplitsRenderer({ ...props, elementOffset, hovering, typeClass })
 		case SourceLayerType.AUDIO:
+			return AudioRenderer({ ...props, elementOffset, hovering, typeClass })
 		case SourceLayerType.CAMERA:
 		case SourceLayerType.LIVE_SPEAK:
 		case SourceLayerType.VT:

--- a/meteor/client/ui/SegmentStoryboard/StoryboardPartThumbnail/Renderers/AudioThumbnailRenderer.tsx
+++ b/meteor/client/ui/SegmentStoryboard/StoryboardPartThumbnail/Renderers/AudioThumbnailRenderer.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import { VTContent } from '@sofie-automation/blueprints-integration'
+import { getNoticeLevelForPieceStatus } from '../../../../../lib/notifications/notifications'
+import { RundownUtils } from '../../../../lib/rundown'
+import { IProps } from './ThumbnailRendererFactory'
+import { PieceStatusIcon } from '../../../../lib/ui/PieceStatusIcon'
+import { PieceStatusCode } from '@sofie-automation/corelib/dist/dataModel/Piece'
+import { AudioFloatingInspector } from '../../../FloatingInspectors/AudioFloatingInspector'
+
+export function AudioThumbnailRenderer({
+	pieceInstance,
+	hovering,
+	originPosition,
+	layer,
+	height,
+}: IProps): JSX.Element {
+	const status = pieceInstance.contentStatus?.status
+	const vtContent = pieceInstance.instance.piece.content as VTContent
+	const thumbnailUrl: string | undefined = pieceInstance.contentStatus?.thumbnailUrl
+	const noticeLevel = getNoticeLevelForPieceStatus(status)
+
+	return (
+		<>
+			<AudioFloatingInspector
+				status={status || PieceStatusCode.UNKNOWN}
+				showMiniInspector={hovering}
+				content={vtContent}
+				position={{
+					top: originPosition.top,
+					left: originPosition.left,
+					height,
+					anchor: 'start',
+					position: 'top-start',
+				}}
+				typeClass={layer && RundownUtils.getSourceLayerClassName(layer.type)}
+				itemElement={null}
+				noticeMessages={pieceInstance.contentStatus?.messages || null}
+				noticeLevel={noticeLevel}
+				thumbnailUrl={thumbnailUrl}
+			/>
+			<div className="segment-storyboard__thumbnail__label">
+				{noticeLevel !== null && <PieceStatusIcon noticeLevel={noticeLevel} />}
+				{pieceInstance.instance.piece.name}
+			</div>
+		</>
+	)
+}

--- a/meteor/client/ui/SegmentStoryboard/StoryboardPartThumbnail/Renderers/ThumbnailRendererFactory.ts
+++ b/meteor/client/ui/SegmentStoryboard/StoryboardPartThumbnail/Renderers/ThumbnailRendererFactory.ts
@@ -10,6 +10,7 @@ import { GraphicsThumbnailRenderer } from './GraphicsThumbnailRenderer'
 import { LocalThumbnailRenderer } from './LocalThumbnailRenderer'
 import { SplitsThumbnailRenderer } from './SplitsThumbnailRenderer'
 import { VTThumbnailRenderer } from './VTThumbnailRenderer'
+import { AudioThumbnailRenderer } from './AudioThumbnailRenderer'
 
 export interface IProps {
 	partId: PartId
@@ -44,6 +45,7 @@ export default function renderThumbnail(props: IProps): JSX.Element {
 		case SourceLayerType.LOCAL:
 			return LocalThumbnailRenderer(props)
 		case SourceLayerType.AUDIO:
+			return AudioThumbnailRenderer(props)
 		case SourceLayerType.SCRIPT:
 		case SourceLayerType.TRANSITION:
 		case SourceLayerType.UNKNOWN:

--- a/meteor/client/ui/SegmentTimeline/Renderers/AudioSourceRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/AudioSourceRenderer.tsx
@@ -1,0 +1,127 @@
+import * as React from 'react'
+import ClassNames from 'classnames'
+import { getElementWidth } from '../../../utils/dimensions'
+
+import { CustomLayerItemRenderer, ICustomLayerItemProps } from './CustomLayerItemRenderer'
+import { AudioFloatingInspector } from '../../FloatingInspectors/AudioFloatingInspector'
+import { NoticeLevel, getNoticeLevelForPieceStatus } from '../../../../lib/notifications/notifications'
+import { VTContent } from '@sofie-automation/blueprints-integration'
+import { WithTranslation } from 'react-i18next'
+
+type IProps = ICustomLayerItemProps
+interface IState {
+	noticeLevel: NoticeLevel | null
+}
+
+export class AudioSourceRenderer extends CustomLayerItemRenderer<IProps, IState> {
+	leftLabel: HTMLSpanElement | null
+	rightLabel: HTMLSpanElement | null
+
+	constructor(props: IProps & WithTranslation) {
+		super(props)
+		this.state = {
+			noticeLevel: getNoticeLevelForPieceStatus(props.piece.contentStatus?.status),
+		}
+	}
+
+	private setLeftLabelRef = (e: HTMLSpanElement) => {
+		this.leftLabel = e
+	}
+
+	private setRightLabelRef = (e: HTMLSpanElement) => {
+		this.rightLabel = e
+	}
+
+	componentDidMount(): void {
+		this.updateAnchoredElsWidths()
+	}
+
+	private updateAnchoredElsWidths = () => {
+		const leftLabelWidth = this.leftLabel ? getElementWidth(this.leftLabel) : 0
+		const rightLabelWidth = this.rightLabel ? getElementWidth(this.rightLabel) : 0
+
+		this.setAnchoredElsWidths(leftLabelWidth, rightLabelWidth)
+	}
+
+	componentDidUpdate(prevProps: Readonly<IProps>, prevState: Readonly<IState>): void {
+		if (super.componentDidUpdate && typeof super.componentDidUpdate === 'function') {
+			super.componentDidUpdate(prevProps, prevState)
+		}
+
+		if (this.props.piece.instance.piece.name !== prevProps.piece.instance.piece.name) {
+			this.updateAnchoredElsWidths()
+		}
+
+		const innerPiece = this.props.piece.instance.piece
+		const newState: Partial<IState> = {}
+		if (
+			innerPiece.name !== prevProps.piece.instance.piece.name ||
+			this.props.piece.contentStatus?.status !== prevProps.piece.contentStatus?.status
+		) {
+			newState.noticeLevel = getNoticeLevelForPieceStatus(this.props.piece.contentStatus?.status)
+		}
+
+		if (Object.keys(newState).length > 0) {
+			this.setState(newState as IState, () => {
+				if (newState.noticeLevel && newState.noticeLevel !== prevState.noticeLevel) {
+					this.updateAnchoredElsWidths()
+				}
+			})
+		}
+	}
+
+	render(): JSX.Element | false {
+		const label = this.props.piece.instance.piece.name
+		const duration = this.renderDuration()
+		const vtContent = this.props.piece.instance.piece.content as VTContent | undefined
+
+		return (
+			!this.props.isTooSmallForText && (
+				<>
+					{!this.props.piece.hasOriginInPreceedingPart || this.props.isLiveLine ? (
+						<span
+							className="segment-timeline__piece__label"
+							ref={this.setLeftLabelRef}
+							style={this.getItemLabelOffsetLeft()}
+						>
+							<span
+								className={ClassNames('segment-timeline__piece__label', {
+									'with-duration': !!duration,
+									[`with-duration--${this.getSourceDurationLabelAlignment()}`]: !!duration,
+								})}
+							>
+								{duration ? (
+									<>
+										<span>{label}</span>
+										{duration}
+									</>
+								) : (
+									label
+								)}
+							</span>
+						</span>
+					) : null}
+					<span
+						className="segment-timeline__piece__label right-side overflow-label"
+						ref={this.setRightLabelRef}
+						style={this.getItemLabelOffsetRight()}
+					>
+						{this.renderInfiniteIcon()}
+						{this.renderOverflowTimeLabel()}
+					</span>
+					<AudioFloatingInspector
+						status={this.props.piece.contentStatus?.status}
+						position={this.getFloatingInspectorStyle()}
+						content={vtContent}
+						itemElement={this.props.itemElement}
+						noticeLevel={this.state.noticeLevel}
+						showMiniInspector={this.props.showMiniInspector}
+						typeClass={this.props.typeClass}
+						noticeMessages={this.props.piece.contentStatus?.messages || []}
+						thumbnailUrl={this.props.piece.contentStatus?.thumbnailUrl}
+					/>
+				</>
+			)
+		)
+	}
+}

--- a/meteor/client/ui/SegmentTimeline/SourceLayerItem.tsx
+++ b/meteor/client/ui/SegmentTimeline/SourceLayerItem.tsx
@@ -20,6 +20,7 @@ import { SourceDurationLabelAlignment } from './Renderers/CustomLayerItemRendere
 import { TransitionSourceRenderer } from './Renderers/TransitionSourceRenderer'
 import { UIStudio } from '../../../lib/api/studios'
 import { CalculateTimingsPiece } from '@sofie-automation/corelib/dist/playout/timings'
+import { AudioSourceRenderer } from './Renderers/AudioSourceRenderer'
 const LEFT_RIGHT_ANCHOR_SPACER = 15
 const MARGINAL_ANCHORED_WIDTH = 5
 
@@ -553,6 +554,20 @@ export const SourceLayerItem = withTranslation()(
 				case SourceLayerType.VT:
 					return (
 						<VTSourceRenderer
+							key={unprotectString(this.props.piece.instance._id)}
+							typeClass={typeClass}
+							getItemDuration={this.getItemDuration}
+							getSourceDurationLabelAlignment={this.getSourceDurationLabelAlignment}
+							getItemLabelOffsetLeft={this.getItemLabelOffsetLeft}
+							getItemLabelOffsetRight={this.getItemLabelOffsetRight}
+							setAnchoredElsWidths={this.setAnchoredElsWidths}
+							{...this.props}
+							{...this.state}
+						/>
+					)
+				case SourceLayerType.AUDIO:
+					return (
+						<AudioSourceRenderer
 							key={unprotectString(this.props.piece.instance._id)}
 							typeClass={typeClass}
 							getItemDuration={this.getItemDuration}


### PR DESCRIPTION
This PR is being opened on behalf of myself.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

Audio pieces have limited inspectability.

* **What is the new behavior (if this is a feature change)?**

Audio pieces now display a waveform image on hover, if available from Package Manager.

![image](https://github.com/nrkno/sofie-core/assets/873012/ee4d4382-07f3-40a4-a14f-a40f18c5ff54)

* **Other information**:

This PR depends on https://github.com/nrkno/sofie-package-manager/pull/93

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
