### PR TITLE
feat: respect json schema required field in ui SOFIE-2436

### DIFF
--- a/meteor/client/lib/forms/SchemaFormForCollection.tsx
+++ b/meteor/client/lib/forms/SchemaFormForCollection.tsx
@@ -10,7 +10,7 @@ import { WrappedOverridableItemNormal, OverrideOpHelperForItemContents } from '.
 import { SchemaFormCommonProps } from './schemaFormUtil'
 import { SchemaFormWithOverrides } from './SchemaFormWithOverrides'
 
-interface SchemaFormForCollectionProps extends SchemaFormCommonProps {
+interface SchemaFormForCollectionProps extends Omit<SchemaFormCommonProps, 'isRequired'> {
 	/** The collection to operate on */
 	collection: MongoCollection<any>
 	/** Id of the document in the collection */
@@ -80,7 +80,7 @@ export function SchemaFormForCollection({
 		}
 	}, [object, partialOverridesForObject])
 
-	return <SchemaFormWithOverrides {...commonProps} attr={''} item={wrappedItem} overrideHelper={helper} />
+	return <SchemaFormWithOverrides {...commonProps} attr={''} item={wrappedItem} overrideHelper={helper} isRequired />
 }
 
 /**

--- a/meteor/client/lib/forms/SchemaFormInPlace.tsx
+++ b/meteor/client/lib/forms/SchemaFormInPlace.tsx
@@ -4,7 +4,7 @@ import { WrappedOverridableItemNormal, OverrideOpHelperForItemContents } from '.
 import { SchemaFormCommonProps } from './schemaFormUtil'
 import { SchemaFormWithOverrides } from './SchemaFormWithOverrides'
 
-interface SchemaFormInPlaceProps extends SchemaFormCommonProps {
+interface SchemaFormInPlaceProps extends Omit<SchemaFormCommonProps, 'isRequired'> {
 	/** The object to be modified in place */
 	object: any
 }
@@ -27,7 +27,7 @@ export function SchemaFormInPlace({ object, ...commonProps }: SchemaFormInPlaceP
 		[object, editCount]
 	)
 
