### PR TITLE
fix: AdLibs don't appear in Live Status Gateway until first take

### DIFF
--- a/packages/live-status-gateway/src/collections/adLibActions.ts
+++ b/packages/live-status-gateway/src/collections/adLibActions.ts
@@ -42,7 +42,7 @@ export class AdLibActionsHandler
 		await new Promise(process.nextTick.bind(this))
 		if (!this._collectionName) return
 		if (!this._publicationName) return
-		if (prevRundownId !== this._curRundownId || prevCurPartInstance !== this._curPartInstance)) {
+		if (prevRundownId !== this._curRundownId || prevCurPartInstance !== this._curPartInstance) {
 			if (this._subscriptionId) this._coreHandler.unsubscribe(this._subscriptionId)
 			if (this._dbObserver) this._dbObserver.stop()
 			if (this._curRundownId && this._curPartInstance) {

--- a/packages/live-status-gateway/src/collections/adLibActions.ts
+++ b/packages/live-status-gateway/src/collections/adLibActions.ts
@@ -15,6 +15,7 @@ export class AdLibActionsHandler
 	public observerName: string
 	private _core: CoreConnection
 	private _curRundownId: string | undefined
+	private _curPartInstance: DBPartInstance | undefined
 
 	constructor(logger: Logger, coreHandler: CoreHandler) {
 		super(AdLibActionsHandler.name, CollectionName.AdLibActions, 'adLibActions', logger, coreHandler)
@@ -34,15 +35,17 @@ export class AdLibActionsHandler
 	async update(source: string, data: Map<PartInstanceName, DBPartInstance | undefined> | undefined): Promise<void> {
 		this._logger.info(`${this._name} received partInstances update from ${source}`)
 		const prevRundownId = this._curRundownId
-		this._curRundownId = data ? unprotectString(data.get(PartInstanceName.current)?.rundownId) : undefined
+		const prevCurPartInstance = this._curPartInstance
+		this._curPartInstance = data ? data.get(PartInstanceName.current) ?? data.get(PartInstanceName.next) : undefined
+		this._curRundownId = this._curPartInstance ? unprotectString(this._curPartInstance.rundownId) : undefined
 
 		await new Promise(process.nextTick.bind(this))
 		if (!this._collectionName) return
 		if (!this._publicationName) return
-		if (prevRundownId !== this._curRundownId) {
+		if (!(prevRundownId === this._curRundownId && prevCurPartInstance === this._curPartInstance)) {
 			if (this._subscriptionId) this._coreHandler.unsubscribe(this._subscriptionId)
 			if (this._dbObserver) this._dbObserver.stop()
-			if (this._curRundownId) {
+			if (this._curRundownId && this._curPartInstance) {
 				this._subscriptionId = await this._coreHandler.setupSubscription(this._publicationName, {
 					rundownId: this._curRundownId,
 				})
@@ -56,7 +59,10 @@ export class AdLibActionsHandler
 
 				const collection = this._core.getCollection<AdLibAction>(this._collectionName)
 				if (!collection) throw new Error(`collection '${this._collectionName}' not found!`)
-				this._collectionData = collection.find(undefined)
+				this._collectionData = collection.find({
+					rundownId: this._curRundownId,
+					partId: this._curPartInstance.part._id,
+				})
 				await this.notify(this._collectionData)
 			}
 		}

--- a/packages/live-status-gateway/src/collections/adLibActions.ts
+++ b/packages/live-status-gateway/src/collections/adLibActions.ts
@@ -7,6 +7,7 @@ import { DBPartInstance } from '@sofie-automation/corelib/dist/dataModel/PartIns
 import { unprotectString } from '@sofie-automation/shared-lib/dist/lib/protectedString'
 import { PartInstanceName } from './partInstances'
 import { CollectionName } from '@sofie-automation/corelib/dist/dataModel/Collections'
+import _ = require('underscore')
 
 export class AdLibActionsHandler
 	extends CollectionBase<AdLibAction[]>
@@ -42,7 +43,7 @@ export class AdLibActionsHandler
 		await new Promise(process.nextTick.bind(this))
 		if (!this._collectionName) return
 		if (!this._publicationName) return
-		if (prevRundownId !== this._curRundownId || prevCurPartInstance !== this._curPartInstance) {
+		if (prevRundownId !== this._curRundownId || !_.isEqual(prevCurPartInstance, this._curPartInstance)) {
 			if (this._subscriptionId) this._coreHandler.unsubscribe(this._subscriptionId)
 			if (this._dbObserver) this._dbObserver.stop()
 			if (this._curRundownId && this._curPartInstance) {

--- a/packages/live-status-gateway/src/collections/adLibActions.ts
+++ b/packages/live-status-gateway/src/collections/adLibActions.ts
@@ -42,7 +42,7 @@ export class AdLibActionsHandler
 		await new Promise(process.nextTick.bind(this))
 		if (!this._collectionName) return
 		if (!this._publicationName) return
-		if (!(prevRundownId === this._curRundownId && prevCurPartInstance === this._curPartInstance)) {
+		if (prevRundownId !== this._curRundownId || prevCurPartInstance !== this._curPartInstance)) {
 			if (this._subscriptionId) this._coreHandler.unsubscribe(this._subscriptionId)
 			if (this._dbObserver) this._dbObserver.stop()
 			if (this._curRundownId && this._curPartInstance) {

--- a/packages/live-status-gateway/src/collections/adLibs.ts
+++ b/packages/live-status-gateway/src/collections/adLibs.ts
@@ -15,6 +15,7 @@ export class AdLibsHandler
 	public observerName: string
 	private _core: CoreConnection
 	private _curRundownId: string | undefined
+	private _curPartInstance: DBPartInstance | undefined
 
 	constructor(logger: Logger, coreHandler: CoreHandler) {
 		super(AdLibsHandler.name, CollectionName.AdLibPieces, 'adLibPieces', logger, coreHandler)
@@ -34,15 +35,17 @@ export class AdLibsHandler
 	async update(source: string, data: Map<PartInstanceName, DBPartInstance | undefined> | undefined): Promise<void> {
 		this._logger.info(`${this._name} received adLibs update from ${source}`)
 		const prevRundownId = this._curRundownId
-		this._curRundownId = data ? unprotectString(data.get(PartInstanceName.current)?.rundownId) : undefined
+		const prevCurPartInstance = this._curPartInstance
+		this._curPartInstance = data ? data.get(PartInstanceName.current) ?? data.get(PartInstanceName.next) : undefined
+		this._curRundownId = this._curPartInstance ? unprotectString(this._curPartInstance.rundownId) : undefined
 
 		await new Promise(process.nextTick.bind(this))
 		if (!this._collectionName) return
 		if (!this._publicationName) return
-		if (prevRundownId !== this._curRundownId) {
+		if (!(prevRundownId === this._curRundownId && prevCurPartInstance === this._curPartInstance)) {
 			if (this._subscriptionId) this._coreHandler.unsubscribe(this._subscriptionId)
 			if (this._dbObserver) this._dbObserver.stop()
-			if (this._curRundownId) {
+			if (this._curRundownId && this._curPartInstance) {
 				this._subscriptionId = await this._coreHandler.setupSubscription(this._publicationName, {
 					rundownId: this._curRundownId,
 				})
@@ -56,7 +59,10 @@ export class AdLibsHandler
 
 				const collection = this._core.getCollection<AdLibPiece>(this._collectionName)
 				if (!collection) throw new Error(`collection '${this._collectionName}' not found!`)
-				this._collectionData = collection.find({ rundownId: this._curRundownId })
+				this._collectionData = collection.find({
+					rundownId: this._curRundownId,
+					partId: this._curPartInstance.part._id,
+				})
 				await this.notify(this._collectionData)
 			}
 		}

--- a/packages/live-status-gateway/src/collections/adLibs.ts
+++ b/packages/live-status-gateway/src/collections/adLibs.ts
@@ -7,6 +7,7 @@ import { DBPartInstance } from '@sofie-automation/corelib/dist/dataModel/PartIns
 import { unprotectString } from '@sofie-automation/shared-lib/dist/lib/protectedString'
 import { PartInstanceName } from './partInstances'
 import { CollectionName } from '@sofie-automation/corelib/dist/dataModel/Collections'
+import _ = require('underscore')
 
 export class AdLibsHandler
 	extends CollectionBase<AdLibPiece[]>
@@ -42,7 +43,7 @@ export class AdLibsHandler
 		await new Promise(process.nextTick.bind(this))
 		if (!this._collectionName) return
 		if (!this._publicationName) return
-		if (!(prevRundownId === this._curRundownId && prevCurPartInstance === this._curPartInstance)) {
+		if (prevRundownId !== this._curRundownId || !_.isEqual(prevCurPartInstance, this._curPartInstance)) {
 			if (this._subscriptionId) this._coreHandler.unsubscribe(this._subscriptionId)
 			if (this._dbObserver) this._dbObserver.stop()
 			if (this._curRundownId && this._curPartInstance) {

--- a/packages/live-status-gateway/src/collections/globalAdLibActions.ts
+++ b/packages/live-status-gateway/src/collections/globalAdLibActions.ts
@@ -42,7 +42,8 @@ export class GlobalAdLibActionsHandler
 	async update(source: string, data: Map<PartInstanceName, DBPartInstance | undefined> | undefined): Promise<void> {
 		this._logger.info(`${this._name} received partInstances update from ${source}`)
 		const prevRundownId = this._curRundownId
-		this._curRundownId = data ? unprotectString(data.get(PartInstanceName.current)?.rundownId) : undefined
+		const partInstance = data ? data.get(PartInstanceName.current) ?? data.get(PartInstanceName.next) : undefined
+		this._curRundownId = partInstance ? unprotectString(partInstance.rundownId) : undefined
 
 		await new Promise(process.nextTick.bind(this))
 		if (!this._collectionName) return

--- a/packages/live-status-gateway/src/collections/globalAdLibs.ts
+++ b/packages/live-status-gateway/src/collections/globalAdLibs.ts
@@ -42,7 +42,8 @@ export class GlobalAdLibsHandler
 	async update(source: string, data: Map<PartInstanceName, DBPartInstance | undefined> | undefined): Promise<void> {
 		this._logger.info(`${this._name} received globalAdLibs update from ${source}`)
 		const prevRundownId = this._curRundownId
-		this._curRundownId = data ? unprotectString(data.get(PartInstanceName.current)?.rundownId) : undefined
+		const partInstance = data ? data.get(PartInstanceName.current) ?? data.get(PartInstanceName.next) : undefined
+		this._curRundownId = partInstance ? unprotectString(partInstance.rundownId) : undefined
 
 		await new Promise(process.nextTick.bind(this))
 		if (!this._collectionName) return

--- a/packages/live-status-gateway/src/coreHandler.ts
+++ b/packages/live-status-gateway/src/coreHandler.ts
@@ -117,8 +117,10 @@ export class CoreHandler {
 		this.logger.info('Core: Setting up subscriptions..')
 		this.logger.info('DeviceId: ' + this.core.deviceId)
 
-		await this.core.autoSubscribe('peripheralDeviceForDevice', this.core.deviceId)
-
+		await Promise.all([
+			this.core.autoSubscribe('peripheralDeviceForDevice', this.core.deviceId),
+			this.core.autoSubscribe('peripheralDeviceCommands', this.core.deviceId),
+		])
 		this.logger.info('Core: Subscriptions are set up!')
 		if (this._observers.length) {
 			this.logger.info('CoreMos: Clearing observers..')
@@ -131,6 +133,7 @@ export class CoreHandler {
 		const observer = this.core.observe('peripheralDeviceForDevice')
 		observer.added = (id: string) => this.onDeviceChanged(protectString(id))
 		observer.changed = (id: string) => this.onDeviceChanged(protectString(id))
+		this.setupObserverForPeripheralDeviceCommands(this)
 	}
 	async destroy(): Promise<void> {
 		this._statusDestroyed = true
@@ -246,6 +249,38 @@ export class CoreHandler {
 	}
 	retireExecuteFunction(cmdId: string): void {
 		delete this._executedFunctions[cmdId]
+	}
+	setupObserverForPeripheralDeviceCommands(functionObject: CoreHandler): void {
+		const observer = functionObject.core.observe('peripheralDeviceCommands')
+		functionObject._observers.push(observer)
+		const addedChangedCommand = (id: string) => {
+			const cmds = functionObject.core.getCollection<PeripheralDeviceCommand>('peripheralDeviceCommands')
+			if (!cmds) throw Error('"peripheralDeviceCommands" collection not found!')
+			const cmd = cmds.findOne(protectString(id))
+			if (!cmd) throw Error('PeripheralCommand "' + id + '" not found!')
+			// console.log('addedChangedCommand', id)
+			if (cmd.deviceId === functionObject.core.deviceId) {
+				this.executeFunction(cmd, functionObject)
+			} else {
+				// console.log('not mine', cmd.deviceId, this.core.deviceId)
+			}
+		}
+		observer.added = (id: string) => {
+			addedChangedCommand(id)
+		}
+		observer.changed = (id: string) => {
+			addedChangedCommand(id)
+		}
+		observer.removed = (id: string) => {
+			this.retireExecuteFunction(id)
+		}
+		const cmds = functionObject.core.getCollection<PeripheralDeviceCommand>('peripheralDeviceCommands')
+		if (!cmds) throw Error('"peripheralDeviceCommands" collection not found!')
+		cmds.find({}).forEach((cmd) => {
+			if (cmd.deviceId === functionObject.core.deviceId) {
+				this.executeFunction(cmd, functionObject)
+			}
+		})
 	}
 	killProcess(actually: number): boolean {
 		if (actually === 1) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix.

**What is the current behavior?** (You can also link to an open issue here)

The Live Status Gateway doesn't populate a list of AdLibs until the first Part of a Rundown is taken.

**What is the new behavior (if this is a feature change)?**

The list is now populated on activate.

**Other information**:

This PR also includes a fix for a bug where the Live Status Gateway would not restart when requested.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
