### PR TITLE
sisyfos use multiple restarts to create stable connection (Sofie 2576)

### DIFF
--- a/meteor/yarn.lock
+++ b/meteor/yarn.lock
@@ -9820,10 +9820,10 @@ timecode@0.0.4:
   resolved "https://registry.yarnpkg.com/timecode/-/timecode-0.0.4.tgz#cdea9d2352009700e50da657cb7fb7c1720f5704"
   integrity sha512-xFVZlWnqls5eVphtUJo0UuXeJa0grBmxESSn5QPQB7CMsaVgTnLdP9PTZqb4KyFmLdrE+PUu3eEt42zHsMxCtw==
 
-timeline-state-resolver-types@7.5.0:
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-7.5.0.tgz#122b4ec78b99b45665ff74f0f7d184a2866123ab"
-  integrity sha512-K9vp91tVX+F2mTOY37ZX9zmzn28KYUdwMm4p05s9LxfCsZCJEUQLZ1oBQN5mzhFL+06UJceEdflUoG2Y4WFhpQ==
+timeline-state-resolver-types@7.5.1-nightly-SOFIE-2576-r-1-47-5-sisyfos-use-multiple-restarts-to-create-stable-connection-20230831-100603-c11801a1f.0:
+  version "7.5.1-nightly-SOFIE-2576-r-1-47-5-sisyfos-use-multiple-restarts-to-create-stable-connection-20230831-100603-c11801a1f.0"
+  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-7.5.1-nightly-SOFIE-2576-r-1-47-5-sisyfos-use-multiple-restarts-to-create-stable-connection-20230831-100603-c11801a1f.0.tgz#6b478528ee16bf755088bc26ccae470e7d8c575d"
+  integrity sha512-O/JWsmr3NexWUu12UL1Pwgw3+L66/D5nvXlXH2wcMNhlW4zZZu+2h9k9AhaRpMfQtKEmc9VrsKF9borqG75xyA==
   dependencies:
     tslib "^2.3.1"
 

--- a/meteor/yarn.lock
+++ b/meteor/yarn.lock
@@ -9820,10 +9820,10 @@ timecode@0.0.4:
   resolved "https://registry.yarnpkg.com/timecode/-/timecode-0.0.4.tgz#cdea9d2352009700e50da657cb7fb7c1720f5704"
   integrity sha512-xFVZlWnqls5eVphtUJo0UuXeJa0grBmxESSn5QPQB7CMsaVgTnLdP9PTZqb4KyFmLdrE+PUu3eEt42zHsMxCtw==
 
-timeline-state-resolver-types@7.5.1-nightly-SOFIE-2576-r-1-47-5-sisyfos-use-multiple-restarts-to-create-stable-connection-20230831-100603-c11801a1f.0:
-  version "7.5.1-nightly-SOFIE-2576-r-1-47-5-sisyfos-use-multiple-restarts-to-create-stable-connection-20230831-100603-c11801a1f.0"
-  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-7.5.1-nightly-SOFIE-2576-r-1-47-5-sisyfos-use-multiple-restarts-to-create-stable-connection-20230831-100603-c11801a1f.0.tgz#6b478528ee16bf755088bc26ccae470e7d8c575d"
-  integrity sha512-O/JWsmr3NexWUu12UL1Pwgw3+L66/D5nvXlXH2wcMNhlW4zZZu+2h9k9AhaRpMfQtKEmc9VrsKF9borqG75xyA==
+timeline-state-resolver-types@7.5.1-nightly-release47-20230901-122602-a1541133a.0:
+  version "7.5.1-nightly-release47-20230901-122602-a1541133a.0"
+  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-7.5.1-nightly-release47-20230901-122602-a1541133a.0.tgz#f830ac39505a0797df228b7848e5af672814505d"
+  integrity sha512-bqAN7I76R5/uxa+1IooN6kSbO3mM8h2Zn+vGnpAN3sinfP7ZHyuKWjJb0qcq25jhHzQ5gDfKBXSsuJFnCUXlwA==
   dependencies:
     tslib "^2.3.1"
 

--- a/packages/blueprints-integration/package.json
+++ b/packages/blueprints-integration/package.json
@@ -39,7 +39,7 @@
 	],
 	"dependencies": {
 		"@sofie-automation/shared-lib": "link:../shared-lib",
-		"timeline-state-resolver-types": "7.5.0",
+		"timeline-state-resolver-types": "7.5.1-nightly-SOFIE-2576-r-1-47-5-sisyfos-use-multiple-restarts-to-create-stable-connection-20230831-154753-028167ae7.0",
 		"tslib": "^2.4.0",
 		"type-fest": "^2.19.0"
 	},

