### PR TITLE
fix(LiveStatus): interpolate adlib names

### DIFF
--- a/packages/live-status-gateway/src/topics/activePlaylist.ts
+++ b/packages/live-status-gateway/src/topics/activePlaylist.ts
@@ -17,6 +17,7 @@ import { WebSocketTopicBase, WebSocketTopic, CollectionObserver } from '../wsHan
 import { PartInstanceName } from '../collections/partInstances'
 import { applyAndValidateOverrides } from '@sofie-automation/corelib/dist/settings/objectWithOverrides'
 import { AdLibPiece } from '@sofie-automation/corelib/dist/dataModel/AdLibPiece'
+import { interpollateTranslation } from '@sofie-automation/corelib/dist/TranslatableMessage'
 
 interface PartStatus {
 	id: string
@@ -96,13 +97,13 @@ export class ActivePlaylistTopic
 						? action.triggerModes.map((t) =>
 								literal<AdLibActionType>({
 									name: t.data,
-									label: t.display.label.key,
+									label: interpollateTranslation(t.display.label.key, t.display.label.args),
 								})
 						  )
 						: []
 					return literal<AdLibStatus>({
 						id: unprotectString(action._id),
-						name: action.display.label.key,
+						name: interpollateTranslation(action.display.label.key, action.display.label.args),
 						sourceLayer: sourceLayerName ? sourceLayerName : 'invalid',
 						outputLayer: outputLayerName ? outputLayerName : 'invalid',
 						actionType: triggerModes,
@@ -140,13 +141,13 @@ export class ActivePlaylistTopic
 						? action.triggerModes.map((t) =>
 								literal<AdLibActionType>({
 									name: t.data,
-									label: t.display.label.key,
+									label: interpollateTranslation(t.display.label.key, t.display.label.args),
 								})
 						  )
 						: []
 					return literal<AdLibStatus>({
 						id: unprotectString(action._id),
-						name: action.display.label.key,
+						name: interpollateTranslation(action.display.label.key, action.display.label.args),
 						sourceLayer: sourceLayerName ? sourceLayerName : 'invalid',
 						outputLayer: outputLayerName ? outputLayerName : 'invalid',
 						actionType: triggerModes,


### PR DESCRIPTION
This PR is being opened on behalf of TV 2 Norge.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Adlib names have unprocessed interpolation markers in them, such as `{{fileName}}`.

* **What is the new behavior (if this is a feature change)?**

These strings are now properly interpolated.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
