### PR TITLE
Fix: Memory leak on initialize loop (SOFIE-2632)

### DIFF
--- a/meteor/server/api/__tests__/peripheralDevice.test.ts
+++ b/meteor/server/api/__tests__/peripheralDevice.test.ts
@@ -234,6 +234,7 @@ describe('test peripheralDevice general API methods', () => {
 	testInFiber('ping', async () => {
 		expect(PeripheralDevices.findOne(device._id)).toBeTruthy()
 		const lastSeen = (PeripheralDevices.findOne(device._id) as PeripheralDevice).lastSeen
+		await sleep(1000) // Wait a bit, to ensure that the lastSeen is updated
 		await MeteorCall.peripheralDevice.ping(device._id, device.token)
 		expect((PeripheralDevices.findOne(device._id) as PeripheralDevice).lastSeen).toBeGreaterThan(lastSeen)
 	})
@@ -282,8 +283,9 @@ describe('test peripheralDevice general API methods', () => {
 		const lastSeen = device2.lastSeen - 100
 		PeripheralDevices.update(device._id, { $set: { lastSeen: lastSeen } })
 
-		const message = 'Waving!'
+		await sleep(1000) // Wait a bit, to ensure that the lastSeen is updated
 		// Note: the null is so that Metor doesnt try to use pingCompleted  as a callback instead of blocking
+		const message = 'Waving!'
 		await MeteorCall.peripheralDevice.pingWithCommand(device._id, device.token, message, pingCompleted)
 		expect((PeripheralDevices.findOne(device._id) as PeripheralDevice).lastSeen).toBeGreaterThan(lastSeen)
 		const command = PeripheralDeviceCommands.find({ deviceId: device._id }).fetch()[0]

--- a/packages/playout-gateway/src/coreHandler.ts
+++ b/packages/playout-gateway/src/coreHandler.ts
@@ -1,4 +1,10 @@
-import { CoreConnection, CoreOptions, DDPConnectorOptions, Observer } from '@sofie-automation/server-core-integration'
+import {
+	CoreConnection,
+	CoreOptions,
+	DDPConnectorOptions,
+	Observer,
+	stringifyError,
+} from '@sofie-automation/server-core-integration'
 
 import {
 	DeviceType,
@@ -524,6 +530,7 @@ export class CoreTSRDeviceHandler {
 		statusCode: StatusCode.BAD,
 		messages: ['Starting up...'],
 	}
+	private disposed = false
 
 	constructor(
 		parent: CoreHandler,
@@ -538,6 +545,7 @@ export class CoreTSRDeviceHandler {
 	}
 	async init(): Promise<void> {
 		this._device = await this._devicePr
+		if (this.disposed) return
 		const deviceId = this._device.deviceId
 		const deviceName = `${deviceId} (${this._device.deviceName})`
 
@@ -652,6 +660,7 @@ export class CoreTSRDeviceHandler {
 	}
 
 	async dispose(): Promise<void> {
+		this.disposed = true
 		this._observers.forEach((obs) => {
 			obs.stop()
 		})
@@ -659,6 +668,7 @@ export class CoreTSRDeviceHandler {
 		for (const subId of this._subscriptions) {
 			this.core.unsubscribe(subId)
 		}
+		this._subscriptions = []
 
 		await this._tsrHandler.tsr.removeDevice(this._deviceId)
 		await this.core.setStatus({

--- a/packages/playout-gateway/src/coreHandler.ts
+++ b/packages/playout-gateway/src/coreHandler.ts
@@ -545,7 +545,7 @@ export class CoreTSRDeviceHandler {
 	}
 	async init(): Promise<void> {
 		this._device = await this._devicePr
-		if (this.disposed) return
+		if (this.disposed) throw new Error('CoreTSRDeviceHandler cant init, is disposed')
 		const deviceId = this._device.deviceId
 		const deviceName = `${deviceId} (${this._device.deviceName})`
 
@@ -560,6 +560,7 @@ export class CoreTSRDeviceHandler {
 			this._coreParentHandler.logger.error(`(${this._deviceId}): Core Error: ${stringifyError(err)}`)
 		})
 		await this.core.init(this._coreParentHandler.core)
+		if (this.disposed) throw new Error('CoreTSRDeviceHandler cant init, is disposed')
 
 		if (!this._hasGottenStatusChange) {
 			this._deviceStatus = {
@@ -571,7 +572,10 @@ export class CoreTSRDeviceHandler {
 			}
 			this.sendStatus()
 		}
+		if (this.disposed) throw new Error('CoreTSRDeviceHandler cant init, is disposed')
 		await this.setupSubscriptionsAndObservers()
+		if (this.disposed) throw new Error('CoreTSRDeviceHandler cant init, is disposed')
+
 		this._coreParentHandler.logger.debug('setupSubscriptionsAndObservers done')
 	}
 	private async setupSubscriptionsAndObservers(): Promise<void> {

--- a/packages/playout-gateway/src/coreHandler.ts
+++ b/packages/playout-gateway/src/coreHandler.ts
@@ -93,7 +93,7 @@ export class CoreHandler {
 			this.logger.warn('Core Disconnected!')
 		})
 		this.core.onError((err: any) => {
-			this.logger.error('Core Error: ' + (typeof err === 'string' ? err : err.message || err.toString() || err))
+			this.logger.error(`Core Error: ${stringifyError(err)}`)
 		})
 
 		const ddpConfig: DDPConnectorOptions = {
@@ -549,9 +549,7 @@ export class CoreTSRDeviceHandler {
 			)
 		)
 		this.core.onError((err: any) => {
-			this._coreParentHandler.logger.error(
-				'Core Error: ' + ((_.isObject(err) && err.message) || err.toString() || err)
-			)
+			this._coreParentHandler.logger.error(`(${this._deviceId}): Core Error: ${stringifyError(err)}`)
 		})
 		await this.core.init(this._coreParentHandler.core)
 

--- a/packages/playout-gateway/src/coreHandler.ts
+++ b/packages/playout-gateway/src/coreHandler.ts
@@ -1,10 +1,4 @@
-import {
-	CoreConnection,
-	CoreOptions,
-	DDPConnectorOptions,
-	Observer,
-	stringifyError,
-} from '@sofie-automation/server-core-integration'
+import { CoreConnection, CoreOptions, DDPConnectorOptions, Observer } from '@sofie-automation/server-core-integration'
 
 import {
 	DeviceType,

--- a/packages/playout-gateway/src/coreHandler.ts
+++ b/packages/playout-gateway/src/coreHandler.ts
@@ -99,7 +99,7 @@ export class CoreHandler {
 			this.logger.warn('Core Disconnected!')
 		})
 		this.core.onError((err: any) => {
-			this.logger.error(`Core Error: ${stringifyError(err)}`)
+			this.logger.error('Core Error: ' + (typeof err === 'string' ? err : err.message || err.toString() || err))
 		})
 
 		const ddpConfig: DDPConnectorOptions = {
@@ -557,7 +557,9 @@ export class CoreTSRDeviceHandler {
 			)
 		)
 		this.core.onError((err: any) => {
-			this._coreParentHandler.logger.error(`(${this._deviceId}): Core Error: ${stringifyError(err)}`)
+			this._coreParentHandler.logger.error(
+				'Core Error: ' + ((_.isObject(err) && err.message) || err.toString() || err)
+			)
 		})
 		await this.core.init(this._coreParentHandler.core)
 		if (this.disposed) throw new Error('CoreTSRDeviceHandler cant init, is disposed')

--- a/packages/server-core-integration/src/lib/coreConnection.ts
+++ b/packages/server-core-integration/src/lib/coreConnection.ts
@@ -177,6 +177,7 @@ export class CoreConnection extends EventEmitter<CoreConnectionEvents> {
 			this._removeParent()
 			if (this._ddp) {
 				this._ddp.close()
+				this._ddp.removeAllListeners()
 			}
 		}
 		this.removeAllListeners()
@@ -512,6 +513,7 @@ export class CoreConnection extends EventEmitter<CoreConnectionEvents> {
 		})
 	}
 	private _triggerPing() {
+		if (this._destroyed) return
 		if (!this._pingTimeout) {
 			this._pingTimeout = setTimeout(() => {
 				this._pingTimeout = null
@@ -527,7 +529,10 @@ export class CoreConnection extends EventEmitter<CoreConnectionEvents> {
 		}
 		this._triggerPing()
 	}
+	/** We continuously ping Core to let Core know that we're alive */
 	private _ping() {
+		if (this._destroyed) return
+
 		try {
 			if (this.connected) {
 				this.coreMethods.ping().catch((e) => this._emitError('_ping' + e))


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR attempts to fix a memory-leak/crash we've seen in a production environment.


* **What is the current behavior?** (You can also link to an open issue here)

Playout Gateway was in an initialization loop, where it was unable to initialize some devices (likely due to a network issue). This caused issues in Core, eventually leading to out-of-memory and crash.


* **What is the new behavior (if this is a feature change)?**

(Not tested yet) Reduced load on Core, when Playout Gateway re-initializes devices.


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
