### PR TITLE
Chore: Fix time based tests

### DIFF
--- a/meteor/__mocks__/helpers/jest.ts
+++ b/meteor/__mocks__/helpers/jest.ts
@@ -43,10 +43,11 @@ export function testInFiberOnly(testName: string, fcn: () => void | Promise<void
 	)
 }
 const orgSetTimeout = setTimeout
+const DateOrg = Date
 export async function runAllTimers(): Promise<void> {
 	// Run all timers, and wait, multiple times.
 	// This is to allow timers AND internal promises to resolve in inner functions
-	for (let i = 0; i < 50; i++) {
+	for (let i = 0; i < 10; i++) {
 		jest.runOnlyPendingTimers()
 		await new Promise((resolve) => orgSetTimeout(resolve, 0))
 	}
@@ -63,8 +64,9 @@ export async function runTimersUntilNow(): Promise<void> {
 
 /** Returns a Promise that resolves after a speficied number of milliseconds */
 export async function waitTime(ms: number): Promise<void> {
-	return new Promise((resolve) => setTimeout(resolve, ms))
+	return new Promise((resolve) => orgSetTimeout(resolve, ms))
 }
+
 /**
  * Executes {expectFcn} intermittently until it doesn't throw anymore.
  * Waits up to {maxWaitTime} ms, then throws the latest error.
@@ -90,7 +92,7 @@ export async function waitUntil(expectFcn: () => void | Promise<void>, maxWaitTi
 			await expectFcn()
 			return
 		} catch (err) {
-			const waitedTime = Date.now() - startTime
+			const waitedTime = DateOrg.now() - startTime
 			if (waitedTime > maxWaitTime) throw err
 			// else ignore error and try again later
 		}

--- a/meteor/server/__tests__/cronjobs.test.ts
+++ b/meteor/server/__tests__/cronjobs.test.ts
@@ -1,5 +1,5 @@
 import '../../__mocks__/_extendJest'
-import { testInFiber, runAllTimers, beforeAllInFiber } from '../../__mocks__/helpers/jest'
+import { testInFiber, runAllTimers, beforeAllInFiber, waitUntil, testInFiberOnly } from '../../__mocks__/helpers/jest'
 import { MeteorMock } from '../../__mocks__/meteor'
 import { logger } from '../logging'
 import { getRandomId, getRandomString, protectString } from '../../lib/lib'
@@ -30,6 +30,10 @@ jest.mock('../logging')
 // we don't want the deviceTriggers observer to start up at this time
 jest.mock('../api/deviceTriggers/observer')
 
+const MAX_WAIT_TIME = 4 * 1000
+
+const DateOrg = Date
+
 import '../cronjobs'
 
 import '../api/peripheralDevice'
@@ -55,15 +59,6 @@ import {
 import { DBSegment } from '@sofie-automation/corelib/dist/dataModel/Segment'
 import { Settings } from '../../lib/Settings'
 
-async function waitForCronjobDone() {
-	// Run timers, so that all promises in the cronjob has a chance to resolve:
-
-	// Note: call these multiple times, since the cronjob handles a LOT of promises in series.
-	await runAllTimers()
-	await runAllTimers()
-	await runAllTimers()
-	await runAllTimers()
-}
 describe('cronjobs', () => {
 	let env: DefaultEnvironment
 	let rundownId: RundownId
@@ -105,7 +100,8 @@ describe('cronjobs', () => {
 			// cronjob is checked every 5 minutes, so advance 6 minutes
 			jest.advanceTimersByTime(6 * 60 * 1000)
 			expect(lib.getCurrentTime).toHaveBeenCalled()
-			await waitForCronjobDone()
+
+			await runAllTimers()
 
 			expect(logger.info).toHaveBeenCalledTimes(0)
 		})
@@ -115,9 +111,14 @@ describe('cronjobs', () => {
 			// cronjob is checked every 5 minutes, so advance 6 minutes
 			jest.advanceTimersByTime(6 * 60 * 1000)
 			expect(lib.getCurrentTime).toHaveBeenCalled()
-			await waitForCronjobDone()
 
-			expect(logger.info).toHaveBeenLastCalledWith('Nightly cronjob: done')
+			expect(logger.info).not.toHaveBeenLastCalledWith('Nightly cronjob: done')
+			await waitUntil(async () => {
+				// Run timers, so that all promises in the cronjob has a chance to resolve:
+				await runAllTimers()
+
+				expect(logger.info).toHaveBeenLastCalledWith('Nightly cronjob: done')
+			}, MAX_WAIT_TIME)
 		})
 		testInFiber("Doesn't run if less than 20 hours have passed since last run", async () => {
 			// set time to 2020/07/21 04:05 Local Time, should be more than 24 hours after 2020/07/19 00:00 UTC
@@ -125,15 +126,21 @@ describe('cronjobs', () => {
 			// cronjob is checked every 5 minutes, so advance 6 minutes
 			jest.advanceTimersByTime(6 * 60 * 1000)
 			expect(lib.getCurrentTime).toHaveBeenCalled()
-			await waitForCronjobDone()
-			expect(logger.info).toHaveBeenLastCalledWith('Nightly cronjob: done')
+
+			expect(logger.info).not.toHaveBeenLastCalledWith('Nightly cronjob: done')
+			await waitUntil(async () => {
+				// Run timers, so that all promises in the cronjob has a chance to resolve:
+				await runAllTimers()
+				expect(logger.info).toHaveBeenLastCalledWith('Nightly cronjob: done')
+			}, MAX_WAIT_TIME)
 
 			// clear the mock
 			;(logger.info as jest.Mock).mockClear()
 
 			mockCurrentTime = new Date(2020, 6, 20, 4, 50, 0).getTime()
 			jest.advanceTimersByTime(6 * 60 * 1000)
-			await waitForCronjobDone()
+
+			await runAllTimers()
 			// less than 24 hours have passed so we do not expect the cronjob to run
 			expect(logger.info).toHaveBeenCalledTimes(0)
 		})
@@ -146,8 +153,13 @@ describe('cronjobs', () => {
 			mockCurrentTime = new Date(2020, 6, date++, 4, 5, 0).getTime()
 			// cronjob is checked every 5 minutes, so advance 6 minutes
 			jest.advanceTimersByTime(6 * 60 * 1000)
-			await waitForCronjobDone()
-			expect(logger.info).toHaveBeenLastCalledWith('Nightly cronjob: done')
+
+			expect(logger.info).not.toHaveBeenLastCalledWith('Nightly cronjob: done')
+			await waitUntil(async () => {
+				// Run timers, so that all promises in the cronjob has a chance to resolve:
+				await runAllTimers()
+				expect(logger.info).toHaveBeenLastCalledWith('Nightly cronjob: done')
+			}, MAX_WAIT_TIME)
 		}
 
 		testInFiber('Remove IngestDataCache objects that are not connected to any Rundown', async () => {
@@ -473,7 +485,7 @@ describe('cronjobs', () => {
 			mockCurrentTime = new Date(2020, 6, date++, 4, 5, 0).getTime()
 			// cronjob is checked every 5 minutes, so advance 6 minutes
 			jest.advanceTimersByTime(6 * 60 * 1000)
-			await waitForCronjobDone()
+			await runAllTimers()
 
 			// check if the correct PeripheralDevice command has been issued, and only for CasparCG devices
 			const pendingCommands = await PeripheralDeviceCommands.findFetchAsync({})
@@ -495,9 +507,12 @@ describe('cronjobs', () => {
 				)
 			})
 
-			await waitForCronjobDone()
-			// make sure that the cronjob ends
-			expect(logger.info).toHaveBeenLastCalledWith('Nightly cronjob: done')
+			expect(logger.info).not.toHaveBeenLastCalledWith('Nightly cronjob: done')
+			await waitUntil(async () => {
+				// Run timers, so that all promises in the cronjob has a chance to resolve:
+				await runAllTimers()
+				expect(logger.info).toHaveBeenLastCalledWith('Nightly cronjob: done')
+			}, MAX_WAIT_TIME)
 		})
 		testInFiber('Does not attempt to restart CasparCG when job is disabled', async () => {
 			const mockPlayoutGw = protectString<PeripheralDeviceId>(getRandomString())
@@ -593,9 +608,11 @@ describe('cronjobs', () => {
 			const pendingCommands = await PeripheralDeviceCommands.findFetchAsync({})
 			expect(pendingCommands).toHaveLength(0)
 
-			await waitForCronjobDone()
-			// make sure that the cronjob ends
-			expect(logger.info).toHaveBeenLastCalledWith('Nightly cronjob: done')
+			await waitUntil(async () => {
+				// Run timers, so that all promises in the cronjob has a chance to resolve:
+				await runAllTimers()
+				expect(logger.info).toHaveBeenLastCalledWith('Nightly cronjob: done')
+			}, MAX_WAIT_TIME)
 		})
 	})
 })

--- a/meteor/server/__tests__/cronjobs.test.ts
+++ b/meteor/server/__tests__/cronjobs.test.ts
@@ -1,5 +1,5 @@
 import '../../__mocks__/_extendJest'
-import { testInFiber, runAllTimers, beforeAllInFiber, waitUntil, testInFiberOnly } from '../../__mocks__/helpers/jest'
+import { testInFiber, runAllTimers, beforeAllInFiber, waitUntil } from '../../__mocks__/helpers/jest'
 import { MeteorMock } from '../../__mocks__/meteor'
 import { logger } from '../logging'
 import { getRandomId, getRandomString, protectString } from '../../lib/lib'
@@ -31,8 +31,6 @@ jest.mock('../logging')
 jest.mock('../api/deviceTriggers/observer')
 
 const MAX_WAIT_TIME = 4 * 1000
-
-const DateOrg = Date
 
 import '../cronjobs'
 

--- a/meteor/server/api/__tests__/peripheralDevice.test.ts
+++ b/meteor/server/api/__tests__/peripheralDevice.test.ts
@@ -14,9 +14,8 @@ import {
 	getRandomId,
 	LogLevel,
 	getRandomString,
-	sleep,
 } from '../../../lib/lib'
-import { testInFiber } from '../../../__mocks__/helpers/jest'
+import { testInFiber, waitUntil } from '../../../__mocks__/helpers/jest'
 import { setupDefaultStudioEnvironment, DefaultEnvironment } from '../../../__mocks__/helpers/database'
 import { setLogLevel } from '../../logging'
 import {
@@ -313,8 +312,11 @@ describe('test peripheralDevice general API methods', () => {
 			undefined,
 			replyMessage
 		)
-		await sleep(10)
-		expect(await PeripheralDeviceCommands.findOneAsync({})).toBeFalsy()
+
+		expect(await PeripheralDeviceCommands.findOneAsync({})).toBeTruthy()
+		await waitUntil(async () => {
+			expect(await PeripheralDeviceCommands.findOneAsync({})).toBeFalsy()
+		}, 100)
 
 		expect(resultErr).toBeNull()
 		expect(resultMessage).toEqual(replyMessage)

--- a/meteor/server/publications/lib/__tests__/rundownsObserver.test.ts
+++ b/meteor/server/publications/lib/__tests__/rundownsObserver.test.ts
@@ -2,11 +2,13 @@ import { RundownId, RundownPlaylistId, StudioId } from '@sofie-automation/coreli
 import { protectString } from '@sofie-automation/corelib/dist/protectedString'
 import { Rundown } from '../../../../lib/collections/Rundowns'
 import { Rundowns } from '../../../collections'
-import { runAllTimers, runTimersUntilNow, testInFiber } from '../../../../__mocks__/helpers/jest'
+import { runAllTimers, runTimersUntilNow, testInFiber, waitUntil } from '../../../../__mocks__/helpers/jest'
 import { MongoMock } from '../../../../__mocks__/mongo'
 import { RundownsObserver } from '../rundownsObserver'
 
 const RundownsMock = (Rundowns as any).mockCollection as MongoMock.Collection<Rundown>
+
+const MAX_WAIT_TIME = 4000
 
 describe('RundownsObserver', () => {
 	beforeEach(() => {
@@ -32,9 +34,12 @@ describe('RundownsObserver', () => {
 			expect(onChanged).toHaveBeenCalledTimes(0)
 
 			// After debounce
-			await runAllTimers()
-			expect(onChanged).toHaveBeenCalledTimes(1)
-			expect(onChangedCleanup).toHaveBeenCalledTimes(0)
+			await waitUntil(async () => {
+				// Run timers, so that promises in the observer has a chance to resolve:
+				await runAllTimers()
+				expect(onChanged).toHaveBeenCalledTimes(1)
+				expect(onChangedCleanup).toHaveBeenCalledTimes(0)
+			}, MAX_WAIT_TIME)
 
 			// still got an observer
 			expect(RundownsMock.observers).toHaveLength(1)
@@ -76,8 +81,12 @@ describe('RundownsObserver', () => {
 		const observer = new RundownsObserver(studioId, playlistId, onChanged)
 		try {
 			// ensure starts correct
-			await runAllTimers()
-			expect(onChanged).toHaveBeenCalledTimes(1)
+			await waitUntil(async () => {
+				// Run timers, so that promises in the observer has a chance to resolve:
+				await runAllTimers()
+				expect(onChanged).toHaveBeenCalledTimes(1)
+			}, MAX_WAIT_TIME)
+
 			expect(onChanged).toHaveBeenLastCalledWith([])
 			expect(onChangedCleanup).toHaveBeenCalledTimes(0)
 			expect(observer.rundownIds).toEqual([])
@@ -99,8 +108,12 @@ describe('RundownsObserver', () => {
 			expect(onChangedCleanup).toHaveBeenCalledTimes(0)
 
 			// After debounce
-			await runAllTimers()
-			expect(onChanged).toHaveBeenCalledTimes(2)
+			// ensure starts correct
+			await waitUntil(async () => {
+				// Run timers, so that promises in the observer has a chance to resolve:
+				await runAllTimers()
+				expect(onChanged).toHaveBeenCalledTimes(2)
+			}, MAX_WAIT_TIME)
 			expect(onChangedCleanup).toHaveBeenCalledTimes(0)
 			expect(onChanged).toHaveBeenLastCalledWith([mockId0])
 		} finally {
@@ -122,8 +135,12 @@ describe('RundownsObserver', () => {
 		const observer = new RundownsObserver(studioId, playlistId, onChanged)
 		try {
 			// ensure starts correct
-			await runAllTimers()
-			expect(onChanged).toHaveBeenCalledTimes(1)
+			// ensure starts correct
+			await waitUntil(async () => {
+				// Run timers, so that promises in the observer has a chance to resolve:
+				await runAllTimers()
+				expect(onChanged).toHaveBeenCalledTimes(1)
+			}, MAX_WAIT_TIME)
 			expect(onChanged).toHaveBeenLastCalledWith([])
 			expect(onChangedCleanup).toHaveBeenCalledTimes(0)
 			expect(observer.rundownIds).toEqual([])
@@ -145,8 +162,12 @@ describe('RundownsObserver', () => {
 			expect(onChangedCleanup).toHaveBeenCalledTimes(0)
 
 			// After debounce
-			await runAllTimers()
-			expect(onChanged).toHaveBeenCalledTimes(2)
+			// ensure starts correct
+			await waitUntil(async () => {
+				// Run timers, so that promises in the observer has a chance to resolve:
+				await runAllTimers()
+				expect(onChanged).toHaveBeenCalledTimes(2)
+			}, MAX_WAIT_TIME)
 			expect(onChangedCleanup).toHaveBeenCalledTimes(0)
 			expect(onChanged).toHaveBeenLastCalledWith([mockId0])
 		} finally {
@@ -168,8 +189,12 @@ describe('RundownsObserver', () => {
 		const observer = new RundownsObserver(studioId, playlistId, onChanged)
 		try {
 			// ensure starts correct
-			await runAllTimers()
-			expect(onChanged).toHaveBeenCalledTimes(1)
+			// ensure starts correct
+			await waitUntil(async () => {
+				// Run timers, so that promises in the observer has a chance to resolve:
+				await runAllTimers()
+				expect(onChanged).toHaveBeenCalledTimes(1)
+			}, MAX_WAIT_TIME)
 			expect(onChanged).toHaveBeenLastCalledWith([])
 			expect(onChangedCleanup).toHaveBeenCalledTimes(0)
 			expect(observer.rundownIds).toEqual([])
@@ -197,8 +222,12 @@ describe('RundownsObserver', () => {
 			expect(onChangedCleanup).toHaveBeenCalledTimes(0)
 
 			// After debounce
-			await runAllTimers()
-			expect(onChanged).toHaveBeenCalledTimes(2)
+			// ensure starts correct
+			await waitUntil(async () => {
+				// Run timers, so that promises in the observer has a chance to resolve:
+				await runAllTimers()
+				expect(onChanged).toHaveBeenCalledTimes(2)
+			}, MAX_WAIT_TIME)
 			expect(onChangedCleanup).toHaveBeenCalledTimes(0)
 			expect(onChanged).toHaveBeenLastCalledWith([mockId0, mockId1, mockId2, mockId3])
 
@@ -221,8 +250,12 @@ describe('RundownsObserver', () => {
 			expect(onChangedCleanup).toHaveBeenCalledTimes(0)
 
 			// After debounce
-			await runAllTimers()
-			expect(onChanged).toHaveBeenCalledTimes(3)
+			// ensure starts correct
+			await waitUntil(async () => {
+				// Run timers, so that promises in the observer has a chance to resolve:
+				await runAllTimers()
+				expect(onChanged).toHaveBeenCalledTimes(3)
+			}, MAX_WAIT_TIME)
 			expect(onChangedCleanup).toHaveBeenCalledTimes(0)
 			expect(onChanged).toHaveBeenLastCalledWith([mockId0, mockId1, mockId3, mockId4])
 		} finally {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Modify some unit tests that often time out due to that we triggered the Fake Timers a lot. Now, we're using waitUntil() and trigger the Fake Timers less times in between each check


* **What is the current behavior?** (You can also link to an open issue here)

Tests often fail randomly, likely due to the CI worker is under heavy CPU load.


* **What is the new behavior (if this is a feature change)?**

Reduced risk of randomly failing tests




