### PR TITLE
fix: Changes the wrong title "Delete" to "Restart".

### DIFF
--- a/meteor/client/ui/Status/SystemStatus.tsx
+++ b/meteor/client/ui/Status/SystemStatus.tsx
@@ -306,8 +306,10 @@ export const DeviceItem = reacti18next.withTranslation()(
 											e.stopPropagation()
 
 											doModalDialog({
-												title: t('Delete'),
-												message: <p>{t('Are you sure you want to restart this device?')}</p>,
+												message: t('Are you sure you want to restart this device?'),
+												title: t('Restart this Device?'),
+												yes: t('Restart'),
+												no: t('Cancel'),
 												onAccept: () => {
 													const { t } = this.props
 													PeripheralDevicesAPI.restartDevice(this.props.device, e)


### PR DESCRIPTION
Also set all other properties of the modal to match a similar modal with the same message, presented somewhere else in the system - for consistency.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix


* **What is the current behavior?** (You can also link to an open issue here)
Modal title says "Delete"


* **What is the new behavior (if this is a feature change)?**
Modal title says "Restart"
Also, conforms this modal to another similar one for consistency.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