--- a/packages/blueprints-integration/package.json
+++ b/packages/blueprints-integration/package.json
@@ -39,7 +39,7 @@
 	],
 	"dependencies": {
 		"@sofie-automation/shared-lib": "link:../shared-lib",
-		"timeline-state-resolver-types": "7.5.1-nightly-SOFIE-2576-r-1-47-5-sisyfos-use-multiple-restarts-to-create-stable-connection-20230831-154753-028167ae7.0",
+		"timeline-state-resolver-types": "7.5.1-nightly-release47-20230901-122602-a1541133a.0",
 		"tslib": "^2.4.0",
 		"type-fest": "^2.19.0"
 	},

--- a/packages/playout-gateway/package.json
+++ b/packages/playout-gateway/package.json
@@ -62,7 +62,7 @@
 		"debug": "^4.3.3",
 		"fast-clone": "^1.5.13",
 		"influx": "^5.9.3",
-		"timeline-state-resolver": "7.5.0",
+		"timeline-state-resolver": "7.5.1-nightly-SOFIE-2576-r-1-47-5-sisyfos-use-multiple-restarts-to-create-stable-connection-20230831-154753-028167ae7.0",
 		"tslib": "^2.4.0",
 		"underscore": "^1.13.4",
 		"winston": "^3.8.2"

--- a/packages/playout-gateway/package.json
+++ b/packages/playout-gateway/package.json
@@ -62,7 +62,7 @@
 		"debug": "^4.3.3",
 		"fast-clone": "^1.5.13",
 		"influx": "^5.9.3",
-		"timeline-state-resolver": "7.5.1-nightly-SOFIE-2576-r-1-47-5-sisyfos-use-multiple-restarts-to-create-stable-connection-20230831-154753-028167ae7.0",
+		"timeline-state-resolver": "7.5.1-nightly-release47-20230901-122602-a1541133a.0",
 		"tslib": "^2.4.0",
 		"underscore": "^1.13.4",
 		"winston": "^3.8.2"

