### PR TITLE
fix: Initiating restart from status page could end up with an "N/A" event context

### DIFF
--- a/meteor/client/ui/Settings/DeviceSettings.tsx
+++ b/meteor/client/ui/Settings/DeviceSettings.tsx
@@ -69,7 +69,9 @@ export default translateWithTracker<IDeviceSettingsProps, IDeviceSettingsState, 
 			return null
 		}
 
-		restartDevice(device: PeripheralDevice) {
+		restartDevice(device: PeripheralDevice, e: React.UIEvent<HTMLElement>) {
+			e.persist()
+
 			const { t } = this.props
 			doModalDialog({
 				message: t('Are you sure you want to restart this device?'),
@@ -148,7 +150,7 @@ export default translateWithTracker<IDeviceSettingsProps, IDeviceSettingsState, 
 							<h2 className="mhn mtn">{t('Generic Properties')}</h2>
 							<label className="field">
 								<LabelActual label={t('Device Name')} />
-								{!(this.props.device && this.props.device.name) ? (
+								{!(device && device.name) ? (
 									<div className="error-notice inline">
 										{t('No name set')} <FontAwesomeIcon icon={faExclamationTriangle} />
 									</div>
@@ -157,7 +159,7 @@ export default translateWithTracker<IDeviceSettingsProps, IDeviceSettingsState, 
 									<EditAttribute
 										modifiedClassName="bghl"
 										attribute="name"
-										obj={this.props.device}
+										obj={device}
 										type="text"
 										collection={PeripheralDevices}
 										className="mdinput"
@@ -168,7 +170,10 @@ export default translateWithTracker<IDeviceSettingsProps, IDeviceSettingsState, 
 						</div>
 						<div className="col c12 rl-c6 alright">
 							<div className="mbs">
-								<button className="btn btn-secondary btn-tight" onClick={() => device && this.restartDevice(device)}>
+								<button
+									className="btn btn-secondary btn-tight"
+									onClick={(e) => device && this.restartDevice(device, e)}
+								>
 									{t('Restart Device')}
 								</button>
 							</div>
@@ -213,7 +218,7 @@ export default translateWithTracker<IDeviceSettingsProps, IDeviceSettingsState, 
 							<EditAttribute
 								modifiedClassName="bghl"
 								attribute="disableVersionChecks"
-								obj={this.props.device}
+								obj={device}
 								type="checkbox"
 								collection={PeripheralDevices}
 								className="input"
@@ -225,9 +230,9 @@ export default translateWithTracker<IDeviceSettingsProps, IDeviceSettingsState, 
 						{this.renderSpecifics()}
 					</div>
 
-					{this.props.device &&
-					this.props.device.type === PeripheralDeviceType.PACKAGE_MANAGER &&
-					this.props.device.subType === PERIPHERAL_SUBTYPE_PROCESS
+					{device &&
+					device.type === PeripheralDeviceType.PACKAGE_MANAGER &&
+					device.subType === PERIPHERAL_SUBTYPE_PROCESS
 						? this.renderPackageManagerSpecial()
 						: null}
 				</div>

--- a/meteor/client/ui/Status/SystemStatus.tsx
+++ b/meteor/client/ui/Status/SystemStatus.tsx
@@ -313,6 +313,7 @@ export const DeviceItem = reacti18next.withTranslation()(
 										onClick={(e) => {
 											e.preventDefault()
 											e.stopPropagation()
+											e.persist()
 
 											doModalDialog({
 												message: t('Are you sure you want to restart this device?'),

--- a/meteor/lib/clientUserAction.ts
+++ b/meteor/lib/clientUserAction.ts
@@ -263,7 +263,10 @@ export function eventContextForLog(e: any): [string, Time] {
 		str = e.type
 	}
 	if (!str) {
-		logger.error('Unknown event', e)
+		logger.error(
+			'Could not create context in eventContextForLog, because provided event had no identifiable type',
+			e
+		)
 		str = 'N/A'
 	}
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

`Uncaught error happened in GUI: ***Unknown error in handleAccept***` is printed to the log in certain cases

* **What is the new behavior (if this is a feature change)?**

The problem was that we didn't persist the React event in once case, meaning that it got recycled, loosing it's type information by the time we tried to construct `eventContextForLog`. The event should now be persisted for creating the log entry. Also, the log line produced if the context can't be created should now be much easier to understand and pin down to a source.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
