### PR TITLE
chore: fix documentation linking

### DIFF
--- a/packages/documentation/docs/for-developers/for-blueprint-developers/intro.md
+++ b/packages/documentation/docs/for-developers/for-blueprint-developers/intro.md
@@ -8,7 +8,7 @@ sidebar_position: 1
 Documentation for this page is yet to be written.
 :::
 
-[Blueprints](../../user-guide/concepts-and-architecture#blueprints) are programs that run inside Sofie Core and interpret
+[Blueprints](../../user-guide/concepts-and-architecture.md#blueprints) are programs that run inside Sofie Core and interpret
 data coming in from the Rundowns and transform that into playable elements. They use an API published in [@sofie-automation/blueprints-integration](https://nrkno.github.io/sofie-core/typedoc/modules/_sofie_automation_blueprints_integration.html) library to expose their functionality and communicate with Sofie Core.
 
 Technically, a Blueprint is a JavaScript object, implementing one of the `BlueprintManifestBase` interfaces.

--- a/packages/documentation/docs/for-developers/intro.md
+++ b/packages/documentation/docs/for-developers/intro.md
@@ -7,9 +7,9 @@ sidebar_position: 1
 
 The pages below are intended for developers of any of the Sofie-related repos and/or blueprints.
 
-A read-through of the [Concepts & Architectures](../user-guide/concepts-and-architecture) is recommended, before diving too deep into development.
+A read-through of the [Concepts & Architectures](../user-guide/concepts-and-architecture.md) is recommended, before diving too deep into development.
 
-* [Libraries](libraries)
-* [Contribution Guidelines](contribution-guidelines)
-* [For Blueprint Developers](for-blueprint-developers/intro)
-* [API Documentation](api-documentation)
+- [Libraries](libraries.md)
+- [Contribution Guidelines](contribution-guidelines.md)
+- [For Blueprint Developers](for-blueprint-developers/intro.md)
+- [API Documentation](api-documentation.md)

--- a/packages/documentation/docs/for-developers/libraries.md
+++ b/packages/documentation/docs/for-developers/libraries.md
@@ -43,8 +43,8 @@ There are a number of libraries used in the Sofie ecosystem:
 
 There are also a few typings-only libraries that define interfaces between applications:
 
-* [**Blueprints Integration**](https://www.npmjs.com/package/@sofie-automation/blueprints-integration) Defines the interface between [**Blueprints**](../user-guide/concepts-and-architecture#blueprints) and **Sofie&nbsp;Core**.
-* [**Timeline State Resolver types**](https://www.npmjs.com/package/timeline-state-resolver-types) Defines the interface between [**Blueprints**](../user-guide/concepts-and-architecture#blueprints) and the timeline that will be fed into **TSR** for playout.
+* [**Blueprints Integration**](https://www.npmjs.com/package/@sofie-automation/blueprints-integration) Defines the interface between [**Blueprints**](../user-guide/concepts-and-architecture.md#blueprints) and **Sofie&nbsp;Core**.
+* [**Timeline State Resolver types**](https://www.npmjs.com/package/timeline-state-resolver-types) Defines the interface between [**Blueprints**](../user-guide/concepts-and-architecture.md#blueprints) and the timeline that will be fed into **TSR** for playout.
 
 ## Other Sofie-related Repositories
 

--- a/packages/documentation/docs/for-developers/worker-threads-and-locks.md
+++ b/packages/documentation/docs/for-developers/worker-threads-and-locks.md
@@ -2,7 +2,7 @@
 title: Worker Threads & Locks
 ---
 
-Starting with v1.40.0 (_[Release 40](/sofie-core/docs/releases#release-40)_), the core logic of Sofie is split across
+Starting with v1.40.0 (Release 40), the core logic of Sofie is split across
 multiple threads. This has been done to minimise performance bottlenecks such as ingest changes delaying takes. In its
 current state, it should not impact deployment of Sofie.
 

--- a/packages/documentation/docs/user-guide/concepts-and-architecture.md
+++ b/packages/documentation/docs/user-guide/concepts-and-architecture.md
@@ -85,7 +85,7 @@ An AdLib isn't added to the Part in the GUI until it starts playing, instead you
 
 ## Views
 
-Being a web-based system, Sofie has a number of customisable, user-facing web [views](features/sofie-views) used for control and monitoring.
+Being a web-based system, Sofie has a number of customisable, user-facing web [views](features/sofie-views.md) used for control and monitoring.
 
 
 
@@ -126,7 +126,7 @@ The Timeline is a collection of timeline-objects, that together form a "target s
 
 The timeline-objects can be programmed to contain relative references to each other, so programming things like _"play this thing right after this other thing"_ is as easy as `{start: { #otherThing.end }}`
 
-The [Playout Gateway](../for-developers/libraries) picks up the timeline from Sofie&nbsp;Core and \(using the [TSR timeline-state-resolver](https://github.com/nrkno/sofie-timeline-state-resolver)\) controls the playout devices to make sure that they actually play what is intended.
+The [Playout Gateway](../for-developers/libraries.md) picks up the timeline from Sofie&nbsp;Core and \(using the [TSR timeline-state-resolver](https://github.com/nrkno/sofie-timeline-state-resolver)\) controls the playout devices to make sure that they actually play what is intended.
 
 ![Example of 2 objects in a timeline: The #video object, destined to play at a certain time, and #gfx0, destined to start 15 seconds into the video.](/img/docs/main/features/timeline.png)
 
@@ -159,7 +159,7 @@ _Sofie&nbsp;Core_ generates the timeline using:
 - The [Next:ed Part](#next-point-and-lookahead) and Parts that come after it \(the [Lookahead](#lookahead)\)
 - Any [AdLibs](#adlib-pieces) the user has manually selected to play
 
-The [**Playout Gateway**](../for-developers/libraries#gateways) then picks up the new timeline, and pipes it into the [\(TSR\) timeline-state-resolver](https://github.com/nrkno/sofie-timeline-state-resolver) library.
+The [**Playout Gateway**](../for-developers/libraries.md#gateways) then picks up the new timeline, and pipes it into the [\(TSR\) timeline-state-resolver](https://github.com/nrkno/sofie-timeline-state-resolver) library.
 
 The TSR then...
 

--- a/packages/documentation/docs/user-guide/configuration/settings-view.md
+++ b/packages/documentation/docs/user-guide/configuration/settings-view.md
@@ -4,10 +4,10 @@ sidebar_position: 2
 # Settings View
 
 :::caution
-The settings views are only visible to users with the correct [access level](../features/access-levels)!
+The settings views are only visible to users with the correct [access level](../features/access-levels.md)!
 :::
 
-Recommended read before diving into the settings: [System, \(Organization\), Studio & Show Style](../concepts-and-architecture#system-organization-studio-and-show-style).
+Recommended read before diving into the settings: [System, \(Organization\), Studio & Show Style](../concepts-and-architecture.md#system-organization-studio-and-show-style).
 
 ## System
 
@@ -34,11 +34,11 @@ This section allows you to add and remove Gateways that are related to this _Stu
 
 ### Blueprint Configuration
 
-Sofie allows the Blueprints to expose custom configuration fields that allow the System Administrator to reconfigure how these Blueprints work through the Sofie UI. Here you can change the configuration of the [Studio Blueprint](../concepts-and-architecture#studio-blueprints).
+Sofie allows the Blueprints to expose custom configuration fields that allow the System Administrator to reconfigure how these Blueprints work through the Sofie UI. Here you can change the configuration of the [Studio Blueprint](../concepts-and-architecture.md#studio-blueprints).
 
 ### Layer Mappings
 
-This section allows you to add, remove and configure how logical device-control will be translated to physical automation control. [Blueprints](../concepts-and-architecture#blueprints) control devices through objects placed on a [Timeline](../concepts-and-architecture#timeline) using logical device identifiers called _Layers_. A layer represents a single aspect of a device that can be controlled at a given time: a video switcher's M/E bus, an audio mixers's fader, an OSC control node, a video server's output channel. Layer Mappings translate these logical identifiers into physical device aspects, for example:
+This section allows you to add, remove and configure how logical device-control will be translated to physical automation control. [Blueprints](../concepts-and-architecture.md#blueprints) control devices through objects placed on a [Timeline](../concepts-and-architecture.md#timeline) using logical device identifiers called _Layers_. A layer represents a single aspect of a device that can be controlled at a given time: a video switcher's M/E bus, an audio mixers's fader, an OSC control node, a video server's output channel. Layer Mappings translate these logical identifiers into physical device aspects, for example:
 
 ![A sample configuration of a Layer Mapping for the M/E1 Bus of an ATEM switcher](/img/docs/main/features/atem-layer-mapping-example.png)
 
@@ -48,7 +48,7 @@ These mappings allow the System Administrator to reconfigure what devices the Bl
 
 #### Route Sets
 
-In order to allow the Producer to reconfigure the automation from the Switchboard in the [Rundown View](../concepts-and-architecture#rundown-view), as well as have some pre-set automation control available for the System Administrator, Sofie has a concept of Route Sets. Route Sets work on top of the Layer Mappings, by configuring sets of [Layer Mappings](settings-view#layer-mappings) that will re-route the control from one device to another, or to disable the automation altogether. These Route Sets are presented to the Producer in the [Switchboard](../concepts-and-architecture#switchboard) panel.
+In order to allow the Producer to reconfigure the automation from the Switchboard in the [Rundown View](../concepts-and-architecture.md#rundown-view), as well as have some pre-set automation control available for the System Administrator, Sofie has a concept of Route Sets. Route Sets work on top of the Layer Mappings, by configuring sets of [Layer Mappings](settings-view.md#layer-mappings) that will re-route the control from one device to another, or to disable the automation altogether. These Route Sets are presented to the Producer in the [Switchboard](../concepts-and-architecture.md#switchboard) panel.
 
 A Route Set is essentially a distinct set of Layer Mappings, which can modify the settings already configured by the Layer Mappings, but can be turned On and Off. Called Routes, these can change:
 
@@ -91,9 +91,9 @@ The Showstyle contains settings like
 :::caution
 Please note the difference between _Source Layers_ and _timeline-layers_:
 
-[Pieces](../concepts-and-architecture#piece) are put onto _Source layers_, to group different types of content \(such as a VT or Camera\), they are therefore intended only as something to indicate to the user what is going to be played, not what is actually going to happen on the technical level.
+[Pieces](../concepts-and-architecture.md#piece) are put onto _Source layers_, to group different types of content \(such as a VT or Camera\), they are therefore intended only as something to indicate to the user what is going to be played, not what is actually going to happen on the technical level.
 
-[Timeline-objects](../concepts-and-architecture#timeline-object) \(inside of the [Pieces](../concepts-and-architecture#piece)\) are put onto timeline-layers, which are \(through the Mappings in the studio\) mapped to physical devices and outputs.  
+[Timeline-objects](../concepts-and-architecture.md#timeline-object) \(inside of the [Pieces](../concepts-and-architecture.md#piece)\) are put onto timeline-layers, which are \(through the Mappings in the studio\) mapped to physical devices and outputs.  
 The exact timeline-layer is never exposed to the user, but instead used on the technical level to control playout.
 
 An example of the difference could be when playing a VT \(that's a Source Layer\), which could involve all of the timeline-layers _video\_player0_, _audio\_fader\_video_, _audio\_fader\_host_ and _mixer\_pgm._

--- a/packages/documentation/docs/user-guide/features/api.md
+++ b/packages/documentation/docs/user-guide/features/api.md
@@ -8,5 +8,5 @@ The documentation is minimal at the moment, but the API endpoints are listed by 
 
 ## DDP – Core Integration
 
-If you're planning to build NodeJS applications that talk to _Sofie&nbsp;Core_, we recommend using the [core-integration](https://github.com/nrkno/sofie-core/tree/master/packages/server-core-integration) library, which exposes a number of callable methods and allows for subscribing to data the same way the [Gateways](../concepts-and-architecture#gateways) do it.
+If you're planning to build NodeJS applications that talk to _Sofie&nbsp;Core_, we recommend using the [core-integration](https://github.com/nrkno/sofie-core/tree/master/packages/server-core-integration.md) library, which exposes a number of callable methods and allows for subscribing to data the same way the [Gateways](../concepts-and-architecture.md#gateways) do it.
 

--- a/packages/documentation/docs/user-guide/features/prompter.md
+++ b/packages/documentation/docs/user-guide/features/prompter.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Prompter
 
-See [Sofie views](sofie-views#prompter-view) for how to access the prompter page.
+See [Sofie views](sofie-views.md#prompter-view) for how to access the prompter page.
 
 ![Prompter screen before the first Part is taken](/img/docs/main/features/prompter-view.png)
 
@@ -40,11 +40,11 @@ The prompter can be controlled by different types of controllers. The control mo
 | Query parameter         | Description                                                                                                                                                                                                                                    |
 | :---------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Default                 | Controlled by both mouse and keyboard                                                                                                                                                                                                          |
-| `?mode=mouse`           | Controlled by mouse only. [See configuration details](prompter#control-using-mouse-scroll-wheel)                                                                                                                                            |
-| `?mode=keyboard`        | Controlled by keyboard only. [See configuration details](prompter#control-using-keyboard)                                                                                                                                                   |
-| `?mode=shuttlekeyboard` | Controlled by a Contour Design ShuttleXpress, X-keys Jog and Shuttle or any compatible, configured as keyboard-ish device. [See configuration details](prompter#control-using-contour-shuttlexpress-or-x-keys)                              |
-| `?mode=pedal`           | Controlled by any MIDI device outputting note values between 0 - 127 of CC notes on channel 8. Analogue Expression pedals work well with TRS-USB midi-converters. [See configuration details](prompter#control-using-midi-input-mode-pedal) |
-| `?mode=joycon`          | Controlled by Nintendo Switch Joycon, using the HTML5 GamePad API. [See configuration details](prompter#control-using-nintendo-joycon-gamepad)                                                                                              |
+| `?mode=mouse`           | Controlled by mouse only. [See configuration details](prompter.md#control-using-mouse-scroll-wheel)                                                                                                                                            |
+| `?mode=keyboard`        | Controlled by keyboard only. [See configuration details](prompter.md#control-using-keyboard)                                                                                                                                                   |
+| `?mode=shuttlekeyboard` | Controlled by a Contour Design ShuttleXpress, X-keys Jog and Shuttle or any compatible, configured as keyboard-ish device. [See configuration details](prompter.md#control-using-contour-shuttlexpress-or-x-keys)                              |
+| `?mode=pedal`           | Controlled by any MIDI device outputting note values between 0 - 127 of CC notes on channel 8. Analogue Expression pedals work well with TRS-USB midi-converters. [See configuration details](prompter.md#control-using-midi-input-mode-pedal) |
+| `?mode=joycon`          | Controlled by Nintendo Switch Joycon, using the HTML5 GamePad API. [See configuration details](prompter.md#control-using-nintendo-joycon-gamepad)                                                                                              |
 
 #### Control using mouse \(scroll wheel\)
 

--- a/packages/documentation/docs/user-guide/features/sofie-views.mdx
+++ b/packages/documentation/docs/user-guide/features/sofie-views.mdx
@@ -54,7 +54,7 @@ Elements in the [Next point](#next-point) \(or beyond\) might be pre-loaded or "
 
 ### Storyboard Mode
 
-In the top-right corner of the Segment, there's a button controlling the display style of a given Segment. The default display style of a Segment can be indicated by the [Blueprints](../concepts-and-architecture#blueprints), but the User can switch to a different mode at any time. You can also change the display mode of all Segments at once, using a button in the bottom-right corner of the Rundown View.
+In the top-right corner of the Segment, there's a button controlling the display style of a given Segment. The default display style of a Segment can be indicated by the [Blueprints](../concepts-and-architecture.md#blueprints), but the User can switch to a different mode at any time. You can also change the display mode of all Segments at once, using a button in the bottom-right corner of the Rundown View.
 
 ![Storyboard Mode](/img/docs/main/storyboard.png)
 
@@ -70,7 +70,7 @@ Another mode available to display a Segment is the List View. In this mode, each
 
 ![List View Mode](/img/docs/main/list_view.png)
 
-In this mode, the focus is on the "main" Piece of the Part. Additional _Lower-Third_ content that is not spanning the entire Part (is not infinite) will be displayed on top of the main Piece. All other content can be displayed to the right of the mini-timeline as a set of indicators, one per every Layer. Clicking on those indicators will show a pop-up with the Pieces so that they can be investigated using _hover-scrub_. Indicators can be also shown for Ad-Libs assigned to a Part, for easier discovery by the User. Which Layers should be shown in the columns can be decided in the [Settings ● Layers](../configuration/settings-view#show-style) area. A special, larger indicator is reserved for the Script piece, which can be useful to display so-called _out-words_.
+In this mode, the focus is on the "main" Piece of the Part. Additional _Lower-Third_ content that is not spanning the entire Part (is not infinite) will be displayed on top of the main Piece. All other content can be displayed to the right of the mini-timeline as a set of indicators, one per every Layer. Clicking on those indicators will show a pop-up with the Pieces so that they can be investigated using _hover-scrub_. Indicators can be also shown for Ad-Libs assigned to a Part, for easier discovery by the User. Which Layers should be shown in the columns can be decided in the [Settings ● Layers](../configuration/settings-view.md#show-style) area. A special, larger indicator is reserved for the Script piece, which can be useful to display so-called _out-words_.
 
 If a Part has an _in-transition_ Piece, it will be displayed to the left of the Part's Take Point.
 
@@ -155,7 +155,7 @@ For the purpose of running the system in a studio environment, there are some ad
 
 ![Switchboard](/img/docs/main/switchboard.png)
 
-The Switchboard allows the producer to turn automation _On_ and _Off_ for sets of devices, as well as re-route automation control between devices - both with an active rundown and when no rundown is active in a [Studio](../concepts-and-architecture#system-organization-studio-and-show-style).
+The Switchboard allows the producer to turn automation _On_ and _Off_ for sets of devices, as well as re-route automation control between devices - both with an active rundown and when no rundown is active in a [Studio](../concepts-and-architecture.md#system-organization-studio-and-show-style).
 
 The Switchboard panel can be accessed from the Rundown View's right-hand Toolbar, by clicking on the Switchboard button, next to the Support panel button.
 
@@ -169,7 +169,7 @@ Technically, the switchboard activates and deactivates Route Sets. The Route Set
 
 ![Prompter View](/img/docs/main/features/prompter-example.png)
 
-A fullscreen page which displays the prompter text for the currently active rundown. The prompter can be controlled and configured in various ways, see more at the [Prompter](prompter) documentation. If no Rundown is active in a given studio, the [Screensaver](sofie-views#screensaver) will be displayed.
+A fullscreen page which displays the prompter text for the currently active rundown. The prompter can be controlled and configured in various ways, see more at the [Prompter](prompter.md) documentation. If no Rundown is active in a given studio, the [Screensaver](sofie-views.md#screensaver) will be displayed.
 
 ## Presenter View
 
@@ -177,7 +177,7 @@ A fullscreen page which displays the prompter text for the currently active rund
 
 ![Presenter View](/img/docs/main/features/presenter-screen-example.png)
 
-A fullscreen page, intended to be shown to the studio presenter. It displays countdown timers for the current and next items in the rundown. If no Rundown is active in a given studio, the [Screensaver](sofie-views#screensaver) will be shown.
+A fullscreen page, intended to be shown to the studio presenter. It displays countdown timers for the current and next items in the rundown. If no Rundown is active in a given studio, the [Screensaver](sofie-views.md#screensaver) will be shown.
 
 ### Presenter View Overlay
 
@@ -185,7 +185,7 @@ A fullscreen page, intended to be shown to the studio presenter. It displays cou
 
 ![Presenter View Overlay](/img/docs/main/features/presenter-screen-overlay-example.png)
 
-A fullscreen view with transparent background, intended to be shown to the studio presenter as an overlay on top of the produced PGM signal. It displays a reduced amount of the information from the regular [Presenter screen](sofie-views#presenter-view): the countdown to the end of the current Part, a summary preview \(type and name\) of the next item in the Rundown and the current time of day. If no Rundown is active it will show the name of the Studio.
+A fullscreen view with transparent background, intended to be shown to the studio presenter as an overlay on top of the produced PGM signal. It displays a reduced amount of the information from the regular [Presenter screen](sofie-views.md#presenter-view): the countdown to the end of the current Part, a summary preview \(type and name\) of the next item in the Rundown and the current time of day. If no Rundown is active it will show the name of the Studio.
 
 ## Active Rundown View
 
@@ -285,9 +285,9 @@ The result of the operation. "Success" or an error message.
 When a broadcast is done, users can input feedback about how the show went in an evaluation form.
 
 :::info
-Evaluations can be configured to be sent to Slack, by setting the "Slack Webhook URL" in the [Settings View](../configuration/settings-view) under _Studio_.
+Evaluations can be configured to be sent to Slack, by setting the "Slack Webhook URL" in the [Settings View](../configuration/settings-view.md) under _Studio_.
 :::
 
 ## Settings View
 
-The [Settings View](../configuration/settings-view) is only available to users with the [Access Level](access-levels) set correctly.
+The [Settings View](../configuration/settings-view.md) is only available to users with the [Access Level](access-levels.md) set correctly.

--- a/packages/documentation/docs/user-guide/further-reading.md
+++ b/packages/documentation/docs/user-guide/further-reading.md
@@ -6,9 +6,9 @@ description: This guide has a lot of links. Here they are all listed by section.
 
 ## Getting Started
 
-- [Sofie's Concepts & Architecture](concepts-and-architecture)
-- [Gateways](concepts-and-architecture#gateways)
-- [Blueprints](concepts-and-architecture#blueprints)
+- [Sofie's Concepts & Architecture](concepts-and-architecture.md)
+- [Gateways](concepts-and-architecture.md#gateways)
+- [Blueprints](concepts-and-architecture.md#blueprints)
 
 - Ask questions in the [Sofie Slack Channel](https://join.slack.com/t/sofietv/shared_invite/enQtNTk2Mzc3MTQ1NzAzLTJkZjMyMDg3OGM0YWU3MmU4YzBhZDAyZWI1YmJmNmRiYWQ1OTZjYTkzOTkzMTA2YTE1YjgxMmVkM2U1OGZlNWI)
 
@@ -43,7 +43,7 @@ description: This guide has a lot of links. Here they are all listed by section.
 - [Media Scanner](https://github.com/nrkno/sofie-casparcg-launcher/releases) on GitHub.
 - [CasparCG Launcher](https://github.com/nrkno/sofie-casparcg-launcher) on GitHub.
 - [Microsoft Visual C++ 2015 Redistributable](https://www.microsoft.com/en-us/download/details.aspx?id=52685) on Microsoft's website.
-- [Blackmagic Design's DeckLink Cards](https://www.blackmagicdesign.com/products/decklink/models) on Blackmagic Design's website. Check the [DeckLink cards](installation/installing-connections-and-additional-hardware/casparcg-server-installation#decklink-cards) section for compatibility.
+- [Blackmagic Design's DeckLink Cards](https://www.blackmagicdesign.com/products/decklink/models) on Blackmagic Design's website. Check the [DeckLink cards](installation/installing-connections-and-additional-hardware/casparcg-server-installation.md#decklink-cards) section for compatibility.
 - [Installing a DeckLink Card](https://documents.blackmagicdesign.com/UserManuals/DesktopVideoManual.pdf) as a PDF.
 - [Blackmagic Design 'Desktop Video' Driver Download](https://www.blackmagicdesign.com/support/family/capture-and-playback) on Blackmagic Design's website.
 - [CasparCG&nbsp;Server Configuration Validator](https://casparcg.net/validator/)

--- a/packages/documentation/docs/user-guide/installation/initial-sofie-core-setup.md
+++ b/packages/documentation/docs/user-guide/installation/initial-sofie-core-setup.md
@@ -6,9 +6,9 @@ sidebar_position: 3
 
 #### Prerequisites
 
-* [Installed and running _Sofie&nbsp;Core_](installing-sofie-server-core)
+* [Installed and running _Sofie&nbsp;Core_](installing-sofie-server-core.md)
 
-Once _Sofie&nbsp;Core_ has been installed and is running you can begin setting it up. The first step is to navigate to the _Settings page_. Please review the [Sofie Access Level](../features/access-levels) page for assistance getting there.
+Once _Sofie&nbsp;Core_ has been installed and is running you can begin setting it up. The first step is to navigate to the _Settings page_. Please review the [Sofie Access Level](../features/access-levels.md) page for assistance getting there.
 
 To upgrade to a newer version or installation of new blueprints, Sofie needs to run its "Upgrade database" procedure to migrate data and pre-fill various settings. You can do this by clicking the _Upgrade Database_ button in the menu. 
 
@@ -16,5 +16,5 @@ To upgrade to a newer version or installation of new blueprints, Sofie needs to 
 
 Fill in the form as prompted and continue by clicking _Run Migrations Procedure_. Sometimes you will need to go through multiple steps before the upgrade is finished.
 
-Next, you will need to add some [Blueprints](installing-blueprints) and add [Gateways](installing-a-gateway/intro) to allow _Sofie_ to interpret rundown data and then play out things.
+Next, you will need to add some [Blueprints](installing-blueprints.md) and add [Gateways](installing-a-gateway/intro.md) to allow _Sofie_ to interpret rundown data and then play out things.
 

--- a/packages/documentation/docs/user-guide/installation/installing-a-gateway/intro.md
+++ b/packages/documentation/docs/user-guide/installation/installing-a-gateway/intro.md
@@ -6,20 +6,20 @@ sidebar_position: 1
 
 #### Prerequisites
 
-* [Installed and running Sofie&nbsp;Core](../installing-sofie-server-core)
+* [Installed and running Sofie&nbsp;Core](../installing-sofie-server-core.md)
 
-The _Sofie&nbsp;Core_ is the primary application for managing the broadcast, but it doesn't play anything out on it's own. A Gateway will establish the connection from _Sofie&nbsp;Core_ to other pieces of hardware or remote software. A basic setup may include the [Spreadsheet Gateway](rundown-or-newsroom-system-connection/installing-sofie-with-google-spreadsheet-support) which will ingest a rundown from Google Sheets then, use the [Playout Gateway](playout-gateway) send commands to a CasparCG&nbsp;Server graphics playout, an ATEM vision mixer, and / or the [Sisyfos audio controller](https://github.com/olzzon/sisyfos-audio-controller).
+The _Sofie&nbsp;Core_ is the primary application for managing the broadcast, but it doesn't play anything out on it's own. A Gateway will establish the connection from _Sofie&nbsp;Core_ to other pieces of hardware or remote software. A basic setup may include the [Spreadsheet Gateway](rundown-or-newsroom-system-connection/installing-sofie-with-google-spreadsheet-support.md) which will ingest a rundown from Google Sheets then, use the [Playout Gateway](playout-gateway.md) send commands to a CasparCG&nbsp;Server graphics playout, an ATEM vision mixer, and / or the [Sisyfos audio controller](https://github.com/olzzon/sisyfos-audio-controller).
 
-Installing a gateway is a two part process. To begin, you will [add the required Blueprints](../installing-blueprints), or mini plug-in programs, to _Sofie&nbsp;Core_ so it can manipulate the data from the Gateway. Then you will install the Gateway itself. Each Gateway follows a similar installation pattern but, each one does differ slightly. The links below will help you navigate to the correct Gateway for the piece of hardware / software you are using.
+Installing a gateway is a two part process. To begin, you will [add the required Blueprints](../installing-blueprints.md), or mini plug-in programs, to _Sofie&nbsp;Core_ so it can manipulate the data from the Gateway. Then you will install the Gateway itself. Each Gateway follows a similar installation pattern but, each one does differ slightly. The links below will help you navigate to the correct Gateway for the piece of hardware / software you are using.
 
 ### Rundown & Newsroom Gateways
 
-* [Google Spreadsheet Gateway](rundown-or-newsroom-system-connection/installing-sofie-with-google-spreadsheet-support)
-* [iNEWS Gateway](rundown-or-newsroom-system-connection/inews-gateway)
-* [MOS Gateway](rundown-or-newsroom-system-connection/mos-gateway)
+* [Google Spreadsheet Gateway](rundown-or-newsroom-system-connection/installing-sofie-with-google-spreadsheet-support.md)
+* [iNEWS Gateway](rundown-or-newsroom-system-connection/inews-gateway.md)
+* [MOS Gateway](rundown-or-newsroom-system-connection/mos-gateway.md)
 
 ### Playout & Media Manager Gateways
 
-* [Playout Gateway](playout-gateway)
-* [Media Manager](../media-manager)
+* [Playout Gateway](playout-gateway.md)
+* [Media Manager](../media-manager.md)
 

--- a/packages/documentation/docs/user-guide/installation/installing-a-gateway/rundown-or-newsroom-system-connection/installing-sofie-with-google-spreadsheet-support.md
+++ b/packages/documentation/docs/user-guide/installation/installing-a-gateway/rundown-or-newsroom-system-connection/installing-sofie-with-google-spreadsheet-support.md
@@ -6,7 +6,7 @@ The Spreadsheet Gateway is an application for piping data between Sofie&nbsp;Cor
 
 To begin with, you will need to install a set of Blueprints that can handle the data being sent from the _Gateway_ to _Sofie&nbsp;Core_. Download the `demo-blueprints-r*.zip` file containing the blueprints you need from the [Demo Blueprints GitHub Repository](https://github.com/SuperFlyTV/sofie-demo-blueprints/releases). It is recommended to choose the newest release but, an older _Sofie&nbsp;Core_ version may require a different Blueprint version. The _Rundown page_ will warn you about any issue and display the desired versions.
 
-Instructions on how to install any Blueprint can be found in the [Installing Blueprints](../../installing-blueprints) section from earlier.
+Instructions on how to install any Blueprint can be found in the [Installing Blueprints](../../installing-blueprints.md) section from earlier.
 
 ### Spreadsheet Gateway Configuration
 

--- a/packages/documentation/docs/user-guide/installation/installing-a-gateway/rundown-or-newsroom-system-connection/mos-gateway.md
+++ b/packages/documentation/docs/user-guide/installation/installing-a-gateway/rundown-or-newsroom-system-connection/mos-gateway.md
@@ -2,7 +2,7 @@
 
 The MOS Gateway communicates with a device that supports the [MOS protocol](http://mosprotocol.com/wp-content/MOS-Protocol-Documents/MOS-Protocol-2.8.4-Current.htm) to ingest and remain in sync with a rundown. It can connect to any editorial system \(NRCS\) that uses version 2.8.4 of the MOS protocol, such as ENPS, and sync their rundowns with the _Sofie&nbsp;Core_. The rundowns are kept updated in real time and any changes made will be seen in the Sofie GUI.
 
-The setup for the MOS Gateway is handled in the Docker Compose in the [Quick Install](../../installing-sofie-server-core) page.
+The setup for the MOS Gateway is handled in the Docker Compose in the [Quick Install](../../installing-sofie-server-core.md) page.
 
 One thing to note if managing the mos-gateway manually: It needs a few ports open \(10540, 10541\) for MOS-messages to be pushed to it from the NCS.
 

--- a/packages/documentation/docs/user-guide/installation/installing-blueprints.md
+++ b/packages/documentation/docs/user-guide/installation/installing-blueprints.md
@@ -6,14 +6,14 @@ sidebar_position: 4
 
 #### Prerequisites
 
-- [Installed and running Sofie&nbsp;Core](installing-sofie-server-core)
-- [Initial Sofie&nbsp;Core Setup](initial-sofie-core-setup)
+- [Installed and running Sofie&nbsp;Core](installing-sofie-server-core.md)
+- [Initial Sofie&nbsp;Core Setup](initial-sofie-core-setup.md)
 
 Blueprints are little plug-in programs that runs inside _Sofie_. They are the logic that determines how _Sofie_ interacts with rundowns, hardware, and media.
 
 Blueprints are custom scripts that you create yourself \(or download an existing one\). There are a set of example Blueprints for the Spreadsheet Gateway available for use here: [https://github.com/SuperFlyTV/sofie-demo-blueprints](https://github.com/SuperFlyTV/sofie-demo-blueprints).
 
-To begin installing any Blueprint, navigate to the _Settings page_. Getting there is covered in the [Access Levels](../features/access-levels) page.
+To begin installing any Blueprint, navigate to the _Settings page_. Getting there is covered in the [Access Levels](../features/access-levels.md) page.
 
 ![The Settings Page](/img/docs/getting-started/settings-page.jpg)
 

--- a/packages/documentation/docs/user-guide/installation/installing-connections-and-additional-hardware/README.md
+++ b/packages/documentation/docs/user-guide/installation/installing-connections-and-additional-hardware/README.md
@@ -2,14 +2,14 @@
 
 #### Prerequisites
 
-* [Installed and running Sofie&nbsp;Core](../installing-sofie-server-core)
-* [Installed Playout Gateway](../installing-a-gateway/playout-gateway)
-* [Installed and configured Studio Blueprints](../installing-blueprints#installing-a-studio-blueprint)
+* [Installed and running Sofie&nbsp;Core](../installing-sofie-server-core.md)
+* [Installed Playout Gateway](../installing-a-gateway/playout-gateway.md)
+* [Installed and configured Studio Blueprints](../installing-blueprints.md#installing-a-studio-blueprint)
 
 The following pages are broken up by equipment type that is supported by Sofie's Gateways.
 
 ## Playout & Recording
-* [CasparCG Graphics and Video Server](casparcg-server-installation) - _Graphics / Playout / Recording_
+* [CasparCG Graphics and Video Server](casparcg-server-installation.md) - _Graphics / Playout / Recording_
 * [Blackmagic Design's HyperDeck](https://www.blackmagicdesign.com/products/hyperdeckstudio) - _Recording_ 
 * [Quantel](http://www.quantel.com) Solutions - _Playout_
 * [Vizrt](https://www.vizrt.com/) Graphics Solutions - _Graphics / Playout_

--- a/packages/documentation/docs/user-guide/installation/installing-connections-and-additional-hardware/casparcg-server-installation.md
+++ b/packages/documentation/docs/user-guide/installation/installing-connections-and-additional-hardware/casparcg-server-installation.md
@@ -119,7 +119,7 @@ The default configuration will give you one preview window. No additional change
 
 #### Required Hardware
 
-To be production ready, you will need to output an SDI or HDMI signal from your production machine. CasparCG&nbsp;Server supports Blackmagic Design's DeckLink cards because they provide a key generator which will aid in keeping the alpha and fill channels of your graphics in sync. Please review the [DeckLink Cards](casparcg-server-installation#decklink-cards) section of this page to choose which card will best fit your production needs.
+To be production ready, you will need to output an SDI or HDMI signal from your production machine. CasparCG&nbsp;Server supports Blackmagic Design's DeckLink cards because they provide a key generator which will aid in keeping the alpha and fill channels of your graphics in sync. Please review the [DeckLink Cards](casparcg-server-installation.md#decklink-cards) section of this page to choose which card will best fit your production needs.
 
 #### Configuration
 
@@ -213,7 +213,7 @@ A window will open and display the status for the server and scanner. You can st
 
 ## Connecting Sofie to the CasparCG&nbsp;Server
 
-Now that your CasparCG&nbsp;Server software is running, you can connect it to the _Sofie&nbsp;Core_. Navigate back to the _Settings page_ and in the menu, select the _Playout Gateway_. If the _Playout Gateway's_ status does not read _Good_, then please review the [Installing and Setting up the Playout Gateway](../installing-a-gateway/playout-gateway) section of this guide.
+Now that your CasparCG&nbsp;Server software is running, you can connect it to the _Sofie&nbsp;Core_. Navigate back to the _Settings page_ and in the menu, select the _Playout Gateway_. If the _Playout Gateway's_ status does not read _Good_, then please review the [Installing and Setting up the Playout Gateway](../installing-a-gateway/playout-gateway.md) section of this guide.
 
 Under the Sub Devices section, you can add a new device with the _+_ button. Then select the pencil \( edit \) icon on the new device to open the sub device's settings. Select the _Device Type_ option and choose _CasparCG_ from the drop down menu. Some additional fields will be added to the form.
 
@@ -227,7 +227,7 @@ In the _Attached Sub Devices_ section, you should now see the status of the Casp
 - [Media Scanner Releases](https://github.com/nrkno/sofie-media-scanner/releases) on GitHub.
 - [CasparCG Launcher](https://github.com/nrkno/sofie-casparcg-launcher) on GitHub.
 - [Microsoft Visual C++ 2015 Redistributable](https://www.microsoft.com/en-us/download/details.aspx?id=52685) on Microsoft's website.
-- [Blackmagic Design's DeckLink Cards](https://www.blackmagicdesign.com/products/decklink/models) on Blackmagic's website. Check the [DeckLink cards](casparcg-server-installation#decklink-cards) section for compatibility.
+- [Blackmagic Design's DeckLink Cards](https://www.blackmagicdesign.com/products/decklink/models) on Blackmagic's website. Check the [DeckLink cards](casparcg-server-installation.md#decklink-cards) section for compatibility.
 - [Installing a DeckLink Card](https://documents.blackmagicdesign.com/UserManuals/DesktopVideoManual.pdf) as a PDF.
 - [Desktop Video Download Page](https://www.blackmagicdesign.com/support/family/capture-and-playback) on Blackmagic's website.
 - [CasparCG Configuration Validator](https://casparcg.net/validator/)

--- a/packages/documentation/docs/user-guide/installation/installing-connections-and-additional-hardware/vision-mixers.md
+++ b/packages/documentation/docs/user-guide/installation/installing-connections-and-additional-hardware/vision-mixers.md
@@ -2,7 +2,7 @@
 
 ## ATEM – Blackmagic Design 
 
-The [Playout Gateway](../installing-a-gateway/playout-gateway) supports communicating with the entire line up of Blackmagic Design's ATEM vision mixers.
+The [Playout Gateway](../installing-a-gateway/playout-gateway.md) supports communicating with the entire line up of Blackmagic Design's ATEM vision mixers.
 
 ### Connecting Sofie
 

--- a/packages/documentation/docs/user-guide/installation/installing-package-manager.md
+++ b/packages/documentation/docs/user-guide/installation/installing-package-manager.md
@@ -6,11 +6,11 @@ sidebar_position: 7
 
 ### Prerequisites
 
-- [Installed and running Sofie&nbsp;Core](installing-sofie-server-core)
-- [Initial Sofie&nbsp;Core Setup](initial-sofie-core-setup)
+- [Installed and running Sofie&nbsp;Core](installing-sofie-server-core.md)
+- [Initial Sofie&nbsp;Core Setup](initial-sofie-core-setup.md)
 - [Installed and configured Demo Blueprints](https://github.com/SuperFlyTV/sofie-demo-blueprints)
-- [Installed, configured, and running CasparCG&nbsp;Server](installing-connections-and-additional-hardware/casparcg-server-installation)
-- [`FFmpeg` and `FFprobe` available in `PATH`](installing-connections-and-additional-hardware/ffmpeg-installation)
+- [Installed, configured, and running CasparCG&nbsp;Server](installing-connections-and-additional-hardware/casparcg-server-installation.md)
+- [`FFmpeg` and `FFprobe` available in `PATH`](installing-connections-and-additional-hardware/ffmpeg-installation.md)
 
 Package Manager is used by Sofie to copy, analyze, and process media files. It is what powers Sofie's ability to copy media files to playout devices, to know when a media file is ready for playout, and to display details about media files in the rundown view such as scene changes, black frames, freeze frames, and more.
 
@@ -58,7 +58,7 @@ We provide pre-built executables for Windows (x64) systems that can be used in p
 package-manager-single-app.exe --coreHost=<Core Host Name> --corePort=<Core HTTP(S) port> --deviceId=<Peripheral Device Id> --deviceToken=<Peripheral Device Token/Password>
 ```
 
-Package Manager can be launched from [CasparCG Launcher](./installing-connections-and-additional-hardware/casparcg-server-installation#installing-the-casparcg-launcher) alongside Caspar-CG. This will make management and log collection easier on a production Video Server.
+Package Manager can be launched from [CasparCG Launcher](./installing-connections-and-additional-hardware/casparcg-server-installation.md#installing-the-casparcg-launcher) alongside Caspar-CG. This will make management and log collection easier on a production Video Server.
 
 You can see a list of available options by running `package-manager-single-app.exe --help`.
 
@@ -82,7 +82,7 @@ You can see a list of available options by running `package-manager-single-app.e
 
 In this basic configuration, Package Manager won't be copying any packages into your CasparCG&nbsp;Server media folder. Instead, it will simply check that the files in the rundown are present in your CasparCG&nbsp;Server media folder, and you'll have to manually place those files in the correct directory. However, thumbnail and preview generation will still function, as will status reporting.
 
-If you're using the demo rundown provided by the [Rundown Editor](rundown-editor), you should already see work statuses on the Package Status page ([Status > Packages](http://localhost:3000/status/expected-packages)).
+If you're using the demo rundown provided by the [Rundown Editor](rundown-editor.md), you should already see work statuses on the Package Status page ([Status > Packages](http://localhost:3000/status/expected-packages)).
 
 ![Example Package Manager status display](/img/docs/Package_Manager_status_example.jpg)
 

--- a/packages/documentation/docs/user-guide/installation/installing-sofie-server-core.md
+++ b/packages/documentation/docs/user-guide/installation/installing-sofie-server-core.md
@@ -13,7 +13,7 @@ sidebar_position: 2
 
 ### Installation
 
-This docker-compose file automates the basic setup of the [Sofie-Core application](../../for-developers/libraries#main-application), the backend database and different Gateway options.
+This docker-compose file automates the basic setup of the [Sofie-Core application](../../for-developers/libraries.md#main-application), the backend database and different Gateway options.
 
 ```yaml
 # This is NOT recommended to be used for a production deployment.
@@ -112,13 +112,13 @@ volumes:
 
 Create a `Sofie` folder, copy the above content, and save it as `docker-compose.yaml` within the `Sofie` folder.
 
-Navigate to the _ingest-gateway_ section of `docker-compose.yaml` and select which type of _ingest-gateway_ you'd like installed by uncommenting it. Save your changes. If you are using the [Rundown Editor](rundown-editor), then no ingest gateways need to be uncommented.
+Navigate to the _ingest-gateway_ section of `docker-compose.yaml` and select which type of _ingest-gateway_ you'd like installed by uncommenting it. Save your changes. If you are using the [Rundown Editor](rundown-editor.md), then no ingest gateways need to be uncommented.
 
 Then open a terminal, `cd your-sofie-folder` and `sudo docker-compose up` \(just `docker-compose up` on Windows\).
 
 Once the installation is done, Sofie should be running on [http://localhost:3000](http://localhost:3000)
 
-Next, you will need to install a Rundown Gateway. Visit [Rundowns & Newsroom Systems](installing-a-gateway/rundown-or-newsroom-system-connection/intro) to see which _Rundown Gateway_ is best suited for _your_ production environment.
+Next, you will need to install a Rundown Gateway. Visit [Rundowns & Newsroom Systems](installing-a-gateway/rundown-or-newsroom-system-connection/intro.md) to see which _Rundown Gateway_ is best suited for _your_ production environment.
 
 ### Tips for running in production
 
@@ -133,6 +133,6 @@ There are some things not covered in this guide needed to run _Sofie_ in a produ
 Installation instructions for installing Sofie-Core or the various gateways are available in the README file in their respective github repos.
 
 Common prerequisites are [Node.js](https://nodejs.org/) and [Yarn](https://yarnpkg.com/).  
-Links to the repos are listed at [Applications & Libraries](../../for-developers/libraries).
+Links to the repos are listed at [Applications & Libraries](../../for-developers/libraries.md).
 
 [_Sofie&nbsp;Core_ GitHub Page for Developers](https://github.com/nrkno/sofie-core)

--- a/packages/documentation/docs/user-guide/installation/intro.md
+++ b/packages/documentation/docs/user-guide/installation/intro.md
@@ -3,9 +3,9 @@ sidebar_position: 1
 ---
 # Getting Started
 
-_Sofie_ can be installed in many different ways, depending on which platforms, needs, and features you desire. The _Sofie_ system consists of several applications that work together to provide complete broadcast automation system. Each of these components' installation will be covered in this guide. Additional information about the products or services mentioned alongside the Sofie Installation can be found on the [Further Reading](../further-reading).
+_Sofie_ can be installed in many different ways, depending on which platforms, needs, and features you desire. The _Sofie_ system consists of several applications that work together to provide complete broadcast automation system. Each of these components' installation will be covered in this guide. Additional information about the products or services mentioned alongside the Sofie Installation can be found on the [Further Reading](../further-reading.md).
 
-There are four minimum required components to get a Sofie system up and running. First you need the [_Sofie Core_](installing-sofie-server-core), which is the brains of the operation. Then a set of [_Blueprints_](installing-blueprints) to handle and interpret incoming and outgoing data. Next, an [_Ingest Gateway_](installing-a-gateway/rundown-or-newsroom-system-connection/intro) to fetch the data for the Blueprints. Then finally, a [_Playout Gateway_](installing-a-gateway/playout-gateway) to send the data to your playout device of choice.
+There are four minimum required components to get a Sofie system up and running. First you need the [_Sofie Core_](installing-sofie-server-core.md), which is the brains of the operation. Then a set of [_Blueprints_](installing-blueprints.md) to handle and interpret incoming and outgoing data. Next, an [_Ingest Gateway_](installing-a-gateway/rundown-or-newsroom-system-connection/intro.md) to fetch the data for the Blueprints. Then finally, a [_Playout Gateway_](installing-a-gateway/playout-gateway.md) to send the data to your playout device of choice.
 
 
 
@@ -19,7 +19,7 @@ The _Status_ views displays the current status for the attached devices and gate
 
 ![Status View &#x2013; Describes the state of _Sofie&nbsp;Core_](/img/docs/getting-started/status-page.jpg)
 
-The _Settings_ views contains various settings for the studio, show styles, blueprints etc.. If the link to the settings view is not visible in your application, check your [Access Levels](../features/access-levels). More info on specific parts of the _Settings_ view can be found in their corresponding guide sections. 
+The _Settings_ views contains various settings for the studio, show styles, blueprints etc.. If the link to the settings view is not visible in your application, check your [Access Levels](../features/access-levels.md). More info on specific parts of the _Settings_ view can be found in their corresponding guide sections. 
 
 ![Settings View &#x2013; Describes how the _Sofie&nbsp;Core_ is configured](/img/docs/getting-started/settings-page.jpg)
 
@@ -29,7 +29,7 @@ The _Sofie&nbsp;Core_ is the primary application for managing the broadcast but,
 
 ### Gateways
 
-Gateways are separate applications that bridge the gap between the _Sofie&nbsp;Core_ and other pieces of hardware or services. At minimum, you will need a _Playout Gateway_ so your timeline can interact with your playout system of choice. To install the _Playout Gateway_, visit the [Installing a Gateway](installing-a-gateway/intro) section of this guide and for a more in-depth look, please see [Gateways](../concepts-and-architecture#gateways). 
+Gateways are separate applications that bridge the gap between the _Sofie&nbsp;Core_ and other pieces of hardware or services. At minimum, you will need a _Playout Gateway_ so your timeline can interact with your playout system of choice. To install the _Playout Gateway_, visit the [Installing a Gateway](installing-a-gateway/intro.md) section of this guide and for a more in-depth look, please see [Gateways](../concepts-and-architecture.md#gateways). 
 
 ### Blueprints
 

--- a/packages/documentation/docs/user-guide/intro.md
+++ b/packages/documentation/docs/user-guide/intro.md
@@ -18,12 +18,12 @@ sidebar_position: 0
 ![The prompter view](/img/docs/prompter-view.png)
 
 :::info
-Tip: The different web views \(such as the host view and the prompter\) can easily be transmitted over an SDI signal using the HTML producer in [CasparCG](installation/installing-connections-and-additional-hardware/casparcg-server-installation).
+Tip: The different web views \(such as the host view and the prompter\) can easily be transmitted over an SDI signal using the HTML producer in [CasparCG](installation/installing-connections-and-additional-hardware/casparcg-server-installation.md).
 :::
 
 ### Modular Device Control
 
-Sofie controls playout devices \(such as vision and audio mixers, graphics and video playback\) via the Playout Gateway, using the [Timeline](concepts-and-architecture#timeline).  
+Sofie controls playout devices \(such as vision and audio mixers, graphics and video playback\) via the Playout Gateway, using the [Timeline](concepts-and-architecture.md#timeline).  
 The Playout Gateway controls the devices and keeps track of their state and statuses, and lets the user know via the GUI if something's wrong that can affect the show.
 
 ### _State-based Playout_
@@ -37,5 +37,5 @@ Sofie features a modular ingest data-flow, allowing multiple types of input data
 
 ### Blueprints
 
-The [Blueprints](concepts-and-architecture#blueprints) are plugins to _Sofie_, which allows for customization and tailor-made show designs.
+The [Blueprints](concepts-and-architecture.md#blueprints) are plugins to _Sofie_, which allows for customization and tailor-made show designs.
 The blueprints are made different depending on how the input data \(rundowns\) look like, how the show-design look like, and what devices to control.


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix links in the documentation that did not end in `.md`

* **What is the current behavior?** (You can also link to an open issue here)

https://github.com/nrkno/Sofie-TV-automation/issues/54

* **What is the new behavior (if this is a feature change)?**

Links end in `.md`, see https://github.com/facebook/docusaurus/issues/8693#issuecomment-1441547554 as to why this is nexessary

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
