### PR TITLE
fix(Server Integration): don't rely on winston types in `server-core-integration`, have own logger interface

### DIFF
--- a/packages/server-core-integration/src/lib/process.ts
+++ b/packages/server-core-integration/src/lib/process.ts
@@ -1,5 +1,4 @@
 // eslint-disable-next-line node/no-extraneous-import
-import type { Logger } from 'winston'
 import * as fs from 'fs'
 
 export interface CertificatesConfig {
@@ -9,7 +8,7 @@ export interface CertificatesConfig {
 	certificates: string[]
 }
 
-export function loadCertificatesFromDisk(logger: Logger, certConfig: CertificatesConfig): Buffer[] {
+export function loadCertificatesFromDisk(logger: SomeLogger, certConfig: CertificatesConfig): Buffer[] {
 	if (certConfig.unsafeSSL) {
 		logger.info('Disabling NODE_TLS_REJECT_UNAUTHORIZED, be sure to ONLY DO THIS ON A LOCAL NETWORK!')
 		process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0'
@@ -31,4 +30,12 @@ export function loadCertificatesFromDisk(logger: Logger, certConfig: Certificate
 	}
 
 	return certificates
+}
+
+interface SomeLogger {
+	info(message: string, ...meta: any[]): void
+	error(message: string, ...meta: any[]): void
+	warn(message: string, ...meta: any[]): void
+	log(message: string, ...meta: any[]): void
+	debug(message: string, ...meta: any[]): void
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

`server-core-integration` uses an undeclared `winston` dependency.

* **What is the new behavior (if this is a feature change)?**

Replace the `winston` type import with an internal interface definition of a common logger, for more logging flexibility.

* **Other information**:

Fixes #925 

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