-	return <SchemaFormWithOverrides {...commonProps} attr={''} item={wrappedItem} overrideHelper={helper} />
+	return <SchemaFormWithOverrides {...commonProps} attr={''} item={wrappedItem} overrideHelper={helper} isRequired />
 }
 
 /**

--- a/meteor/client/lib/forms/SchemaFormTable/ArrayTable.tsx
+++ b/meteor/client/lib/forms/SchemaFormTable/ArrayTable.tsx
@@ -134,6 +134,7 @@ export const SchemaFormArrayTable = ({
 							<ArrayTableRow
 								key={i}
 								columns={columns}
+								requiredColumns={schema.items?.required}
 								summaryFields={summaryFields}
 								translationNamespaces={translationNamespaces}
 								sofieEnumDefinitons={sofieEnumDefinitons}

--- a/meteor/client/lib/forms/SchemaFormTable/ArrayTableRow.tsx
+++ b/meteor/client/lib/forms/SchemaFormTable/ArrayTableRow.tsx
@@ -6,9 +6,11 @@ import { literal } from '@sofie-automation/shared-lib/dist/lib/lib'
 import { JSONSchema } from '@sofie-automation/blueprints-integration'
 import { SchemaSummaryField, SchemaFormSofieEnumDefinition } from '../schemaFormUtil'
 import { OverrideOpHelperArrayTable } from './ArrayTableOpHelper'
+import { ReadonlyDeep } from 'type-fest'
 
 interface ArrayTableRowProps {
 	columns: Record<string, JSONSchema | undefined>
+	requiredColumns: ReadonlyDeep<string[]> | undefined
 	summaryFields: SchemaSummaryField[]
 	translationNamespaces: string[]
 	sofieEnumDefinitons: Record<string, SchemaFormSofieEnumDefinition> | undefined
@@ -25,6 +27,7 @@ interface ArrayTableRowProps {
 
 export function ArrayTableRow({
 	columns,
+	requiredColumns,
 	summaryFields,
 	translationNamespaces,
 	sofieEnumDefinitons,
@@ -64,6 +67,7 @@ export function ArrayTableRow({
 					sofieEnumDefinitons={sofieEnumDefinitons}
 					rowId={rowId}
 					columns={columns}
+					requiredColumns={requiredColumns}
 					rowItem={rowItem}
 					editItem={toggleExpanded}
 					overrideHelper={overrideHelper}

--- a/meteor/client/lib/forms/SchemaFormTable/ObjectTable.tsx
+++ b/meteor/client/lib/forms/SchemaFormTable/ObjectTable.tsx
@@ -192,6 +192,7 @@ export const SchemaFormObjectTable = ({
 											sofieEnumDefinitons={sofieEnumDefinitons}
 											rowId={rowItem.id}
 											columns={columns}
+											requiredColumns={rowSchema?.required}
 											rowItem={rowItem}
 											editItem={toggleExpanded}
 											overrideHelper={tableOverrideHelper}

--- a/meteor/client/lib/forms/SchemaFormTable/TableEditRow.tsx
+++ b/meteor/client/lib/forms/SchemaFormTable/TableEditRow.tsx
@@ -6,12 +6,14 @@ import { OverrideOpHelperForItemContents } from '../../../ui/Settings/util/Overr
 import { SchemaFormSofieEnumDefinition } from '../schemaFormUtil'
 import { SchemaFormWithOverrides } from '../SchemaFormWithOverrides'
 import { JSONSchema } from '@sofie-automation/shared-lib/dist/lib/JSONSchemaTypes'
+import { ReadonlyDeep } from 'type-fest'
 
 interface SchemaFormTableEditRowProps {
 	sofieEnumDefinitons: Record<string, SchemaFormSofieEnumDefinition> | undefined
 	translationNamespaces: string[]
 	rowId: number | string
 	columns: Record<string, JSONSchema | undefined>
+	requiredColumns: ReadonlyDeep<string[]> | undefined
 	editItem: (rowId: number | string, forceState?: boolean) => void
 
 	rowItem: any
@@ -23,6 +25,7 @@ export function SchemaFormTableEditRow({
 	translationNamespaces,
 	rowId,
 	columns,
+	requiredColumns,
 	editItem,
 	rowItem,
 	overrideHelper,
@@ -44,6 +47,7 @@ export function SchemaFormTableEditRow({
 								overrideHelper={overrideHelper}
 								translationNamespaces={translationNamespaces}
 								allowTables
+								isRequired={requiredColumns?.includes(id) ?? false}
 							/>
 						) : (
 							''

--- a/meteor/client/lib/forms/SchemaFormWithOverrides.tsx
+++ b/meteor/client/lib/forms/SchemaFormWithOverrides.tsx
@@ -235,12 +235,14 @@ interface EnumFormControlWrapperProps extends FormComponentProps {
 	options: DropdownInputOption<any>[]
 }
 const EnumFormControlWrapper = ({ commonAttrs, multiple, options, isRequired }: EnumFormControlWrapperProps) => {
+	const { t } = useTranslation()
+
 	const optionsWithNoneField = useMemo(() => {
 		if (isRequired && !multiple) {
 			return [
 				{
 					i: -1,
-					name: 'None',
+					name: t('None'),
 					value: undefined,
 				},
 				...options,
@@ -248,7 +250,7 @@ const EnumFormControlWrapper = ({ commonAttrs, multiple, options, isRequired }: 
 		} else {
 			return options
 		}
-	}, [options, isRequired, multiple])
+	}, [t, options, isRequired, multiple])
 
 	return (
 		<>

--- a/meteor/client/lib/forms/SchemaFormWithOverrides.tsx
+++ b/meteor/client/lib/forms/SchemaFormWithOverrides.tsx
@@ -45,6 +45,9 @@ interface FormComponentProps {
 		itemKey: string
 		opPrefix: string
 	}
+
+	/** Whether this field has been marked as "required" */
+	isRequired: boolean
 }
 
 function useChildPropsForFormComponent(props: SchemaFormWithOverridesProps) {
@@ -63,8 +66,9 @@ function useChildPropsForFormComponent(props: SchemaFormWithOverridesProps) {
 				opPrefix: props.item.id,
 				overrideHelper: props.overrideHelper,
 			},
+			isRequired: props.isRequired,
 		}
-	}, [props.schema, props.translationNamespaces, props.attr, props.item, props.overrideHelper])
+	}, [props.schema, props.translationNamespaces, props.attr, props.item, props.overrideHelper, props.isRequired])
 }
 
 export function SchemaFormWithOverrides(props: SchemaFormWithOverridesProps): JSX.Element {
@@ -170,6 +174,7 @@ const ObjectFormWithOverrides = (props: SchemaFormWithOverridesProps) => {
 						translationNamespaces={props.translationNamespaces}
 						sofieEnumDefinitons={props.sofieEnumDefinitons}
 						allowTables={props.allowTables}
+						isRequired={props.schema.required?.includes(index) ?? false}
 					/>
 				)
 			})}
@@ -229,10 +234,25 @@ interface EnumFormControlWrapperProps extends FormComponentProps {
 
 	options: DropdownInputOption<any>[]
 }
