### PR TITLE
fix: zero duration pieces breaking ab resolver

### DIFF
--- a/packages/job-worker/src/playout/abPlayback/abPlaybackSessions.ts
+++ b/packages/job-worker/src/playout/abPlayback/abPlaybackSessions.ts
@@ -41,7 +41,7 @@ export function calculateSessionTimeRanges(
 			)
 
 			// Note: multiple generated sessionIds for a single piece will not work as there will not be enough info to assign objects to different players. TODO is this still true?
-			const val = sessionRequests[sessionId] || undefined
+			const val = sessionRequests[sessionId]
 			if (val) {
 				// This session is already known, so extend the session to cover all the pieces
 				sessionRequests[sessionId] = {
@@ -105,7 +105,7 @@ export function calculateSessionTimeRanges(
 		if (!sessionRequests[grp.id]) {
 			result.push({
 				id: grp.id,
-				start: Number.POSITIVE_INFINITY, // Distant future
+				start: Number.MAX_SAFE_INTEGER, // Distant future
 				end: undefined,
 				lookaheadRank: i + 1, // This is so that we can easily work out which to use first
 				playerId: previousAssignmentMap[grp.id]?.playerId,

--- a/packages/job-worker/src/playout/pieces.ts
+++ b/packages/job-worker/src/playout/pieces.ts
@@ -174,9 +174,8 @@ function resolvePieceTimeline(
 	// Clamp the times to be reasonably valid
 	resolvedPieces.forEach((resolvedPiece) => {
 		resolvedPiece.resolvedStart = Math.max(0, resolvedPiece.resolvedStart - 1)
-		resolvedPiece.resolvedDuration = resolvedPiece.resolvedDuration
-			? Math.max(0, resolvedPiece.resolvedDuration)
-			: undefined
+		resolvedPiece.resolvedDuration =
+			resolvedPiece.resolvedDuration !== undefined ? Math.max(0, resolvedPiece.resolvedDuration) : undefined
 	})
 
 	return resolvedPieces


### PR DESCRIPTION
This PR is being opened on behalf of TV 2 Norge.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Sofie resolves the piece timeline, to be able to provide concrete times to the ab resolved, `onTimelineGenerate` and other places.  
If a piece is resolved to have a duration of 0, that gets lost during the resolving, so that it ends up with no duration.

* **What is the new behavior (if this is a feature change)?**

It now treats a duration of 0 as a valid value, preserving it rather than replacing it with undefined.

* **Other information**:

Some minor tweaks have been made so that lookahead ab sessions use a start time that is json serializable, as this confused us while debugging due to infinity being converted to `null` when stringified for json

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
