### PR TITLE
fix: don't log UserError messages at error level from the job-worker SOFIE-2592

### DIFF
--- a/meteor/lib/api/rest/v1/playlists.ts
+++ b/meteor/lib/api/rest/v1/playlists.ts
@@ -121,7 +121,7 @@ export interface PlaylistsRestAPI {
 		connection: Meteor.Connection,
 		event: string,
 		rundownPlaylistId: RundownPlaylistId
-	): Promise<ClientAPI.ClientResponse<object>>
+	): Promise<ClientAPI.ClientResponse<void>>
 	/**
 	 * Resets a Playlist back to its pre-played state.
 	 *

--- a/meteor/lib/api/triggers/actionFactory.ts
+++ b/meteor/lib/api/triggers/actionFactory.ts
@@ -515,7 +515,7 @@ export function createAction(action: SomeAction, sourceLayers: SourceLayers): Ex
 				if (rundownId) {
 					return MeteorCall.userAction.activateScratchpadMode(e, ts, ctx.rundownPlaylistId.get(), rundownId)
 				} else {
-					return ClientAPI.responseError(UserError.create(UserErrorMessage.InternalError))
+					return ClientAPI.responseError(UserError.create(UserErrorMessage.InactiveRundown))
 				}
 			})
 		case PlayoutActions.take:

--- a/meteor/server/api/rest/v1/playlists.ts
+++ b/meteor/server/api/rest/v1/playlists.ts
@@ -261,8 +261,8 @@ class PlaylistsServerAPI implements PlaylistsRestAPI {
 		connection: Meteor.Connection,
 		event: string,
 		rundownPlaylistId: RundownPlaylistId
-	): Promise<ClientAPI.ClientResponse<object>> {
-		return ServerClientAPI.runUserActionInLogForPlaylist<object>(
+	): Promise<ClientAPI.ClientResponse<void>> {
+		return ServerClientAPI.runUserActionInLogForPlaylist<void>(
 			this.context.getMethodContext(connection),
 			event,
 			getCurrentTime(),
@@ -277,12 +277,11 @@ class PlaylistsServerAPI implements PlaylistsRestAPI {
 				const success = !reloadResponse.rundownsResponses.reduce((missing, rundownsResponse) => {
 					return missing || rundownsResponse.response === TriggerReloadDataResponse.MISSING
 				}, false)
-				return success
-					? {}
-					: UserError.from(
-							new Error(`Failed to reload playlist ${rundownPlaylistId}`),
-							UserErrorMessage.InternalError
-					  )
+				if (!success)
+					throw UserError.from(
+						new Error(`Failed to reload playlist ${rundownPlaylistId}`),
+						UserErrorMessage.InternalError
+					)
 			}
 		)
 	}
@@ -557,7 +556,7 @@ export function registerRoutes(registerRoute: APIRegisterHook<PlaylistsRestAPI>)
 		}
 	)
 
-	registerRoute<{ playlistId: string }, never, object>(
+	registerRoute<{ playlistId: string }, never, void>(
 		'put',
 		'/playlists/:playlistId/reload-playlist',
 		new Map([[404, [UserErrorMessage.RundownPlaylistNotFound]]]),


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

fix

* **What is the current behavior?** (You can also link to an open issue here)

when a useraction calls into the job-worker, an expected failure will result in an error log line of that expected failure

* **What is the new behavior (if this is a feature change)?**

those failures are now logged at the info level

* **Other information**:

This also includes a fix for a stable api endpoint where it was returning an error instead of throwing it.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
