### PR TITLE
 fix: don't display a warning when an audio piece is missing video

### DIFF
--- a/meteor/server/publications/pieceContentStatusUI/checkPieceContentStatus.ts
+++ b/meteor/server/publications/pieceContentStatusUI/checkPieceContentStatus.ts
@@ -800,7 +800,7 @@ function checkStreamFormatsAndCounts(
 	sourceLayer: ISourceLayer,
 	ignoreMediaAudioStatus: boolean | undefined
 ): number {
-	if (!ignoreMediaAudioStatus && streams.length < 2) {
+	if (!ignoreMediaAudioStatus && streams.length < 2 && sourceLayer.type !== SourceLayerType.AUDIO) {
 		messages.push({
 			status: PieceStatusCode.SOURCE_BROKEN,
 			message: generateTranslation("{{sourceLayer}} doesn't have both audio & video", {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Audio-only pieces will often display a warning about their corresponding files missing video.

* **What is the new behavior (if this is a feature change)?**

This warning has been disabled for pieces which reside on an `AUDIO` source layer. If there is a better heuristic, let me know.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
