### PR TITLE
chore: do not send code test coverage to CodeCov on release branches

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -19,4 +19,5 @@ The author is encouraged to do a functional test before submitting
 -->
 - [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
 - [ ] The functionality has been tested by the PR author
+- [ ] Automated tests to cover the new functionality and/or guard against regressions have been added
 - [ ] The functionality has been tested by NRK

--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -77,6 +77,7 @@ jobs:
         env:
           CI: true
       - name: Send coverage
+        if: (!startsWith(github.ref_name, 'release'))
         uses: codecov/codecov-action@v3
 
   build-core:
@@ -466,7 +467,7 @@ jobs:
         env:
           CI: true
       - name: Send coverage
-        if: matrix.node-version == '16.x' || matrix.send-coverage == true
+        if: (matrix.node-version == '16.x' || matrix.send-coverage == true) && (!startsWith(github.ref_name, 'release'))
         uses: codecov/codecov-action@v3
 
   publish-docs:


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Workflow improvement

* **What is the current behavior?** (You can also link to an open issue here)

Code test coverage information on release branches does not seem to be reliable. It is not very informative and obscures the "at a glance" quality of the CI pipeline we have by producing false negatives.

* **What is the new behavior (if this is a feature change)?**

"Send coverage" set will not be executed on release branches.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