--- a/packages/playout-gateway/src/coreHandler.ts
+++ b/packages/playout-gateway/src/coreHandler.ts
@@ -163,6 +163,9 @@ export class CoreHandler {
 		observer.added = (id: string) => this.onDeviceChanged(protectString(id))
 		observer.changed = (id: string) => this.onDeviceChanged(protectString(id))
 		this.setupObserverForPeripheralDeviceCommands(this)
+
+		// trigger this callback because the observer doesn't the first time..
+		this.onDeviceChanged(this.core.deviceId)
 	}
 	async destroy(): Promise<void> {
 		this._statusDestroyed = true

--- a/packages/playout-gateway/src/index.ts
+++ b/packages/playout-gateway/src/index.ts
@@ -31,8 +31,7 @@ if (logPath) {
 	console.log = function (...args: any[]) {
 		// orgConsoleLog('a')
 		if (args.length >= 1) {
-			// @ts-expect-error one or more arguments
-			logger.debug(...args)
+			logger.debug(args.join(' '), { rawData: args })
 			orgConsoleLog(...args)
 		}
 	}
@@ -62,8 +61,7 @@ if (logPath) {
 	console.log = function (...args: any[]) {
 		// orgConsoleLog('a')
 		if (args.length >= 1) {
-			// @ts-expect-error one or more arguments
-			logger.debug(...args)
+			logger.debug(args.join(' '), { rawData: args })
 		}
 	}
 }

--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -400,7 +400,7 @@ export class TSRHandler {
 		if (this._errorReporting !== this._coreHandler.errorReporting) {
 			this._errorReporting = this._coreHandler.errorReporting
 
-			this.logger.info('ErrorReporting: ' + this._multiThreaded)
+			this.logger.info('ErrorReporting: ' + this._errorReporting)
 		}
 		if (this.tsr.estimateResolveTimeMultiplier !== this._coreHandler.estimateResolveTimeMultiplier) {
 			this.tsr.estimateResolveTimeMultiplier = this._coreHandler.estimateResolveTimeMultiplier
@@ -867,16 +867,15 @@ export class TSRHandler {
 			const onClearMediaObjectCollection = (collectionId: string) => {
 				coreTsrHandler.onClearMediaObjectCollection(collectionId)
 			}
-			const fixError = (e: any): string => {
+			const fixLog = (e: string): string => `Device "${device.deviceName || deviceId}" (${device.instanceId})` + e
+			const fixError = (e: Error): any => {
 				const name = `Device "${device.deviceName || deviceId}" (${device.instanceId})`
-				if (e.reason) e.reason = name + ': ' + e.reason
-				if (e.message) e.message = name + ': ' + e.message
-				if (e.stack) {
-					e.stack += '\nAt device' + name
-				}
-				if (_.isString(e)) e = name + ': ' + e
 
-				return e
+				return {
+					message: e.message && name + ': ' + e.message,
+					name: e.name && name + ': ' + e.name,
+					stack: e.stack && e.stack + '\nAt device' + name,
+				}
 			}
 			const fixContext = (...context: any[]): any => {
 				return {
@@ -917,14 +916,15 @@ export class TSRHandler {
 			await device.device.on('updateMediaObject', onUpdateMediaObject as () => void)
 			await device.device.on('clearMediaObjects', onClearMediaObjectCollection as () => void)
 
-			await device.device.on('info', ((e: any, ...args: any[]) => {
-				this.logger.info(fixError(e), fixContext(args))
+			// note - these callbacks do not give type warnings. check them manually against TSR typings
+			await device.device.on('info', ((info: string) => {
+				this.logger.info(fixLog(info))
 			}) as () => void)
-			await device.device.on('warning', ((e: any, ...args: any[]) => {
-				this.logger.warn(fixError(e), fixContext(args))
+			await device.device.on('warning', ((warning: string) => {
+				this.logger.warn(fixLog(warning))
 			}) as () => void)
-			await device.device.on('error', ((e: any, ...args: any[]) => {
-				this.logger.error(fixError(e), fixContext(args))
+			await device.device.on('error', ((context: string, err: Error) => {
+				this.logger.error(fixError(err), fixContext(context))
 			}) as () => void)
 
 			await device.device.on('debug', (...args: any[]) => {

--- a/packages/yarn.lock
+++ b/packages/yarn.lock
@@ -3307,10 +3307,10 @@
     webpack-sources "^3.2.2"
 
 "@sofie-automation/blueprints-integration@link:blueprints-integration":
-  version "1.47.1-1"
+  version "1.47.5"
   dependencies:
     "@sofie-automation/shared-lib" "link:shared-lib"
-    timeline-state-resolver-types "7.5.0"
+    timeline-state-resolver-types "7.5.1-nightly-SOFIE-2576-r-1-47-5-sisyfos-use-multiple-restarts-to-create-stable-connection-20230831-154753-028167ae7.0"
     tslib "^2.4.0"
     type-fest "^2.19.0"
 
@@ -3335,7 +3335,7 @@
     shelljs "^0.8.5"
 
 "@sofie-automation/corelib@link:corelib":
-  version "1.47.1-1"
+  version "1.47.5"
   dependencies:
     "@sofie-automation/blueprints-integration" "link:blueprints-integration"
     "@sofie-automation/shared-lib" "link:shared-lib"
@@ -3351,7 +3351,7 @@
     underscore "^1.13.4"
 
 "@sofie-automation/shared-lib@link:shared-lib":
-  version "1.47.1-1"
+  version "1.47.5"
   dependencies:
     tslib "^2.4.0"
     type-fest "^2.19.0"
@@ -3599,9 +3599,10 @@
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
 
-"@tv2media/v-connection@git+https://github.com/nrkno/v-connection.git#5386986d87ea6d1b5164d206ea42c975654b36cd":
-  version "7.2.1"
-  resolved "git+https://github.com/nrkno/v-connection.git#5386986d87ea6d1b5164d206ea42c975654b36cd"
+"@tv2media/v-connection@7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@tv2media/v-connection/-/v-connection-7.3.0.tgz#1d6bed97a386d59b618b272ffd5867feb84cb284"
+  integrity sha512-rGg+rLS+Q69YuYgg8XfMD8ZiBr+zUlTNIQyTOFbOwnbV3ycBn+G0WDpNXuo6R73r5svh4BtCr+yapenUPO3jxg==
   dependencies:
     request "^2.88.2"
     request-promise-native "^1.0.9"
@@ -14354,19 +14355,19 @@ timecode@0.0.4:
   resolved "https://registry.yarnpkg.com/timecode/-/timecode-0.0.4.tgz#cdea9d2352009700e50da657cb7fb7c1720f5704"
   integrity sha512-xFVZlWnqls5eVphtUJo0UuXeJa0grBmxESSn5QPQB7CMsaVgTnLdP9PTZqb4KyFmLdrE+PUu3eEt42zHsMxCtw==
 
-timeline-state-resolver-types@7.5.0:
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-7.5.0.tgz#122b4ec78b99b45665ff74f0f7d184a2866123ab"
-  integrity sha512-K9vp91tVX+F2mTOY37ZX9zmzn28KYUdwMm4p05s9LxfCsZCJEUQLZ1oBQN5mzhFL+06UJceEdflUoG2Y4WFhpQ==
+timeline-state-resolver-types@7.5.1-nightly-SOFIE-2576-r-1-47-5-sisyfos-use-multiple-restarts-to-create-stable-connection-20230831-154753-028167ae7.0:
+  version "7.5.1-nightly-SOFIE-2576-r-1-47-5-sisyfos-use-multiple-restarts-to-create-stable-connection-20230831-154753-028167ae7.0"
+  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-7.5.1-nightly-SOFIE-2576-r-1-47-5-sisyfos-use-multiple-restarts-to-create-stable-connection-20230831-154753-028167ae7.0.tgz#85b5438468882e50f7408a7132c70cb79a6ace14"
+  integrity sha512-L5cXHkyJZBAR4bp/S9Wn5Dp2alSPTxzN2j6x9ZsoQODml37yvGZT0gEYH5qx8MtqFQeRztTocYUQWI9DUIGtbw==
   dependencies:
     tslib "^2.3.1"
 
-timeline-state-resolver@7.5.0:
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/timeline-state-resolver/-/timeline-state-resolver-7.5.0.tgz#ee885336648e7ecac9dc700bb5d42cdcbb5e2d09"
-  integrity sha512-cBwQXLxKK+r77ldDhvwhLzfA9UQwbCb7EVf2mxoYvV9xq+4tbRIZSIkCA9nNOONVFfDDAcwSJDP/ruXVZz6bHA==
+timeline-state-resolver@7.5.1-nightly-SOFIE-2576-r-1-47-5-sisyfos-use-multiple-restarts-to-create-stable-connection-20230831-154753-028167ae7.0:
+  version "7.5.1-nightly-SOFIE-2576-r-1-47-5-sisyfos-use-multiple-restarts-to-create-stable-connection-20230831-154753-028167ae7.0"
+  resolved "https://registry.yarnpkg.com/timeline-state-resolver/-/timeline-state-resolver-7.5.1-nightly-SOFIE-2576-r-1-47-5-sisyfos-use-multiple-restarts-to-create-stable-connection-20230831-154753-028167ae7.0.tgz#b981b984bd10bbfb4c4cabffe5441ccf5f599e48"
+  integrity sha512-qE210nRPJnr6EGznxyz0CqjT1lbc+U+pZ1Fa5EdJ89bS1jxL8Yx9HUqnG1GygWdLb6s33DxCbe+x6wrQR8hBmg==
   dependencies:
-    "@tv2media/v-connection" "git+https://github.com/nrkno/v-connection.git#5386986d87ea6d1b5164d206ea42c975654b36cd"
+    "@tv2media/v-connection" "7.3.0"
     atem-connection "2.4.0"
     atem-state "^0.12.2"
     casparcg-connection "^5.1.0"
@@ -14386,7 +14387,7 @@ timeline-state-resolver@7.5.0:
     sprintf-js "^1.1.2"
     superfly-timeline "^8.3.1"
     threadedclass "^1.1.1"
-    timeline-state-resolver-types "7.5.0"
+    timeline-state-resolver-types "7.5.1-nightly-SOFIE-2576-r-1-47-5-sisyfos-use-multiple-restarts-to-create-stable-connection-20230831-154753-028167ae7.0"
     tslib "^2.3.1"
     tv-automation-quantel-gateway-client "^2.0.5"
     underscore "^1.13.4"

--- a/packages/yarn.lock
+++ b/packages/yarn.lock
@@ -3310,7 +3310,7 @@
   version "1.47.5"
   dependencies:
     "@sofie-automation/shared-lib" "link:shared-lib"
-    timeline-state-resolver-types "7.5.1-nightly-SOFIE-2576-r-1-47-5-sisyfos-use-multiple-restarts-to-create-stable-connection-20230831-154753-028167ae7.0"
+    timeline-state-resolver-types "7.5.1-nightly-release47-20230901-122602-a1541133a.0"
     tslib "^2.4.0"
     type-fest "^2.19.0"
 
@@ -14355,17 +14355,17 @@ timecode@0.0.4:
   resolved "https://registry.yarnpkg.com/timecode/-/timecode-0.0.4.tgz#cdea9d2352009700e50da657cb7fb7c1720f5704"
   integrity sha512-xFVZlWnqls5eVphtUJo0UuXeJa0grBmxESSn5QPQB7CMsaVgTnLdP9PTZqb4KyFmLdrE+PUu3eEt42zHsMxCtw==
 
-timeline-state-resolver-types@7.5.1-nightly-SOFIE-2576-r-1-47-5-sisyfos-use-multiple-restarts-to-create-stable-connection-20230831-154753-028167ae7.0:
-  version "7.5.1-nightly-SOFIE-2576-r-1-47-5-sisyfos-use-multiple-restarts-to-create-stable-connection-20230831-154753-028167ae7.0"
-  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-7.5.1-nightly-SOFIE-2576-r-1-47-5-sisyfos-use-multiple-restarts-to-create-stable-connection-20230831-154753-028167ae7.0.tgz#85b5438468882e50f7408a7132c70cb79a6ace14"
-  integrity sha512-L5cXHkyJZBAR4bp/S9Wn5Dp2alSPTxzN2j6x9ZsoQODml37yvGZT0gEYH5qx8MtqFQeRztTocYUQWI9DUIGtbw==
+timeline-state-resolver-types@7.5.1-nightly-release47-20230901-122602-a1541133a.0:
+  version "7.5.1-nightly-release47-20230901-122602-a1541133a.0"
+  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-7.5.1-nightly-release47-20230901-122602-a1541133a.0.tgz#f830ac39505a0797df228b7848e5af672814505d"
+  integrity sha512-bqAN7I76R5/uxa+1IooN6kSbO3mM8h2Zn+vGnpAN3sinfP7ZHyuKWjJb0qcq25jhHzQ5gDfKBXSsuJFnCUXlwA==
   dependencies:
     tslib "^2.3.1"
 
-timeline-state-resolver@7.5.1-nightly-SOFIE-2576-r-1-47-5-sisyfos-use-multiple-restarts-to-create-stable-connection-20230831-154753-028167ae7.0:
-  version "7.5.1-nightly-SOFIE-2576-r-1-47-5-sisyfos-use-multiple-restarts-to-create-stable-connection-20230831-154753-028167ae7.0"
-  resolved "https://registry.yarnpkg.com/timeline-state-resolver/-/timeline-state-resolver-7.5.1-nightly-SOFIE-2576-r-1-47-5-sisyfos-use-multiple-restarts-to-create-stable-connection-20230831-154753-028167ae7.0.tgz#b981b984bd10bbfb4c4cabffe5441ccf5f599e48"
-  integrity sha512-qE210nRPJnr6EGznxyz0CqjT1lbc+U+pZ1Fa5EdJ89bS1jxL8Yx9HUqnG1GygWdLb6s33DxCbe+x6wrQR8hBmg==
+timeline-state-resolver@7.5.1-nightly-release47-20230901-122602-a1541133a.0:
+  version "7.5.1-nightly-release47-20230901-122602-a1541133a.0"
+  resolved "https://registry.yarnpkg.com/timeline-state-resolver/-/timeline-state-resolver-7.5.1-nightly-release47-20230901-122602-a1541133a.0.tgz#cafe75378d0b90320f8b50c7e99eaa5cd3f60d75"
+  integrity sha512-QX2ugIz0MT0/J5wQIyK/9btOV7H596ZhWy8WAaz4O9opM59oGg55/mZSX0uuJIqe1DUvQpXlJgkYWo6Q0oeBwQ==
   dependencies:
     "@tv2media/v-connection" "7.3.0"
     atem-connection "2.4.0"
@@ -14387,7 +14387,7 @@ timeline-state-resolver@7.5.1-nightly-SOFIE-2576-r-1-47-5-sisyfos-use-multiple-r
     sprintf-js "^1.1.2"
     superfly-timeline "^8.3.1"
     threadedclass "^1.1.1"
-    timeline-state-resolver-types "7.5.1-nightly-SOFIE-2576-r-1-47-5-sisyfos-use-multiple-restarts-to-create-stable-connection-20230831-154753-028167ae7.0"
+    timeline-state-resolver-types "7.5.1-nightly-release47-20230901-122602-a1541133a.0"
     tslib "^2.3.1"
     tv-automation-quantel-gateway-client "^2.0.5"
     underscore "^1.13.4"


### PR DESCRIPTION
This includes a couple of fixes for playout-gw:
 - Device settings were not retrieved on start up, this caused the TSR to start in single-threaded mode
 - Logs made from console.log in libraries would only show the first argument, more arguments would be put on the object (i.e. `console.log(123, 'a log')` result in `{ 0: "a", 1: " ", 2: "l", 3: "o", 4: "g" , message: 123}`)
 - Errors logged from the devices using `.emit('error', ...)` now serialise the emitted error correctly (previously would just log en empty object)
 - Bumped TSR improving terminate implementation of multiple devices

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
