### PR TITLE
fix(openapi): change setNextSegment method to POST instead of PUT

### DIFF
--- a/packages/openapi/api/definitions/playlists.yaml
+++ b/packages/openapi/api/definitions/playlists.yaml
@@ -350,7 +350,7 @@ resources:
         500:
           $ref: '#/components/responses/internalServerError'
   setNextSegment:
-    put:
+    post:
       operationId: setNextSegment
       tags:
         - playlists


### PR DESCRIPTION
This PR is being opened on behalf of TV 2 Norge.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
An OpenAPI definition update, which can be considered a fix for those who use the OpenAPI definitions to generate client code


* **What is the current behavior?** (You can also link to an open issue here)
`/playlists/{playlistId}/set-next-segment` is defined to use the PUT method, but it has been agreed [and implemented](https://github.com/nrkno/sofie-core/blob/7fbcbaf362833eb98a0c0a4d2d4430e3c352c50a/meteor/server/api/rest/v1/index.ts#L1455-L1457) to use POST


* **What is the new behavior (if this is a feature change)?**
The OpenAPI definition for `/playlists/{playlistId}/set-next-segment` defines a POST method


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] Automated tests to cover the new functionality and/or guard against regressions have been added
- [ ] The functionality has been tested by NRK
