### PR TITLE
feat: A/B player Ids as strings

### DIFF
--- a/packages/blueprints-integration/src/abPlayback.ts
+++ b/packages/blueprints-integration/src/abPlayback.ts
@@ -20,7 +20,7 @@ export const AB_MEDIA_PLAYER_AUTO = '__auto__'
  * Description of a player in an AB pool
  */
 export interface ABPlayerDefinition {
-	playerId: number
+	playerId: number | string
 }
 
 /**
@@ -30,7 +30,7 @@ export interface ABTimelineLayerChangeRule {
 	/** What AB pools can this rule be used for */
 	acceptedPoolNames: string[]
 	/** A function to generate the new layer name for a chosen playerId */
-	newLayerName: (playerId: number) => string
+	newLayerName: (playerId: number | string) => string
 	/** Whether this rule can be used for lookaheadObjects */
 	allowsLookahead: boolean
 }
@@ -60,7 +60,7 @@ export interface ABResolverConfiguration {
 	customApplyToObject?: (
 		context: ICommonContext,
 		poolName: string,
-		playerId: number,
+		playerId: number | string,
 		timelineObject: OnGenerateTimelineObj<TSR.TSRTimelineContent>
 	) => boolean
 }

--- a/packages/corelib/src/dataModel/RundownPlaylist.ts
+++ b/packages/corelib/src/dataModel/RundownPlaylist.ts
@@ -27,7 +27,7 @@ export interface ABSessionInfo {
 
 export interface ABSessionAssignment {
 	sessionId: string
-	playerId: number
+	playerId: number | string
 	lookahead: boolean // purely informational for debugging
 }
 

--- a/packages/job-worker/src/playout/abPlayback/__tests__/abPlayback.spec.ts
+++ b/packages/job-worker/src/playout/abPlayback/__tests__/abPlayback.spec.ts
@@ -179,9 +179,9 @@ describe('resolveMediaPlayers', () => {
 
 		expect(mockGetPieceSessionId).toHaveBeenCalledTimes(3)
 		expect(mockGetObjectSessionId).toHaveBeenCalledTimes(0)
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(1, pieces[0], 'clip_abc')
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(2, pieces[1], 'clip_def')
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(3, pieces[2], 'clip_ghi')
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(1, pieces[0].instance, 'clip_abc')
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(2, pieces[1].instance, 'clip_def')
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(3, pieces[2].instance, 'clip_ghi')
 	})
 
 	test('basic pieces - players with number and string Ids', () => {
@@ -215,9 +215,9 @@ describe('resolveMediaPlayers', () => {
 
 		expect(mockGetPieceSessionId).toHaveBeenCalledTimes(3)
 		expect(mockGetObjectSessionId).toHaveBeenCalledTimes(0)
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(1, pieces[0], 'clip_abc')
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(2, pieces[1], 'clip_def')
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(3, pieces[2], 'clip_ghi')
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(1, pieces[0].instance, 'clip_abc')
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(2, pieces[1].instance, 'clip_def')
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(3, pieces[2].instance, 'clip_ghi')
 	})
 
 	test('Multiple pieces same id', () => {

--- a/packages/job-worker/src/playout/abPlayback/__tests__/abPlayback.spec.ts
+++ b/packages/job-worker/src/playout/abPlayback/__tests__/abPlayback.spec.ts
@@ -72,7 +72,7 @@ function resolveAbSessions(
 	timelineObjs: OnGenerateTimelineObjExt[],
 	previousAssignmentMap: ABSessionAssignments,
 	sessionPool: string,
-	playerIds: number[],
+	playerIds: Array<number | string>,
 	now: number
 ): AssignmentResult {
 	const sessionRequests = calculateSessionTimeRanges(
@@ -146,6 +146,78 @@ describe('resolveMediaPlayers', () => {
 		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(1, pieces[0].instance, 'clip_abc')
 		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(2, pieces[1].instance, 'clip_def')
 		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(3, pieces[2].instance, 'clip_ghi')
+	})
+
+	test('basic pieces - players with string Ids', () => {
+		const previousAssignments = {}
+		const pieces = [
+			createBasicResolvedPieceInstance('0', 400, 5000, 'abc'),
+			createBasicResolvedPieceInstance('1', 400, 5000, 'def'),
+			createBasicResolvedPieceInstance('2', 800, 4000, 'ghi'),
+		]
+
+		mockGetPieceSessionId.mockImplementation((piece, name) => `${piece._id}_${name}`)
+
+		const assignments = resolveAbSessions(
+			abSessionHelper,
+			resolverOptions,
+			pieces,
+			[],
+			previousAssignments,
+			POOL_NAME,
+			['player1', 'player2'],
+			4500
+		)
+		expect(assignments.failedRequired).toEqual(['inst_2_clip_ghi'])
+		expect(assignments.failedOptional).toHaveLength(0)
+		expect(assignments.requests).toHaveLength(3)
+		expect(assignments.requests).toEqual([
+			{ end: 5400, id: 'inst_0_clip_abc', playerId: 'player1', start: 400, optional: false },
+			{ end: 5400, id: 'inst_1_clip_def', playerId: 'player2', start: 400, optional: false },
+			{ end: 4800, id: 'inst_2_clip_ghi', playerId: undefined, start: 800, optional: false }, // Massive overlap
+		])
+
+		expect(mockGetPieceSessionId).toHaveBeenCalledTimes(3)
+		expect(mockGetObjectSessionId).toHaveBeenCalledTimes(0)
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(1, pieces[0], 'clip_abc')
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(2, pieces[1], 'clip_def')
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(3, pieces[2], 'clip_ghi')
+	})
+
+	test('basic pieces - players with number and string Ids', () => {
+		const previousAssignments = {}
+		const pieces = [
+			createBasicResolvedPieceInstance('0', 400, 5000, 'abc'),
+			createBasicResolvedPieceInstance('1', 400, 5000, 'def'),
+			createBasicResolvedPieceInstance('2', 800, 4000, 'ghi'),
+		]
+
+		mockGetPieceSessionId.mockImplementation((piece, name) => `${piece._id}_${name}`)
+
+		const assignments = resolveAbSessions(
+			abSessionHelper,
+			resolverOptions,
+			pieces,
+			[],
+			previousAssignments,
+			POOL_NAME,
+			[1, 'player2'],
+			4500
+		)
+		expect(assignments.failedRequired).toEqual(['inst_2_clip_ghi'])
+		expect(assignments.failedOptional).toHaveLength(0)
+		expect(assignments.requests).toHaveLength(3)
+		expect(assignments.requests).toEqual([
+			{ end: 5400, id: 'inst_0_clip_abc', playerId: 1, start: 400, optional: false },
+			{ end: 5400, id: 'inst_1_clip_def', playerId: 'player2', start: 400, optional: false },
+			{ end: 4800, id: 'inst_2_clip_ghi', playerId: undefined, start: 800, optional: false }, // Massive overlap
+		])
+
+		expect(mockGetPieceSessionId).toHaveBeenCalledTimes(3)
+		expect(mockGetObjectSessionId).toHaveBeenCalledTimes(0)
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(1, pieces[0], 'clip_abc')
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(2, pieces[1], 'clip_def')
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(3, pieces[2], 'clip_ghi')
 	})
 
 	test('Multiple pieces same id', () => {

--- a/packages/job-worker/src/playout/abPlayback/applyAssignments.ts
+++ b/packages/job-worker/src/playout/abPlayback/applyAssignments.ts
@@ -33,7 +33,7 @@ export function applyAbPlayerObjectAssignments(
 	poolName: string
 ): ABSessionAssignments {
 	const newAssignments: ABSessionAssignments = {}
-	const persistAssignment = (sessionId: string, playerId: number, lookahead: boolean): void => {
+	const persistAssignment = (sessionId: string, playerId: number | string, lookahead: boolean): void => {
 		// Track the assignment, so that the next onTimelineGenerate can try to reuse the same session
 		if (newAssignments[sessionId]) {
 			// TODO - warn?
@@ -117,24 +117,18 @@ function updateObjectsToAbPlayer(
 	context: ICommonContext,
 	abConfiguration: Pick<ABResolverConfiguration, 'timelineObjectLayerChangeRules' | 'customApplyToObject'>,
 	poolName: string,
-	poolIndex: number,
+	poolId: number | string,
 	objs: OnGenerateTimelineObj<TSR.TSRTimelineContent>[]
 ): OnGenerateTimelineObj<TSR.TSRTimelineContent>[] {
 	const failedObjects: OnGenerateTimelineObj<TSR.TSRTimelineContent>[] = []
 
 	for (const obj of objs) {
-		const updatedKeyframes = applyUpdateToKeyframes(poolName, poolIndex, obj)
+		const updatedKeyframes = applyUpdateToKeyframes(poolName, poolId, obj)
 
-		const updatedLayer = applylayerMoveRule(
-			abConfiguration.timelineObjectLayerChangeRules,
-			poolName,
-			poolIndex,
-			obj
-		)
+		const updatedLayer = applylayerMoveRule(abConfiguration.timelineObjectLayerChangeRules, poolName, poolId, obj)
 
 		const updatedCustom =
-			abConfiguration.customApplyToObject &&
-			abConfiguration.customApplyToObject(context, poolName, poolIndex, obj)
+			abConfiguration.customApplyToObject && abConfiguration.customApplyToObject(context, poolName, poolId, obj)
 
 		if (!updatedKeyframes && !updatedLayer && !updatedCustom) {
 			failedObjects.push(obj)
@@ -146,7 +140,7 @@ function updateObjectsToAbPlayer(
 
 function applyUpdateToKeyframes(
 	poolName: string,
-	poolIndex: number,
+	poolId: number | string,
 	obj: OnGenerateTimelineObj<TSR.TSRTimelineContent>
 ): boolean {
 	if (!obj.keyframes) return false
@@ -160,7 +154,7 @@ function applyUpdateToKeyframes(
 			// Preserve from other ab pools
 			if (kf.abSession.poolName !== poolName) return kf
 
-			if (kf.abSession.playerIndex === poolIndex) {
+			if (kf.abSession.playerId === poolId) {
 				// Make sure any ab keyframe is active
 				kf.disabled = false
 				updated = true
@@ -178,7 +172,7 @@ function applyUpdateToKeyframes(
 function applylayerMoveRule(
 	timelineObjectLayerChangeRules: ABTimelineLayerChangeRules | undefined,
 	poolName: string,
-	poolIndex: number,
+	poolId: number | string,
 	obj: OnGenerateTimelineObj<TSR.TSRTimelineContent>
 ): boolean {
 	const ruleId = obj.isLookahead ? obj.lookaheadForLayer || obj.layer : obj.layer
@@ -190,13 +184,13 @@ function applylayerMoveRule(
 	if (obj.isLookahead && moveRule.allowsLookahead && obj.lookaheadForLayer) {
 		// This works on the assumption that layer will contain lookaheadForLayer, but not the exact syntax.
 		// Hopefully this will be durable to any potential future core changes
-		const newLayer = moveRule.newLayerName(poolIndex)
+		const newLayer = moveRule.newLayerName(poolId)
 		obj.layer = (obj.layer + '').replace(obj.lookaheadForLayer + '', newLayer)
 		obj.lookaheadForLayer = newLayer
 
 		return true
 	} else if (!obj.isLookahead || (obj.isLookahead && !obj.lookaheadForLayer)) {
-		obj.layer = moveRule.newLayerName(poolIndex)
+		obj.layer = moveRule.newLayerName(poolId)
 		return true
 	}
 

--- a/packages/shared-lib/src/core/model/Timeline.ts
+++ b/packages/shared-lib/src/core/model/Timeline.ts
@@ -58,7 +58,7 @@ export interface TimelineKeyframeCoreExt<TContent extends { deviceType: TSR.Devi
 
 	abSession?: {
 		poolName: string
-		playerIndex: number
+		playerId: number | string
 	}
 }
 


### PR DESCRIPTION
This PR has been opened by SuperFly.tv on behalf of EVS Broadcast Equipment (henceforth EVS).

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature change.

**What is the current behavior?** (You can also link to an open issue here)

A/B players must be referred to by numeric index.

**What is the new behavior (if this is a feature change)?**

Player Ids can be provided as strings.

**Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] Automated tests to cover the new functionality and/or guard against regressions have been added
- [ ] The functionality has been tested by NRK