-const EnumFormControlWrapper = ({ commonAttrs, multiple, options }: EnumFormControlWrapperProps) => {
+const EnumFormControlWrapper = ({ commonAttrs, multiple, options, isRequired }: EnumFormControlWrapperProps) => {
+	const optionsWithNoneField = useMemo(() => {
+		if (isRequired && !multiple) {
+			return [
+				{
+					i: -1,
+					name: 'None',
+					value: undefined,
+				},
+				...options,
+			]
+		} else {
+			return options
+		}
+	}, [options, isRequired, multiple])
+
 	return (
 		<>
-			<LabelAndOverridesForDropdown {...commonAttrs} options={options}>
+			<LabelAndOverridesForDropdown {...commonAttrs} options={optionsWithNoneField}>
 				{(value, handleUpdate, options) => {
 					if (multiple) {
 						return (

--- a/meteor/client/lib/forms/schemaFormUtil.tsx
+++ b/meteor/client/lib/forms/schemaFormUtil.tsx
@@ -21,6 +21,9 @@ export interface SchemaFormCommonProps {
 	/** Allow special 'built-in' enum types to be used with the 'ui:sofie-enum' property in the schema */
 	sofieEnumDefinitons?: Record<string, SchemaFormSofieEnumDefinition>
 
+	/** Whether this field has been marked as "required" */
+	isRequired: boolean
+
 	/**
 	 * In some situations, it is desirable to not allow tables to be used by a schema
 	 * For example, a table inside a table will not display properly so this gets set automatically

--- a/meteor/client/ui/Settings/BlueprintConfigSchema/CategoryEntry.tsx
+++ b/meteor/client/ui/Settings/BlueprintConfigSchema/CategoryEntry.tsx
@@ -60,6 +60,7 @@ export function ConfigCategoryEntry({
 								item={wrappedItem}
 								overrideHelper={overrideHelper}
 								sofieEnumDefinitons={sofieEnumDefinitons}
+								isRequired
 							/>
 						</div>
 						<div className="mod alright">

--- a/meteor/client/ui/Settings/Studio/Devices/GenericSubDevices.tsx
+++ b/meteor/client/ui/Settings/Studio/Devices/GenericSubDevices.tsx
@@ -393,6 +393,7 @@ function SubDeviceEditForm({ peripheralDevice, item, overrideHelper }: SubDevice
 					overrideHelper={overrideHelper}
 					translationNamespaces={translationNamespaces}
 					allowTables
+					isRequired
 				/>
 			)}
 
@@ -404,6 +405,7 @@ function SubDeviceEditForm({ peripheralDevice, item, overrideHelper }: SubDevice
 					overrideHelper={overrideHelper}
 					translationNamespaces={translationNamespaces}
 					allowTables
+					isRequired
 				/>
 			) : (
 				<p>{t('Device is of unknown type')}</p>

--- a/meteor/client/ui/Settings/Studio/Mappings.tsx
+++ b/meteor/client/ui/Settings/Studio/Mappings.tsx
@@ -554,6 +554,7 @@ function StudioMappingsEntry({
 											item={mappingSchemaItem}
 											attr="options"
 											overrideHelper={overrideHelper}
+											isRequired
 										/>
 									) : (
 										<p>{t('No schema has been provided for this mapping')}</p>

--- a/packages/documentation/docs/for-developers/json-config-schema.md
+++ b/packages/documentation/docs/for-developers/json-config-schema.md
@@ -63,7 +63,7 @@ Valid for both show-style and studio blueprint configuration
 
 This will provide a dropdown of all mappings in the studio, or studios where the show-style can be used.
 
-Setting `ui:sofie-enum:filter` to an array of numbers will filter the dropdown by the specified DeviceType.
+Setting `ui:sofie-enum:filter` to an array of strings will filter the dropdown by the specified DeviceType.
 
 #### `source-layers`
 
@@ -202,7 +202,7 @@ An `object` table is better than an `array` in blueprint-configuration, as it al
 	"items": {
 		"type": "string",
 		"ui:sofie-enum": "mappings",
-		"ui:sofie-enum:filter": [2],
+		"ui:sofie-enum:filter": ["ATEM"],
 	},
 	"uniqueItems": true
 },


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

* **What is the new behavior (if this is a feature change)?**

The `required` field in the schema defines whether the typescript property comes out as optional.
This can be useful to use in some cases, to mark a dropdown as being allowed to have no value selected.

In particular, this is useful in combination with the sofie-enums, to allow for 0-1 values to be selected.  
This change informs each control about whether it is marked as required, and utilises this for the dropdowns to add a 'None' value

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
