### PR TITLE
fix: go-to-part action

### DIFF
--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -503,18 +503,41 @@ export const SegmentTimelineContainer = withResolvedSegment(
 
 		onGoToPartInner = (part: PartUi, _timingDurations: RundownTimingContext, zoomInToFit?: boolean) => {
 			this.setState((state) => {
+				const timelineWidth = this.timelineDiv instanceof HTMLElement ? getElementWidth(this.timelineDiv) : 0 // unsure if this is good default/substitute
 				let newScale: number | undefined
-
 				let scrollLeft = state.scrollLeft
 
 				if (zoomInToFit) {
-					const timelineWidth = this.timelineDiv instanceof HTMLElement ? getElementWidth(this.timelineDiv) : 0 // unsure if this is good default/substitute
-					newScale =
-						(Math.max(0, timelineWidth - TIMELINE_RIGHT_PADDING * 2) / 3 || 1) /
-						(SegmentTimelinePartClass.getPartDisplayDuration(part, this.context?.durations) || 1)
+					// display dur in ms
+					const displayDur = (SegmentTimelinePartClass.getPartDisplayDuration(part, this.context?.durations) || 1)
+					// is the padding is larger than the width of the resulting size?
+					const tooSmallTimeline = timelineWidth < TIMELINE_RIGHT_PADDING * 3
+					// width in px, pad on both sides
+					const desiredWidth = tooSmallTimeline ? timelineWidth * .8 : Math.max(1, timelineWidth - TIMELINE_RIGHT_PADDING * 2)
+					// scale = pixels / time
+					newScale = desiredWidth / displayDur
 
-					scrollLeft = Math.max(0, scrollLeft - TIMELINE_RIGHT_PADDING / newScale)
+					// the left padding
+					const padding = tooSmallTimeline ? timelineWidth * .1 / newScale : TIMELINE_RIGHT_PADDING / newScale
+					// offset in ms
+					scrollLeft = part.startsAt - padding
+					// scrollLeft should be at least 0
+					scrollLeft = Math.max(0, scrollLeft)
+				} else if (
+					this.state.scrollLeft > part.startsAt ||
+					this.state.scrollLeft * this.state.timeScale + timelineWidth < part.startsAt * this.state.timeScale
+				) {
+					// If part is not within viewport scroll to its start
+					scrollLeft = part.startsAt
 				}
+
+				/**
+				 * note from mint @ 07-09-23
+				 * 
+				 * there are some edge cases still here. the ones i'm aware of are:
+				 *  - when following the live line, this will zoom but not scroll
+				 *  - when a segment starts with a short part, followed by a long part the left padding will be inconsistent
+				 */
 
 				return {
 					scrollLeft,

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -509,16 +509,18 @@ export const SegmentTimelineContainer = withResolvedSegment(
 
 				if (zoomInToFit) {
 					// display dur in ms
-					const displayDur = (SegmentTimelinePartClass.getPartDisplayDuration(part, this.context?.durations) || 1)
+					const displayDur = SegmentTimelinePartClass.getPartDisplayDuration(part, this.context?.durations) || 1
 					// is the padding is larger than the width of the resulting size?
 					const tooSmallTimeline = timelineWidth < TIMELINE_RIGHT_PADDING * 3
 					// width in px, pad on both sides
-					const desiredWidth = tooSmallTimeline ? timelineWidth * .8 : Math.max(1, timelineWidth - TIMELINE_RIGHT_PADDING * 2)
+					const desiredWidth = tooSmallTimeline
+						? timelineWidth * 0.8
+						: Math.max(1, timelineWidth - TIMELINE_RIGHT_PADDING * 2)
 					// scale = pixels / time
 					newScale = desiredWidth / displayDur
 
 					// the left padding
-					const padding = tooSmallTimeline ? timelineWidth * .1 / newScale : TIMELINE_RIGHT_PADDING / newScale
+					const padding = tooSmallTimeline ? (timelineWidth * 0.1) / newScale : TIMELINE_RIGHT_PADDING / newScale
 					// offset in ms
 					scrollLeft = part.startsAt - padding
 					// scrollLeft should be at least 0
@@ -533,7 +535,7 @@ export const SegmentTimelineContainer = withResolvedSegment(
 
 				/**
 				 * note from mint @ 07-09-23
-				 * 
+				 *
 				 * there are some edge cases still here. the ones i'm aware of are:
 				 *  - when following the live line, this will zoom but not scroll
 				 *  - when a segment starts with a short part, followed by a long part the left padding will be inconsistent


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This updates the scroll behaviour for the "go to part" action, as is used when clicked on part identifiers 

* **What is the current behavior?** (You can also link to an open issue here)

Inconsistent zoom and scroll

* **What is the new behavior (if this is a feature change)?**

Mostly* consistent zoom and scroll. Part should fill up the space between the 2 red lines, denoted by where the next line should be in a playing part and the space left on the right side with default sizing. (As indicated by blue arrows)

<img width="1800" alt="image" src="https://github.com/nrkno/sofie-core/assets/9898648/9877bf9e-ebb6-49f4-8ee4-6e0a2cf4db15">


\* some edge cases remain, but they are either not easily fixable or not very problematic..

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
