### PR TITLE
fix: allow BucketAdlibAction to access PackageInfos SOFIE-2655

### DIFF
--- a/packages/job-worker/src/playout/adlibAction.ts
+++ b/packages/job-worker/src/playout/adlibAction.ts
@@ -54,7 +54,11 @@ export async function handleExecuteAdlibAction(
 		const watchedPackages = await WatchedPackagesHelper.create(context, context.studio._id, {
 			pieceId: data.actionDocId,
 			fromPieceType: {
-				$in: [ExpectedPackageDBType.ADLIB_ACTION, ExpectedPackageDBType.BASELINE_ADLIB_ACTION],
+				$in: [
+					ExpectedPackageDBType.ADLIB_ACTION,
+					ExpectedPackageDBType.BASELINE_ADLIB_ACTION,
+					ExpectedPackageDBType.BUCKET_ADLIB_ACTION,
+				],
 			},
 		})
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Bucket adlib-actions can and should generage expectedPackages for their media.  
But they cannot use the `listenForPackageUpdates` flow to be regenerated when this changes.  
They also cannot fetch any generated package infos when they are executed

* **What is the new behavior (if this is a feature change)?**

This allows them to fetch any generated package infos when they are executed.  
While not the full flow implementation, this is the easy and safe portion which allows bucket adlib-actions to execute with knowledge on the status of their expectedpackages

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] Automated tests to cover the new functionality and/or guard against regressions have been added
- [ ] The functionality has been tested by NRK
