### PR TITLE
feat: typed publications in gateways/peripheraldevices SOFIE-1183

### DIFF
--- a/meteor/client/lib/ConnectionStatusNotification.tsx
+++ b/meteor/client/lib/ConnectionStatusNotification.tsx
@@ -16,7 +16,7 @@ import {
 import { WithManagedTracker } from './reactiveData/reactiveDataHelper'
 import { withTranslation } from 'react-i18next'
 import { NotificationCenterPopUps } from './notifications/NotificationCenterPanel'
-import { PubSub } from '../../lib/api/pubsub'
+import { MeteorPubSub } from '../../lib/api/pubsub'
 import { ICoreSystem, ServiceMessage, Criticality } from '../../lib/collections/CoreSystem'
 import { TFunction } from 'react-i18next'
 import { getRandomId } from '@sofie-automation/corelib/dist/lib'
@@ -31,7 +31,7 @@ export class ConnectionStatusNotifier extends WithManagedTracker {
 	constructor(t: TFunction) {
 		super()
 
-		this.subscribe(PubSub.coreSystem)
+		this.subscribe(MeteorPubSub.coreSystem)
 
 		this._translator = t
 

--- a/meteor/client/lib/MeteorReactComponent.ts
+++ b/meteor/client/lib/MeteorReactComponent.ts
@@ -2,7 +2,7 @@ import { Tracker } from 'meteor/tracker'
 import * as React from 'react'
 import { stringifyObjects } from '../../lib/lib'
 import { Meteor } from 'meteor/meteor'
-import { PubSubTypes } from '../../lib/api/pubsub'
+import { AllPubSubTypes } from '../../lib/api/pubsub'
 import { catchError } from './lib'
 export class MeteorReactComponent<IProps, IState = {}> extends React.Component<IProps, IState> {
 	private _subscriptions: { [id: string]: Meteor.SubscriptionHandle } = {}
@@ -14,7 +14,10 @@ export class MeteorReactComponent<IProps, IState = {}> extends React.Component<I
 	componentWillUnmount(): void {
 		this._cleanUp()
 	}
-	subscribe<K extends keyof PubSubTypes>(name: K, ...args: Parameters<PubSubTypes[K]>): Meteor.SubscriptionHandle {
+	subscribe<K extends keyof AllPubSubTypes>(
+		name: K,
+		...args: Parameters<AllPubSubTypes[K]>
+	): Meteor.SubscriptionHandle {
 		return Tracker.nonreactive(() => {
 			// let id = name + '_' + JSON.stringify(args.join())
 			const id = name + '_' + stringifyObjects(args)

--- a/meteor/client/lib/ReactMeteorData/ReactMeteorData.tsx
+++ b/meteor/client/lib/ReactMeteorData/ReactMeteorData.tsx
@@ -6,7 +6,7 @@ import { Mongo } from 'meteor/mongo'
 import { Tracker } from 'meteor/tracker'
 import { withTranslation, WithTranslation } from 'react-i18next'
 import { MeteorReactComponent } from '../MeteorReactComponent'
-import { meteorSubscribe, PubSubTypes } from '../../../lib/api/pubsub'
+import { meteorSubscribe, AllPubSubTypes } from '../../../lib/api/pubsub'
 import { stringifyObjects } from '../../../lib/lib'
 
 const globalTrackerQueue: Array<Function> = []
@@ -340,7 +340,10 @@ export function useTracker<T, K extends undefined | T = undefined>(
  * @param {...any[]} args A list of arugments for the subscription. This is used for optimizing the subscription across
  * 		renders so that it isn't torn down and created for every render.
  */
-export function useSubscription<K extends keyof PubSubTypes>(sub: K, ...args: Parameters<PubSubTypes[K]>): boolean {
+export function useSubscription<K extends keyof AllPubSubTypes>(
+	sub: K,
+	...args: Parameters<AllPubSubTypes[K]>
+): boolean {
 	const [ready, setReady] = useState<boolean>(false)
 
 	useEffect(() => {
@@ -359,9 +362,9 @@ export function useSubscription<K extends keyof PubSubTypes>(sub: K, ...args: Pa
 /**
  * Sets up multiple subscriptions of the same type, but with different arguments
  */
-export function useSubscriptions<K extends keyof PubSubTypes>(
+export function useSubscriptions<K extends keyof AllPubSubTypes>(
 	sub: K,
-	argsArray: Parameters<PubSubTypes[K]>[]
+	argsArray: Parameters<AllPubSubTypes[K]>[]
 ): boolean {
 	const [ready, setReady] = useState<boolean>(false)
 

--- a/meteor/client/lib/reactiveData/reactiveDataHelper.ts
+++ b/meteor/client/lib/reactiveData/reactiveDataHelper.ts
@@ -1,5 +1,5 @@
 import { Tracker } from 'meteor/tracker'
-import { meteorSubscribe, PubSubTypes } from '../../../lib/api/pubsub'
+import { meteorSubscribe, AllPubSubTypes } from '../../../lib/api/pubsub'
 import { Meteor } from 'meteor/meteor'
 
 /**
@@ -70,7 +70,7 @@ export abstract class WithManagedTracker {
 		return this._subs.every((e) => e.ready())
 	}
 
-	protected subscribe<K extends keyof PubSubTypes>(sub: K, ...args: Parameters<PubSubTypes[K]>): void {
+	protected subscribe<K extends keyof AllPubSubTypes>(sub: K, ...args: Parameters<AllPubSubTypes[K]>): void {
 		this._subs.push(meteorSubscribe(sub, ...args))
 	}
 

--- a/meteor/client/lib/triggers/TriggersHandler.tsx
+++ b/meteor/client/lib/triggers/TriggersHandler.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react'
 import { TFunction } from 'i18next'
 import { useTranslation } from 'react-i18next'
 import Sorensen from '@sofie-automation/sorensen'
-import { PubSub } from '../../../lib/api/pubsub'
+import { MeteorPubSub } from '../../../lib/api/pubsub'
 import { useSubscription, useTracker } from '../ReactMeteorData/ReactMeteorData'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { PlayoutActions, SomeAction, SomeBlueprintTrigger, TriggerType } from '@sofie-automation/blueprints-integration'
@@ -43,6 +43,7 @@ import { isHotkeyTrigger } from '../../../lib/api/triggers/triggerTypeSelectors'
 import { RundownPlaylistCollectionUtil } from '../../../lib/collections/rundownPlaylistUtil'
 import { catchError } from '../lib'
 import { logger } from '../../../lib/logging'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 type HotkeyTriggerListener = (e: KeyboardEvent) => void
 
@@ -72,32 +73,32 @@ function useSubscriptions(
 	showStyleBaseId: ShowStyleBaseId
 ) {
 	const allReady = [
-		useSubscription(PubSub.rundownPlaylists, {
+		useSubscription(CorelibPubSub.rundownPlaylists, {
 			_id: rundownPlaylistId,
 		}),
-		useSubscription(PubSub.rundowns, [rundownPlaylistId], null),
+		useSubscription(CorelibPubSub.rundowns, [rundownPlaylistId], null),
 
-		useSubscription(PubSub.adLibActions, {
+		useSubscription(CorelibPubSub.adLibActions, {
 			rundownId: {
 				$in: rundownIds,
 			},
 		}),
-		useSubscription(PubSub.adLibPieces, {
+		useSubscription(CorelibPubSub.adLibPieces, {
 			rundownId: {
 				$in: rundownIds,
 			},
 		}),
-		useSubscription(PubSub.rundownBaselineAdLibActions, {
+		useSubscription(CorelibPubSub.rundownBaselineAdLibActions, {
 			rundownId: {
 				$in: rundownIds,
 			},
 		}),
-		useSubscription(PubSub.rundownBaselineAdLibPieces, {
+		useSubscription(CorelibPubSub.rundownBaselineAdLibPieces, {
 			rundownId: {
 				$in: rundownIds,
 			},
 		}),
-		useSubscription(PubSub.uiShowStyleBase, showStyleBaseId),
+		useSubscription(MeteorPubSub.uiShowStyleBase, showStyleBaseId),
 	]
 
 	return !allReady.some((state) => state === false)
@@ -371,7 +372,7 @@ export const TriggersHandler: React.FC<IProps> = function TriggersHandler(
 		JSON.stringify(props.nextSegmentPartIds),
 	])
 
-	const triggerSubReady = useSubscription(PubSub.uiTriggeredActions, props.showStyleBaseId)
+	const triggerSubReady = useSubscription(MeteorPubSub.uiTriggeredActions, props.showStyleBaseId)
 
 	const rundownIds =
 		useTracker(() => {

--- a/meteor/client/ui/Account/OrganizationPage.tsx
+++ b/meteor/client/ui/Account/OrganizationPage.tsx
@@ -3,7 +3,7 @@ import { Translated, translateWithTracker } from '../../lib/ReactMeteorData/reac
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { getUser, User, getUserRoles, DBUser } from '../../../lib/collections/Users'
 import { Spinner } from '../../lib/Spinner'
-import { PubSub } from '../../../lib/api/pubsub'
+import { MeteorPubSub } from '../../../lib/api/pubsub'
 import { DBOrganization, UserRoles } from '../../../lib/collections/Organization'
 import { unprotectString } from '../../../lib/lib'
 import { MeteorCall } from '../../../lib/api/methods'
@@ -53,7 +53,7 @@ export const OrganizationPage = translateWithTracker(() => {
 		componentDidMount(): void {
 			this.autorun(() => {
 				if (this.props.organization) {
-					this.subscribe(PubSub.usersInOrganization, { organizationId: this.props.organization._id })
+					this.subscribe(MeteorPubSub.usersInOrganization, { organizationId: this.props.organization._id })
 				}
 			})
 		}

--- a/meteor/client/ui/ActiveRundownView.tsx
+++ b/meteor/client/ui/ActiveRundownView.tsx
@@ -4,19 +4,20 @@ import { useSubscription, useTracker } from '../lib/ReactMeteorData/ReactMeteorD
 
 import { Spinner } from '../lib/Spinner'
 import { RundownView } from './RundownView'
-import { PubSub } from '../../lib/api/pubsub'
+import { MeteorPubSub } from '../../lib/api/pubsub'
 import { UIStudios } from './Collections'
 import { StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { RundownPlaylists } from '../collections'
 import { useTranslation } from 'react-i18next'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 export function ActiveRundownView({ studioId }: { studioId: StudioId }): JSX.Element | null {
 	const { t } = useTranslation()
 
 	const { path } = useRouteMatch()
 
-	const studioReady = useSubscription(PubSub.uiStudio, studioId)
-	const playlistReady = useSubscription(PubSub.rundownPlaylists, {
+	const studioReady = useSubscription(MeteorPubSub.uiStudio, studioId)
+	const playlistReady = useSubscription(CorelibPubSub.rundownPlaylists, {
 		activationId: { $exists: true },
 		studioId,
 	})

--- a/meteor/client/ui/App.tsx
+++ b/meteor/client/ui/App.tsx
@@ -52,7 +52,7 @@ import { ResetPasswordPage } from './Account/NotLoggedIn/ResetPasswordPage'
 import { AccountPage } from './Account/AccountPage'
 import { OrganizationPage } from './Account/OrganizationPage'
 import { getUser, User } from '../../lib/collections/Users'
-import { PubSub } from '../../lib/api/pubsub'
+import { MeteorPubSub } from '../../lib/api/pubsub'
 import { useTracker, useSubscription } from '../lib/ReactMeteorData/ReactMeteorData'
 import { DocumentTitleProvider } from '../lib/DocumentTitleProvider'
 import { Spinner } from '../lib/Spinner'
@@ -82,8 +82,8 @@ export const App: React.FC = function App() {
 	const [lastStart] = useState(Date.now())
 	const [requestedRoute, setRequestedRoute] = useState<undefined | string>()
 
-	const userReady = useSubscription(PubSub.loggedInUser)
-	const orgReady = useSubscription(PubSub.organization, user?.organizationId ?? null)
+	const userReady = useSubscription(MeteorPubSub.loggedInUser)
+	const orgReady = useSubscription(MeteorPubSub.organization, user?.organizationId ?? null)
 
 	const subsReady = userReady && orgReady
 

--- a/meteor/client/ui/ClipTrimPanel/ClipTrimPanel.tsx
+++ b/meteor/client/ui/ClipTrimPanel/ClipTrimPanel.tsx
@@ -9,9 +9,9 @@ import { UIStudio } from '../../../lib/api/studios'
 import { useTranslation } from 'react-i18next'
 import { useContentStatusForPiece } from '../SegmentTimeline/withMediaObjectStatus'
 import { useSubscription, useTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
-import { PubSub } from '../../../lib/api/pubsub'
 import { PieceId, RundownId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { Pieces } from '../../collections'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 export interface IProps {
 	studio: UIStudio
@@ -86,7 +86,7 @@ export function ClipTrimPanel({
 }: IProps): JSX.Element {
 	const { t } = useTranslation()
 
-	useSubscription(PubSub.pieces, { _id: pieceId, startRundownId: rundownId })
+	useSubscription(CorelibPubSub.pieces, { _id: pieceId, startRundownId: rundownId })
 
 	const piece = useTracker(() => Pieces.findOne(pieceId), [pieceId])
 

--- a/meteor/client/ui/ClockView/CameraScreen/Rundown.tsx
+++ b/meteor/client/ui/ClockView/CameraScreen/Rundown.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react'
 import { useSubscription, useTracker } from '../../../lib/ReactMeteorData/ReactMeteorData'
 import { Rundown as RundownObj } from '@sofie-automation/corelib/dist/dataModel/Rundown'
-import { PubSub } from '../../../../lib/api/pubsub'
+import { MeteorPubSub } from '../../../../lib/api/pubsub'
 import { Segments } from '../../../collections'
 import { DBSegment } from '@sofie-automation/corelib/dist/dataModel/Segment'
 import { Segment as SegmentComponent } from './Segment'
@@ -20,7 +20,7 @@ interface IProps {
 export function Rundown({ playlist, rundown, rundownIdsBefore }: IProps): JSX.Element | null {
 	const rundownId = rundown._id
 
-	useSubscription(PubSub.uiShowStyleBase, rundown.showStyleBaseId)
+	useSubscription(MeteorPubSub.uiShowStyleBase, rundown.showStyleBaseId)
 
 	const segments = useTracker(() => Segments.find({ rundownId }).fetch(), [rundownId], [] as DBSegment[])
 

--- a/meteor/client/ui/ClockView/CameraScreen/index.tsx
+++ b/meteor/client/ui/ClockView/CameraScreen/index.tsx
@@ -3,7 +3,7 @@ import { CameraContent, RemoteContent, SourceLayerType, SplitsContent } from '@s
 import { RundownId, ShowStyleBaseId, StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { Rundown } from '@sofie-automation/corelib/dist/dataModel/Rundown'
 import { unprotectString } from '@sofie-automation/corelib/dist/protectedString'
-import { PubSub } from '../../../../lib/api/pubsub'
+import { MeteorPubSub } from '../../../../lib/api/pubsub'
 import { UIStudio } from '../../../../lib/api/studios'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { PieceExtended } from '../../../../lib/Rundown'
@@ -21,6 +21,7 @@ import { Spinner } from '../../../lib/Spinner'
 import { useBlackBrowserTheme } from '../../../lib/useBlackBrowserTheme'
 import { useWakeLock } from './useWakeLock'
 import { catchError, useDebounce } from '../../../lib/lib'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 interface IProps {
 	playlist: DBRundownPlaylist | undefined
@@ -94,25 +95,25 @@ export function CameraScreen({ playlist, studioId }: IProps): JSX.Element | null
 	const rundownIds = useMemo(() => rundowns.map((rundown) => rundown._id), [rundowns])
 	const showStyleBaseIds = useMemo(() => rundowns.map((rundown) => rundown.showStyleBaseId), [rundowns])
 
-	const rundownsReady = useSubscription(PubSub.rundowns, playlistIds, null)
-	useSubscription(PubSub.segments, {
+	const rundownsReady = useSubscription(CorelibPubSub.rundowns, playlistIds, null)
+	useSubscription(CorelibPubSub.segments, {
 		rundownId: {
 			$in: rundownIds,
 		},
 	})
 
-	const studioReady = useSubscription(PubSub.uiStudio, studioId)
-	useSubscription(PubSub.partInstances, rundownIds, playlist?.activationId)
+	const studioReady = useSubscription(MeteorPubSub.uiStudio, studioId)
+	useSubscription(CorelibPubSub.partInstances, rundownIds, playlist?.activationId)
 
-	useSubscription(PubSub.parts, rundownIds)
+	useSubscription(CorelibPubSub.parts, rundownIds)
 
-	useSubscription(PubSub.pieceInstancesSimple, {
+	useSubscription(CorelibPubSub.pieceInstancesSimple, {
 		rundownId: {
 			$in: rundownIds,
 		},
 	})
 
-	const piecesReady = useSubscription(PubSub.pieces, {
+	const piecesReady = useSubscription(CorelibPubSub.pieces, {
 		startRundownId: {
 			$in: rundownIds,
 		},

--- a/meteor/client/ui/ClockView/ClockView.tsx
+++ b/meteor/client/ui/ClockView/ClockView.tsx
@@ -4,7 +4,6 @@ import { useSubscription, useTracker } from '../../lib/ReactMeteorData/react-met
 
 import { RundownTimingProvider } from '../RundownView/RundownTiming/RundownTimingProvider'
 
-import { PubSub } from '../../../lib/api/pubsub'
 import { StudioScreenSaver } from '../StudioScreenSaver/StudioScreenSaver'
 import { PresenterScreen } from './PresenterScreen'
 import { OverlayScreen } from './OverlayScreen'
@@ -12,9 +11,10 @@ import { OverlayScreenSaver } from './OverlayScreenSaver'
 import { RundownPlaylists } from '../../collections'
 import { StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { CameraScreen } from './CameraScreen'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 export function ClockView({ studioId }: { studioId: StudioId }): JSX.Element {
-	useSubscription(PubSub.rundownPlaylists, {
+	useSubscription(CorelibPubSub.rundownPlaylists, {
 		activationId: { $exists: true },
 		studioId,
 	})

--- a/meteor/client/ui/ClockView/OverlayScreenSaver.tsx
+++ b/meteor/client/ui/ClockView/OverlayScreenSaver.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useRef } from 'react'
 import { Clock } from '../StudioScreenSaver/Clock'
 import { useTracker, useSubscription } from '../../lib/ReactMeteorData/ReactMeteorData'
-import { PubSub } from '../../../lib/api/pubsub'
+import { MeteorPubSub } from '../../../lib/api/pubsub'
 import { findNextPlaylist } from '../StudioScreenSaver/StudioScreenSaver'
 // @ts-expect-error No types available
 import Velocity from 'velocity-animate'
 import { StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 export function OverlayScreenSaver({ studioId }: { studioId: StudioId }): JSX.Element {
 	const studioNameRef = useRef<HTMLDivElement>(null)
@@ -17,8 +18,8 @@ export function OverlayScreenSaver({ studioId }: { studioId: StudioId }): JSX.El
 		}
 	})
 
-	useSubscription(PubSub.uiStudio, studioId)
-	useSubscription(PubSub.rundownPlaylists, { studioId: studioId, activationId: { $exists: false } })
+	useSubscription(MeteorPubSub.uiStudio, studioId)
+	useSubscription(CorelibPubSub.rundownPlaylists, { studioId: studioId, activationId: { $exists: false } })
 
 	const data = useTracker(() => findNextPlaylist({ studioId }), [studioId])
 

--- a/meteor/client/ui/ClockView/PresenterScreen.tsx
+++ b/meteor/client/ui/ClockView/PresenterScreen.tsx
@@ -10,7 +10,7 @@ import { Translated, withTracker } from '../../lib/ReactMeteorData/ReactMeteorDa
 import { extendMandadory, getCurrentTime, protectString, unprotectString } from '../../../lib/lib'
 import { PartInstance } from '../../../lib/collections/PartInstances'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
-import { PubSub } from '../../../lib/api/pubsub'
+import { MeteorPubSub } from '../../../lib/api/pubsub'
 import { PieceIconContainer } from '../PieceIcons/PieceIcon'
 import { PieceNameContainer } from '../PieceIcons/PieceName'
 import { Timediff } from './Timediff'
@@ -41,6 +41,7 @@ import { UIStudio } from '../../../lib/api/studios'
 import { PieceInstances, RundownLayouts, RundownPlaylists, Rundowns, ShowStyleVariants } from '../../collections'
 import { RundownPlaylistCollectionUtil } from '../../../lib/collections/rundownPlaylistUtil'
 import { Piece } from '@sofie-automation/corelib/dist/dataModel/Piece'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 interface SegmentUi extends DBSegment {
 	items: Array<PartUi>
@@ -305,7 +306,7 @@ export class PresenterScreenBase extends MeteorReactComponent<
 
 	protected subscribeToData(): void {
 		this.autorun(() => {
-			this.subscribe(PubSub.uiStudio, this.props.studioId)
+			this.subscribe(MeteorPubSub.uiStudio, this.props.studioId)
 
 			const playlist = RundownPlaylists.findOne(this.props.playlistId, {
 				fields: {
@@ -314,7 +315,7 @@ export class PresenterScreenBase extends MeteorReactComponent<
 				},
 			}) as Pick<DBRundownPlaylist, '_id' | 'activationId'> | undefined
 			if (playlist) {
-				this.subscribe(PubSub.rundowns, [playlist._id], null)
+				this.subscribe(CorelibPubSub.rundowns, [playlist._id], null)
 
 				this.autorun(() => {
 					const rundowns = RundownPlaylistCollectionUtil.getRundownsUnordered(playlist, undefined, {
@@ -328,22 +329,22 @@ export class PresenterScreenBase extends MeteorReactComponent<
 					const showStyleBaseIds = rundowns.map((r) => r.showStyleBaseId)
 					const showStyleVariantIds = rundowns.map((r) => r.showStyleVariantId)
 
-					this.subscribe(PubSub.segments, {
+					this.subscribe(CorelibPubSub.segments, {
 						rundownId: { $in: rundownIds },
 					})
-					this.subscribe(PubSub.parts, rundownIds)
-					this.subscribe(PubSub.partInstances, rundownIds, playlist.activationId)
+					this.subscribe(CorelibPubSub.parts, rundownIds)
+					this.subscribe(CorelibPubSub.partInstances, rundownIds, playlist.activationId)
 
 					for (const rundown of rundowns) {
-						this.subscribe(PubSub.uiShowStyleBase, rundown.showStyleBaseId)
+						this.subscribe(MeteorPubSub.uiShowStyleBase, rundown.showStyleBaseId)
 					}
 
-					this.subscribe(PubSub.showStyleVariants, {
+					this.subscribe(CorelibPubSub.showStyleVariants, {
 						_id: {
 							$in: showStyleVariantIds,
 						},
 					})
-					this.subscribe(PubSub.rundownLayouts, {
+					this.subscribe(MeteorPubSub.rundownLayouts, {
 						showStyleBaseId: {
 							$in: showStyleBaseIds,
 						},
@@ -362,13 +363,13 @@ export class PresenterScreenBase extends MeteorReactComponent<
 							const { nextPartInstance, currentPartInstance } =
 								RundownPlaylistCollectionUtil.getSelectedPartInstances(playlistR)
 							if (currentPartInstance) {
-								this.subscribe(PubSub.pieceInstances, {
+								this.subscribe(CorelibPubSub.pieceInstances, {
 									rundownId: currentPartInstance.rundownId,
 									partInstanceId: currentPartInstance._id,
 								})
 							}
 							if (nextPartInstance) {
-								this.subscribe(PubSub.pieceInstances, {
+								this.subscribe(CorelibPubSub.pieceInstances, {
 									rundownId: nextPartInstance.rundownId,
 									partInstanceId: nextPartInstance._id,
 								})

--- a/meteor/client/ui/MediaStatus/MediaStatus.tsx
+++ b/meteor/client/ui/MediaStatus/MediaStatus.tsx
@@ -1,6 +1,6 @@
 import { useMemo, JSX } from 'react'
 import { useSubscription, useSubscriptions, useTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
-import { PubSub } from '../../../lib/api/pubsub'
+import { MeteorPubSub } from '../../../lib/api/pubsub'
 import { getSegmentsWithPartInstances } from '../../../lib/Rundown'
 import {
 	AdLibActionId,
@@ -35,6 +35,7 @@ import { assertNever, literal } from '@sofie-automation/corelib/dist/lib'
 import { UIPieceContentStatuses, UIShowStyleBases } from '../Collections'
 import { isTranslatableMessage, translateMessage } from '@sofie-automation/corelib/dist/TranslatableMessage'
 import { i18nTranslator } from '../i18n'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 export function MediaStatus({
 	playlistIds,
@@ -256,24 +257,24 @@ function useMediaStatusSubscriptions(
 ): boolean {
 	const readyStatus: boolean[] = []
 	let counter = 0
-	readyStatus[counter++] = useSubscription(PubSub.rundownPlaylists, {
+	readyStatus[counter++] = useSubscription(CorelibPubSub.rundownPlaylists, {
 		_id: {
 			$in: playlistIds,
 		},
 	})
-	readyStatus[counter++] = useSubscription(PubSub.rundowns, playlistIds, null)
+	readyStatus[counter++] = useSubscription(CorelibPubSub.rundowns, playlistIds, null)
 	const uiShowStyleBaseSubArguments = useMemo(
 		() => showStyleBaseIds.map((showStyleBaseId) => [showStyleBaseId] as [ShowStyleBaseId]),
 		[showStyleBaseIds]
 	)
-	readyStatus[counter++] = useSubscriptions(PubSub.uiShowStyleBase, uiShowStyleBaseSubArguments)
-	readyStatus[counter++] = useSubscription(PubSub.segments, {
+	readyStatus[counter++] = useSubscriptions(MeteorPubSub.uiShowStyleBase, uiShowStyleBaseSubArguments)
+	readyStatus[counter++] = useSubscription(CorelibPubSub.segments, {
 		rundownId: {
 			$in: rundownIds,
 		},
 	})
-	readyStatus[counter++] = useSubscription(PubSub.parts, rundownIds)
-	readyStatus[counter++] = useSubscription(PubSub.partInstancesSimple, {
+	readyStatus[counter++] = useSubscription(CorelibPubSub.parts, rundownIds)
+	readyStatus[counter++] = useSubscription(CorelibPubSub.partInstancesSimple, {
 		rundownId: {
 			$in: rundownIds,
 		},
@@ -281,32 +282,32 @@ function useMediaStatusSubscriptions(
 			$ne: true,
 		},
 	})
-	readyStatus[counter++] = useSubscription(PubSub.pieceInstancesSimple, {
+	readyStatus[counter++] = useSubscription(CorelibPubSub.pieceInstancesSimple, {
 		rundownId: {
 			$in: rundownIds,
 		},
 	})
-	readyStatus[counter++] = useSubscription(PubSub.pieces, {
+	readyStatus[counter++] = useSubscription(CorelibPubSub.pieces, {
 		startRundownId: {
 			$in: rundownIds,
 		},
 	})
-	readyStatus[counter++] = useSubscription(PubSub.adLibActions, {
+	readyStatus[counter++] = useSubscription(CorelibPubSub.adLibActions, {
 		rundownId: {
 			$in: rundownIds,
 		},
 	})
-	readyStatus[counter++] = useSubscription(PubSub.adLibPieces, {
+	readyStatus[counter++] = useSubscription(CorelibPubSub.adLibPieces, {
 		rundownId: {
 			$in: rundownIds,
 		},
 	})
-	readyStatus[counter++] = useSubscription(PubSub.rundownBaselineAdLibActions, {
+	readyStatus[counter++] = useSubscription(CorelibPubSub.rundownBaselineAdLibActions, {
 		rundownId: {
 			$in: rundownIds,
 		},
 	})
-	readyStatus[counter++] = useSubscription(PubSub.rundownBaselineAdLibPieces, {
+	readyStatus[counter++] = useSubscription(CorelibPubSub.rundownBaselineAdLibPieces, {
 		rundownId: {
 			$in: rundownIds,
 		},
@@ -315,7 +316,7 @@ function useMediaStatusSubscriptions(
 		() => playlistIds.map((playlistIds) => [playlistIds] as [RundownPlaylistId]),
 		[playlistIds]
 	)
-	readyStatus[counter++] = useSubscriptions(PubSub.uiPieceContentStatuses, uiPieceContentStatusesSubArguments)
+	readyStatus[counter++] = useSubscriptions(MeteorPubSub.uiPieceContentStatuses, uiPieceContentStatusesSubArguments)
 
 	return readyStatus.reduce((mem, current) => mem && current, true)
 }

--- a/meteor/client/ui/PieceIcons/PieceCountdown.tsx
+++ b/meteor/client/ui/PieceIcons/PieceCountdown.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useSubscription, useTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
 import { SourceLayerType, VTContent } from '@sofie-automation/blueprints-integration'
-import { PubSub } from '../../../lib/api/pubsub'
+import { MeteorPubSub } from '../../../lib/api/pubsub'
 import { findPieceInstanceToShow } from './utils'
 import { Timediff } from '../ClockView/Timediff'
 import { getCurrentTime } from '../../../lib/lib'
@@ -11,6 +11,7 @@ import {
 	RundownPlaylistActivationId,
 	ShowStyleBaseId,
 } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 export interface IPropsHeader {
 	partInstanceId: PartInstanceId
@@ -41,12 +42,12 @@ export function PieceCountdownContainer(props: IPropsHeader): JSX.Element | null
 		}
 	)
 
-	useSubscription(PubSub.pieceInstancesSimple, {
+	useSubscription(CorelibPubSub.pieceInstancesSimple, {
 		rundownId: { $in: props.rundownIds },
 		playlistActivationId: props.playlistActivationId,
 	})
 
-	useSubscription(PubSub.uiShowStyleBase, props.showStyleBaseId)
+	useSubscription(MeteorPubSub.uiShowStyleBase, props.showStyleBaseId)
 
 	const piece = pieceInstance ? pieceInstance.piece : undefined
 	const sourceDuration = (piece?.content as VTContent)?.sourceDuration

--- a/meteor/client/ui/PieceIcons/PieceIcon.tsx
+++ b/meteor/client/ui/PieceIcons/PieceIcon.tsx
@@ -14,7 +14,7 @@ import RemoteInputIcon from './Renderers/RemoteInputIcon'
 import LiveSpeakInputIcon from './Renderers/LiveSpeakInputIcon'
 import GraphicsInputIcon from './Renderers/GraphicsInputIcon'
 import UnknownInputIcon from './Renderers/UnknownInputIcon'
-import { PubSub } from '../../../lib/api/pubsub'
+import { MeteorPubSub } from '../../../lib/api/pubsub'
 import { PieceInstance } from '@sofie-automation/corelib/dist/dataModel/PieceInstance'
 import { findPieceInstanceToShow, findPieceInstanceToShowFromInstances } from './utils'
 import LocalInputIcon from './Renderers/LocalInputIcon'
@@ -25,6 +25,7 @@ import {
 	ShowStyleBaseId,
 } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { ReadonlyDeep } from 'type-fest'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 export interface IPropsHeader {
 	partInstanceId: PartInstanceId
@@ -129,12 +130,12 @@ export function PieceIconContainer(props: IPropsHeader): JSX.Element | null {
 		}
 	)
 
-	useSubscription(PubSub.pieceInstancesSimple, {
+	useSubscription(CorelibPubSub.pieceInstancesSimple, {
 		rundownId: { $in: props.rundownIds },
 		playlistActivationId: props.playlistActivationId,
 	})
 
-	useSubscription(PubSub.uiShowStyleBase, props.showStyleBaseId)
+	useSubscription(MeteorPubSub.uiShowStyleBase, props.showStyleBaseId)
 
 	return <PieceIcon pieceInstance={pieceInstance} sourceLayer={sourceLayer} />
 }

--- a/meteor/client/ui/PieceIcons/PieceName.tsx
+++ b/meteor/client/ui/PieceIcons/PieceName.tsx
@@ -2,12 +2,13 @@ import React from 'react'
 import { useSubscription, useTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
 import { EvsContent, SourceLayerType } from '@sofie-automation/blueprints-integration'
 
-import { PubSub } from '../../../lib/api/pubsub'
+import { MeteorPubSub } from '../../../lib/api/pubsub'
 import { IPropsHeader } from './PieceIcon'
 import { findPieceInstanceToShow } from './utils'
 import { PieceGeneric } from '@sofie-automation/corelib/dist/dataModel/Piece'
 import { RundownPlaylistActivationId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { ReadonlyDeep } from 'type-fest'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 interface INamePropsHeader extends IPropsHeader {
 	partName: string
@@ -54,12 +55,12 @@ export function PieceNameContainer(props: INamePropsHeader): JSX.Element | null 
 		}
 	)
 
-	useSubscription(PubSub.pieceInstancesSimple, {
+	useSubscription(CorelibPubSub.pieceInstancesSimple, {
 		rundownId: { $in: props.rundownIds },
 		playlistActivationId: props.playlistActivationId,
 	})
 
-	useSubscription(PubSub.uiShowStyleBase, props.showStyleBaseId)
+	useSubscription(MeteorPubSub.uiShowStyleBase, props.showStyleBaseId)
 
 	if (pieceInstance && sourceLayer && supportedLayers.has(sourceLayer.type)) {
 		return getPieceLabel(pieceInstance.piece, sourceLayer.type)

--- a/meteor/client/ui/Prompter/PrompterView.tsx
+++ b/meteor/client/ui/Prompter/PrompterView.tsx
@@ -14,7 +14,7 @@ import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { firstIfArray, literal, protectString } from '../../../lib/lib'
 import { PrompterData, PrompterAPI, PrompterDataPart } from './prompter'
 import { PrompterControlManager } from './controller/manager'
-import { PubSub } from '../../../lib/api/pubsub'
+import { MeteorPubSub } from '../../../lib/api/pubsub'
 import { documentTitle } from '../../lib/DocumentTitleProvider'
 import { StudioScreenSaver } from '../StudioScreenSaver/StudioScreenSaver'
 import { RundownTimingProvider } from '../RundownView/RundownTiming/RundownTimingProvider'
@@ -26,6 +26,7 @@ import { UIStudio } from '../../../lib/api/studios'
 import { RundownPlaylists, Rundowns } from '../../collections'
 import { RundownPlaylistCollectionUtil } from '../../../lib/collections/rundownPlaylistUtil'
 import { logger } from '../../../lib/logging'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 const DEFAULT_UPDATE_THROTTLE = 250 //ms
 const PIECE_MISSING_UPDATE_THROTTLE = 2000 //ms
@@ -203,9 +204,9 @@ export class PrompterViewInner extends MeteorReactComponent<Translated<IProps & 
 
 	componentDidMount(): void {
 		if (this.props.studioId) {
-			this.subscribe(PubSub.uiStudio, this.props.studioId)
+			this.subscribe(MeteorPubSub.uiStudio, this.props.studioId)
 
-			this.subscribe(PubSub.rundownPlaylists, {
+			this.subscribe(CorelibPubSub.rundownPlaylists, {
 				activationId: { $exists: true },
 				studioId: this.props.studioId,
 			})
@@ -224,7 +225,7 @@ export class PrompterViewInner extends MeteorReactComponent<Translated<IProps & 
 				}
 			) as Pick<DBRundownPlaylist, '_id'> | undefined
 			if (playlist?._id) {
-				this.subscribe(PubSub.rundowns, [playlist._id], null)
+				this.subscribe(CorelibPubSub.rundowns, [playlist._id], null)
 			}
 		})
 
@@ -598,7 +599,7 @@ export const Prompter = translateWithTracker<PropsWithChildren<IPrompterProps>, 
 		}
 
 		componentDidMount(): void {
-			this.subscribe(PubSub.rundowns, [this.props.rundownPlaylistId], null)
+			this.subscribe(CorelibPubSub.rundowns, [this.props.rundownPlaylistId], null)
 
 			this.autorun(() => {
 				const playlist = RundownPlaylists.findOne(this.props.rundownPlaylistId, {
@@ -609,15 +610,15 @@ export const Prompter = translateWithTracker<PropsWithChildren<IPrompterProps>, 
 				}) as Pick<DBRundownPlaylist, '_id' | 'activationId'> | undefined
 				if (playlist) {
 					const rundownIDs = RundownPlaylistCollectionUtil.getRundownUnorderedIDs(playlist)
-					this.subscribe(PubSub.segments, {
+					this.subscribe(CorelibPubSub.segments, {
 						rundownId: { $in: rundownIDs },
 					})
-					this.subscribe(PubSub.parts, rundownIDs)
-					this.subscribe(PubSub.partInstances, rundownIDs, playlist.activationId)
-					this.subscribe(PubSub.pieces, {
+					this.subscribe(CorelibPubSub.parts, rundownIDs)
+					this.subscribe(CorelibPubSub.partInstances, rundownIDs, playlist.activationId)
+					this.subscribe(CorelibPubSub.pieces, {
 						startRundownId: { $in: rundownIDs },
 					})
-					this.subscribe(PubSub.pieceInstancesSimple, {
+					this.subscribe(CorelibPubSub.pieceInstancesSimple, {
 						rundownId: { $in: rundownIDs },
 						reset: { $ne: true },
 					})
@@ -635,7 +636,7 @@ export const Prompter = translateWithTracker<PropsWithChildren<IPrompterProps>, 
 					}
 				).fetch() as Pick<Rundown, '_id' | 'showStyleBaseId'>[]
 				for (const rundown of rundowns) {
-					this.subscribe(PubSub.uiShowStyleBase, rundown.showStyleBaseId)
+					this.subscribe(MeteorPubSub.uiShowStyleBase, rundown.showStyleBaseId)
 				}
 			})
 		}

--- a/meteor/client/ui/RundownList.tsx
+++ b/meteor/client/ui/RundownList.tsx
@@ -1,6 +1,6 @@
 import Tooltip from 'rc-tooltip'
 import * as React from 'react'
-import { PubSub } from '../../lib/api/pubsub'
+import { MeteorPubSub } from '../../lib/api/pubsub'
 import { GENESIS_SYSTEM_VERSION } from '../../lib/collections/CoreSystem'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { getAllowConfigure, getHelpMode } from '../lib/localStorage'
@@ -19,6 +19,7 @@ import { getCoreSystem, RundownLayouts, RundownPlaylists, Rundowns } from '../co
 import { RundownPlaylistCollectionUtil } from '../../lib/collections/rundownPlaylistUtil'
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 export enum ToolTipStep {
 	TOOLTIP_START_HERE = 'TOOLTIP_START_HERE',
@@ -59,17 +60,17 @@ export function RundownList(): JSX.Element {
 	)
 
 	const baseSubsReady = [
-		useSubscription(PubSub.rundownPlaylists, {}),
-		useSubscription(PubSub.uiStudio, null),
-		useSubscription(PubSub.rundownLayouts, {}),
+		useSubscription(CorelibPubSub.rundownPlaylists, {}),
+		useSubscription(MeteorPubSub.uiStudio, null),
+		useSubscription(MeteorPubSub.rundownLayouts, {}),
 
-		useSubscription(PubSub.rundowns, playlistIds, null),
+		useSubscription(CorelibPubSub.rundowns, playlistIds, null),
 
-		useSubscription(PubSub.showStyleBases, {
+		useSubscription(CorelibPubSub.showStyleBases, {
 			_id: { $in: showStyleBaseIds },
 		}),
 
-		useSubscription(PubSub.showStyleVariants, {
+		useSubscription(CorelibPubSub.showStyleVariants, {
 			_id: { $in: showStyleVariantIds },
 		}),
 	].reduce((prev, current) => prev && current, true)

--- a/meteor/client/ui/RundownView/RundownNotifier.tsx
+++ b/meteor/client/ui/RundownView/RundownNotifier.tsx
@@ -14,7 +14,7 @@ import { WithManagedTracker } from '../../lib/reactiveData/reactiveDataHelper'
 import { reactiveData } from '../../lib/reactiveData/reactiveData'
 import { PeripheralDevice } from '@sofie-automation/corelib/dist/dataModel/PeripheralDevice'
 import { getCurrentTime, unprotectString } from '../../../lib/lib'
-import { PubSub, meteorSubscribe } from '../../../lib/api/pubsub'
+import { meteorSubscribe } from '../../../lib/api/pubsub'
 import { ReactiveVar } from 'meteor/reactive-var'
 import { Rundown } from '@sofie-automation/corelib/dist/dataModel/Rundown'
 import { doModalDialog } from '../../lib/ModalDialog'
@@ -44,6 +44,7 @@ import {
 import { UIPieceContentStatuses, UISegmentPartNotes } from '../Collections'
 import { RundownPlaylistCollectionUtil } from '../../../lib/collections/rundownPlaylistUtil'
 import { logger } from '../../../lib/logging'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 export const onRONotificationClick = new ReactiveVar<((e: RONotificationEvent) => void) | undefined>(undefined)
 export const reloadRundownPlaylistClick = new ReactiveVar<((e: any) => void) | undefined>(undefined)
@@ -292,7 +293,7 @@ class RundownViewNotifier extends WithManagedTracker {
 			| ReactiveVar<Pick<PeripheralDevice, '_id' | 'name' | 'ignore' | 'status' | 'connected' | 'parentDeviceId'>[]>
 			| undefined
 		if (studioId) {
-			meteorSubscribe(PubSub.peripheralDevicesAndSubDevices, { studioId: studioId })
+			meteorSubscribe(CorelibPubSub.peripheralDevicesAndSubDevices, { studioId: studioId })
 			reactivePeripheralDevices = reactiveData.getRPeripheralDevices(studioId, {
 				fields: {
 					name: 1,
@@ -576,7 +577,7 @@ class RundownViewNotifier extends WithManagedTracker {
 	}
 
 	private reactiveQueueStatus(studioId: StudioId, playlistId: RundownPlaylistId) {
-		meteorSubscribe(PubSub.externalMessageQueue, { studioId: studioId, playlistId })
+		meteorSubscribe(CorelibPubSub.externalMessageQueue, { studioId: studioId, playlistId })
 		const reactiveUnsentMessageCount = reactiveData.getUnsentExternalMessageCount(studioId, playlistId)
 		this.autorun(() => {
 			if (reactiveUnsentMessageCount.get() > 0 && this._unsentExternalMessagesStatus === undefined) {

--- a/meteor/client/ui/RundownView/RundownSystemStatus.tsx
+++ b/meteor/client/ui/RundownView/RundownSystemStatus.tsx
@@ -13,11 +13,11 @@ import { Time, getCurrentTime, unprotectString } from '../../../lib/lib'
 import { withTranslation, WithTranslation } from 'react-i18next'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
-import { PubSub } from '../../../lib/api/pubsub'
 import { StatusCode } from '@sofie-automation/blueprints-integration'
 import { UIStudio } from '../../../lib/api/studios'
 import { RundownId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { PeripheralDevices } from '../../collections'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 interface IMOSStatusProps {
 	lastUpdate: Time
@@ -180,7 +180,7 @@ export const RundownSystemStatus = translateWithTracker(
 		}
 
 		componentDidMount(): void {
-			this.subscribe(PubSub.peripheralDevicesAndSubDevices, {
+			this.subscribe(CorelibPubSub.peripheralDevicesAndSubDevices, {
 				studioId: this.props.studio._id,
 			})
 		}

--- a/meteor/client/ui/SegmentList/LinePartPieceIndicator/LinePartAdLibIndicator.tsx
+++ b/meteor/client/ui/SegmentList/LinePartPieceIndicator/LinePartAdLibIndicator.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useMemo } from 'react'
-import { PubSub } from '../../../../lib/api/pubsub'
 import { PartId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { AdLibAction } from '@sofie-automation/corelib/dist/dataModel/AdlibAction'
 import { AdLibPiece } from '@sofie-automation/corelib/dist/dataModel/AdLibPiece'
@@ -11,6 +10,7 @@ import { translateMessage } from '@sofie-automation/corelib/dist/TranslatableMes
 import StudioContext from '../../RundownView/StudioContext'
 import { AdLibActions, AdLibPieces } from '../../../collections'
 import RundownViewEventBus, { RundownViewEvents } from '../../../../lib/api/triggers/RundownViewEventBus'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 interface IProps {
 	sourceLayers: ISourceLayerExtended[]
@@ -24,14 +24,14 @@ export const LinePartAdLibIndicator: React.FC<IProps> = function LinePartAdLibIn
 	const sourceLayerIds = useMemo(() => sourceLayers.map((sourceLayer) => sourceLayer._id), [sourceLayers])
 	const label = useMemo(() => sourceLayers[0]?.name ?? '', [sourceLayers])
 
-	useSubscription(PubSub.adLibPieces, {
+	useSubscription(CorelibPubSub.adLibPieces, {
 		partId,
 		sourceLayerId: {
 			$in: sourceLayerIds,
 		},
 	})
 
-	useSubscription(PubSub.adLibActions, {
+	useSubscription(CorelibPubSub.adLibActions, {
 		partId,
 		'display.sourceLayerId': {
 			$in: sourceLayerIds,

--- a/meteor/client/ui/SegmentList/SegmentListContainer.tsx
+++ b/meteor/client/ui/SegmentList/SegmentListContainer.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { PieceLifespan } from '@sofie-automation/blueprints-integration'
-import { PubSub, meteorSubscribe } from '../../../lib/api/pubsub'
+import { meteorSubscribe } from '../../../lib/api/pubsub'
 import { useSubscription, useTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
 import {
 	withResolvedSegment,
@@ -12,6 +12,7 @@ import { SegmentList } from './SegmentList'
 import { unprotectString } from '../../../lib/lib'
 import { LIVELINE_HISTORY_SIZE as TIMELINE_LIVELINE_HISTORY_SIZE } from '../SegmentTimeline/SegmentTimelineContainer'
 import { PartInstances, Parts, Segments } from '../../collections'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 export const LIVELINE_HISTORY_SIZE = TIMELINE_LIVELINE_HISTORY_SIZE
 
@@ -41,7 +42,7 @@ export const SegmentListContainer = withResolvedSegment<IProps>(function Segment
 		[segmentId]
 	)
 
-	useSubscription(PubSub.pieces, {
+	useSubscription(CorelibPubSub.pieces, {
 		startRundownId: rundownId,
 		startPartId: {
 			$in: partIds,
@@ -67,7 +68,7 @@ export const SegmentListContainer = withResolvedSegment<IProps>(function Segment
 		[segmentId]
 	)
 
-	useSubscription(PubSub.pieceInstances, {
+	useSubscription(CorelibPubSub.pieceInstances, {
 		rundownId: rundownId,
 		partInstanceId: {
 			$in: partInstanceIds,
@@ -85,7 +86,7 @@ export const SegmentListContainer = withResolvedSegment<IProps>(function Segment
 			},
 		})
 		segment &&
-			meteorSubscribe(PubSub.pieces, {
+			meteorSubscribe(CorelibPubSub.pieces, {
 				invalid: {
 					$ne: true,
 				},

--- a/meteor/client/ui/SegmentScratchpad/SegmentScratchpadContainer.tsx
+++ b/meteor/client/ui/SegmentScratchpad/SegmentScratchpadContainer.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { PieceLifespan } from '@sofie-automation/blueprints-integration'
-import { meteorSubscribe, PubSub } from '../../../lib/api/pubsub'
+import { meteorSubscribe } from '../../../lib/api/pubsub'
 import { useSubscription, useTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
 import {
 	// PartUi,
@@ -16,6 +16,7 @@ import { PartInstances, Parts, Segments } from '../../collections'
 import { literal } from '@sofie-automation/shared-lib/dist/lib/lib'
 import { MongoFieldSpecifierOnes } from '@sofie-automation/corelib/dist/mongo'
 import { PartInstance } from '../../../lib/collections/PartInstances'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 export const LIVELINE_HISTORY_SIZE = TIMELINE_LIVELINE_HISTORY_SIZE
 
@@ -45,7 +46,7 @@ export const SegmentScratchpadContainer = withResolvedSegment<IProps>(function S
 		[segmentId]
 	)
 
-	const piecesReady = useSubscription(PubSub.pieces, {
+	const piecesReady = useSubscription(CorelibPubSub.pieces, {
 		startRundownId: rundownId,
 		startPartId: {
 			$in: partIds,
@@ -71,7 +72,7 @@ export const SegmentScratchpadContainer = withResolvedSegment<IProps>(function S
 		[segmentId]
 	)
 
-	const pieceInstancesReady = useSubscription(PubSub.pieceInstances, {
+	const pieceInstancesReady = useSubscription(CorelibPubSub.pieceInstances, {
 		rundownId: rundownId,
 		partInstanceId: {
 			$in: partInstanceIds,
@@ -89,7 +90,7 @@ export const SegmentScratchpadContainer = withResolvedSegment<IProps>(function S
 			},
 		})
 		segment &&
-			meteorSubscribe(PubSub.pieces, {
+			meteorSubscribe(CorelibPubSub.pieces, {
 				invalid: {
 					$ne: true,
 				},

--- a/meteor/client/ui/SegmentStoryboard/SegmentStoryboardContainer.tsx
+++ b/meteor/client/ui/SegmentStoryboard/SegmentStoryboardContainer.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { PieceLifespan } from '@sofie-automation/blueprints-integration'
-import { meteorSubscribe, PubSub } from '../../../lib/api/pubsub'
+import { meteorSubscribe } from '../../../lib/api/pubsub'
 import { useSubscription, useTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
 import {
 	// PartUi,
@@ -16,6 +16,7 @@ import { PartInstances, Parts, Segments } from '../../collections'
 import { literal } from '@sofie-automation/shared-lib/dist/lib/lib'
 import { MongoFieldSpecifierOnes } from '@sofie-automation/corelib/dist/mongo'
 import { PartInstance } from '../../../lib/collections/PartInstances'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 export const LIVELINE_HISTORY_SIZE = TIMELINE_LIVELINE_HISTORY_SIZE
 
@@ -45,7 +46,7 @@ export const SegmentStoryboardContainer = withResolvedSegment<IProps>(function S
 		[segmentId]
 	)
 
-	const piecesReady = useSubscription(PubSub.pieces, {
+	const piecesReady = useSubscription(CorelibPubSub.pieces, {
 		startRundownId: rundownId,
 		startPartId: {
 			$in: partIds,
@@ -71,7 +72,7 @@ export const SegmentStoryboardContainer = withResolvedSegment<IProps>(function S
 		[segmentId]
 	)
 
-	const pieceInstancesReady = useSubscription(PubSub.pieceInstances, {
+	const pieceInstancesReady = useSubscription(CorelibPubSub.pieceInstances, {
 		rundownId: rundownId,
 		partInstanceId: {
 			$in: partInstanceIds,
@@ -89,7 +90,7 @@ export const SegmentStoryboardContainer = withResolvedSegment<IProps>(function S
 			},
 		})
 		segment &&
-			meteorSubscribe(PubSub.pieces, {
+			meteorSubscribe(CorelibPubSub.pieces, {
 				invalid: {
 					$ne: true,
 				},

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -11,7 +11,7 @@ import { MAGIC_TIME_SCALE_FACTOR } from '../RundownView'
 import { SpeechSynthesiser } from '../../lib/speechSynthesis'
 import { getElementWidth } from '../../utils/dimensions'
 import { isMaintainingFocus, scrollToSegment, getHeaderHeight } from '../../lib/viewPort'
-import { meteorSubscribe, PubSub } from '../../../lib/api/pubsub'
+import { meteorSubscribe } from '../../../lib/api/pubsub'
 import { unprotectString, equalSets, equivalentArrays } from '../../../lib/lib'
 import { Settings } from '../../../lib/Settings'
 import { Tracker } from 'meteor/tracker'
@@ -34,6 +34,7 @@ import { RundownViewShelf } from '../RundownView/RundownViewShelf'
 import { PartInstanceId, SegmentId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { PartInstances, Parts, Segments } from '../../collections'
 import { catchError } from '../../lib/lib'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 // Kept for backwards compatibility
 export { SegmentUi, PartUi, PieceUi, ISourceLayerUi, IOutputLayerUi } from '../SegmentContainer/withResolvedSegment'
@@ -145,7 +146,7 @@ export const SegmentTimelineContainer = withResolvedSegment(
 					}
 				).map((part) => part._id)
 
-				this.subscribe(PubSub.pieces, {
+				this.subscribe(CorelibPubSub.pieces, {
 					startRundownId: this.props.rundownId,
 					startPartId: {
 						$in: partIds,
@@ -178,7 +179,7 @@ export const SegmentTimelineContainer = withResolvedSegment(
 					},
 				})
 				segment &&
-					this.subscribe(PubSub.pieces, {
+					this.subscribe(CorelibPubSub.pieces, {
 						invalid: {
 							$ne: true,
 						},
@@ -423,7 +424,7 @@ export const SegmentTimelineContainer = withResolvedSegment(
 					this.partInstanceSub.stop()
 				}
 				// we handle this subscription manually
-				this.partInstanceSub = meteorSubscribe(PubSub.pieceInstances, {
+				this.partInstanceSub = meteorSubscribe(CorelibPubSub.pieceInstances, {
 					rundownId: this.props.rundownId,
 					partInstanceId: {
 						$in: partInstanceIds,

--- a/meteor/client/ui/Settings.tsx
+++ b/meteor/client/ui/Settings.tsx
@@ -11,23 +11,23 @@ import BlueprintSettings from './Settings/BlueprintSettings'
 import SystemManagement from './Settings/SystemManagement'
 
 import { MigrationView } from './Settings/Migration'
-import { PubSub } from '../../lib/api/pubsub'
 import { getUser } from '../../lib/collections/Users'
 import { Settings as MeteorSettings } from '../../lib/Settings'
 import { SettingsMenu } from './Settings/SettingsMenu'
 import { getAllowConfigure } from '../lib/localStorage'
 import { protectString } from '@sofie-automation/corelib/dist/protectedString'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 export function Settings(): JSX.Element | null {
 	const user = useTracker(() => getUser(), [], null)
 
 	const history = useHistory()
 
-	useSubscription(PubSub.peripheralDevices, {})
-	useSubscription(PubSub.studios, {})
-	useSubscription(PubSub.showStyleBases, {})
-	useSubscription(PubSub.showStyleVariants, {})
-	useSubscription(PubSub.blueprints, {})
+	useSubscription(CorelibPubSub.peripheralDevices, {})
+	useSubscription(CorelibPubSub.studios, {})
+	useSubscription(CorelibPubSub.showStyleBases, {})
+	useSubscription(CorelibPubSub.showStyleVariants, {})
+	useSubscription(CorelibPubSub.blueprints, {})
 
 	useEffect(() => {
 		if (MeteorSettings.enableUserAccounts && user) {

--- a/meteor/client/ui/Settings/RundownLayoutEditor.tsx
+++ b/meteor/client/ui/Settings/RundownLayoutEditor.tsx
@@ -20,7 +20,7 @@ import {
 	CustomizableRegionSettingsManifest,
 	RundownLayoutsAPI,
 } from '../../../lib/api/rundownLayouts'
-import { PubSub } from '../../../lib/api/pubsub'
+import { MeteorPubSub } from '../../../lib/api/pubsub'
 import { getRandomString, literal, unprotectString } from '../../../lib/lib'
 import { UploadButton } from '../../lib/uploadButton'
 import { doModalDialog } from '../../lib/ModalDialog'
@@ -83,7 +83,7 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 		componentDidMount(): void {
 			super.componentDidMount && super.componentDidMount()
 
-			this.subscribe(PubSub.rundownLayouts, {})
+			this.subscribe(MeteorPubSub.rundownLayouts, {})
 		}
 
 		onAddLayout = () => {

--- a/meteor/client/ui/Settings/SettingsMenu.tsx
+++ b/meteor/client/ui/Settings/SettingsMenu.tsx
@@ -14,7 +14,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { DBShowStyleBase } from '@sofie-automation/corelib/dist/dataModel/ShowStyleBase'
 import { Blueprint } from '@sofie-automation/corelib/dist/dataModel/Blueprint'
-import { PubSub, meteorSubscribe } from '../../../lib/api/pubsub'
+import { meteorSubscribe } from '../../../lib/api/pubsub'
 import { MeteorCall } from '../../../lib/api/methods'
 import { Settings as MeteorSettings } from '../../../lib/Settings'
 import { IOutputLayer, StatusCode } from '@sofie-automation/blueprints-integration'
@@ -23,6 +23,7 @@ import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
 import { Blueprints, PeripheralDevices, ShowStyleBases, Studios } from '../../collections'
 import { applyAndValidateOverrides } from '@sofie-automation/corelib/dist/settings/objectWithOverrides'
 import { catchError } from '../../lib/lib'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 interface ISettingsMenuProps {
 	superAdmin?: boolean
@@ -38,11 +39,11 @@ export const SettingsMenu = translateWithTracker<ISettingsMenuProps, ISettingsMe
 	(_props: ISettingsMenuProps) => {
 		// TODO: add organizationId:
 
-		meteorSubscribe(PubSub.studios, {})
-		meteorSubscribe(PubSub.showStyleBases, {})
-		meteorSubscribe(PubSub.showStyleVariants, {})
-		meteorSubscribe(PubSub.blueprints, {})
-		meteorSubscribe(PubSub.peripheralDevices, {})
+		meteorSubscribe(CorelibPubSub.studios, {})
+		meteorSubscribe(CorelibPubSub.showStyleBases, {})
+		meteorSubscribe(CorelibPubSub.showStyleVariants, {})
+		meteorSubscribe(CorelibPubSub.blueprints, {})
+		meteorSubscribe(CorelibPubSub.peripheralDevices, {})
 
 		return {
 			studios: Studios.find({}).fetch(),

--- a/meteor/client/ui/Settings/ShowStyle/BlueprintConfiguration/index.tsx
+++ b/meteor/client/ui/Settings/ShowStyle/BlueprintConfiguration/index.tsx
@@ -8,7 +8,7 @@ import { MappingsExt } from '@sofie-automation/corelib/dist/dataModel/Studio'
 import { DBShowStyleBase, SourceLayers } from '@sofie-automation/corelib/dist/dataModel/ShowStyleBase'
 import { SelectConfigPreset } from './SelectConfigPreset'
 import { SelectBlueprint } from './SelectBlueprint'
-import { PubSub } from '../../../../../lib/api/pubsub'
+import { MeteorPubSub } from '../../../../../lib/api/pubsub'
 import { useSubscription, useTracker } from '../../../../lib/ReactMeteorData/ReactMeteorData'
 import { UIBlueprintUpgradeStatuses } from '../../../Collections'
 import { getUpgradeStatusMessage, UpgradeStatusButtons } from '../../Upgrades/Components'
@@ -27,7 +27,7 @@ export function ShowStyleBaseBlueprintConfigurationSettings(
 ): JSX.Element {
 	const { t } = useTranslation()
 
-	const isStatusReady = useSubscription(PubSub.uiBlueprintUpgradeStatuses)
+	const isStatusReady = useSubscription(MeteorPubSub.uiBlueprintUpgradeStatuses)
 	const status = useTracker(
 		() =>
 			UIBlueprintUpgradeStatuses.findOne({

--- a/meteor/client/ui/Settings/SnapshotsView.tsx
+++ b/meteor/client/ui/Settings/SnapshotsView.tsx
@@ -13,12 +13,13 @@ import { DBStudio } from '@sofie-automation/corelib/dist/dataModel/Studio'
 import { multilineText, fetchFrom } from '../../lib/lib'
 import { NotificationCenter, Notification, NoticeLevel } from '../../../lib/notifications/notifications'
 import { UploadButton } from '../../lib/uploadButton'
-import { PubSub } from '../../../lib/api/pubsub'
+import { MeteorPubSub } from '../../../lib/api/pubsub'
 import { MeteorCall } from '../../../lib/api/methods'
 import { SnapshotId, StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { Snapshots, Studios } from '../../collections'
 import { ClientAPI } from '../../../lib/api/client'
 import { hashSingleUseToken } from '../../../lib/api/userActions'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 interface IProps {
 	match: {
@@ -59,12 +60,12 @@ export default translateWithTracker<IProps, IState, ITrackedProps>(() => {
 			}
 		}
 		componentDidMount(): void {
-			this.subscribe(PubSub.snapshots, {
+			this.subscribe(MeteorPubSub.snapshots, {
 				created: {
 					$gt: getCurrentTime() - 30 * 24 * 3600 * 1000, // last 30 days
 				},
 			})
-			this.subscribe(PubSub.studios, {})
+			this.subscribe(CorelibPubSub.studios, {})
 		}
 
 		onUploadFile(e: React.ChangeEvent<HTMLInputElement>) {

--- a/meteor/client/ui/Settings/Studio/BlueprintConfiguration/index.tsx
+++ b/meteor/client/ui/Settings/Studio/BlueprintConfiguration/index.tsx
@@ -12,7 +12,7 @@ import { useTranslation } from 'react-i18next'
 import { DBStudio } from '@sofie-automation/corelib/dist/dataModel/Studio'
 import { SelectConfigPreset } from './SelectConfigPreset'
 import { SelectBlueprint } from './SelectBlueprint'
-import { PubSub } from '../../../../../lib/api/pubsub'
+import { MeteorPubSub } from '../../../../../lib/api/pubsub'
 import { UIBlueprintUpgradeStatuses } from '../../../Collections'
 import { getUpgradeStatusMessage, UpgradeStatusButtons } from '../../Upgrades/Components'
 
@@ -23,7 +23,7 @@ interface StudioBlueprintConfigurationSettingsProps {
 export function StudioBlueprintConfigurationSettings(props: StudioBlueprintConfigurationSettingsProps): JSX.Element {
 	const { t } = useTranslation()
 
-	const isStatusReady = useSubscription(PubSub.uiBlueprintUpgradeStatuses)
+	const isStatusReady = useSubscription(MeteorPubSub.uiBlueprintUpgradeStatuses)
 	const status = useTracker(
 		() =>
 			UIBlueprintUpgradeStatuses.findOne({

--- a/meteor/client/ui/Settings/SystemManagement.tsx
+++ b/meteor/client/ui/Settings/SystemManagement.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { translateWithTracker, Translated } from '../../lib/ReactMeteorData/ReactMeteorData'
 import { ICoreSystem, SofieLogo } from '../../../lib/collections/CoreSystem'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
-import { meteorSubscribe, PubSub } from '../../../lib/api/pubsub'
+import { meteorSubscribe, MeteorPubSub } from '../../../lib/api/pubsub'
 import { EditAttribute } from '../../lib/EditAttribute'
 import { doModalDialog } from '../../lib/ModalDialog'
 import { MeteorCall } from '../../../lib/api/methods'
@@ -30,7 +30,7 @@ export default translateWithTracker<IProps, {}, ITrackedProps>((_props: IProps) 
 })(
 	class SystemManagement extends MeteorReactComponent<Translated<IProps & ITrackedProps>> {
 		componentDidMount(): void {
-			meteorSubscribe(PubSub.coreSystem)
+			meteorSubscribe(MeteorPubSub.coreSystem)
 		}
 		cleanUpOldDatabaseIndexes(): void {
 			const { t } = this.props

--- a/meteor/client/ui/Settings/Upgrades/View.tsx
+++ b/meteor/client/ui/Settings/Upgrades/View.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Spinner } from '../../../lib/Spinner'
 import { unprotectString } from '@sofie-automation/corelib/dist/protectedString'
 import { useSubscription, useTracker } from '../../../lib/ReactMeteorData/ReactMeteorData'
-import { PubSub } from '../../../../lib/api/pubsub'
+import { MeteorPubSub } from '../../../../lib/api/pubsub'
 import { UIBlueprintUpgradeStatuses } from '../../Collections'
 import { UIBlueprintUpgradeStatusShowStyle, UIBlueprintUpgradeStatusStudio } from '../../../../lib/api/upgradeStatus'
 import { getUpgradeStatusMessage, UpgradeStatusButtons } from './Components'
@@ -11,7 +11,7 @@ import { getUpgradeStatusMessage, UpgradeStatusButtons } from './Components'
 export function UpgradesView(): JSX.Element {
 	const { t } = useTranslation()
 
-	const isReady = useSubscription(PubSub.uiBlueprintUpgradeStatuses)
+	const isReady = useSubscription(MeteorPubSub.uiBlueprintUpgradeStatuses)
 
 	const statuses = useTracker(() => UIBlueprintUpgradeStatuses.find().fetch(), [])
 

--- a/meteor/client/ui/Settings/components/triggeredActions/TriggeredActionsEditor.tsx
+++ b/meteor/client/ui/Settings/components/triggeredActions/TriggeredActionsEditor.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useContext, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSubscription, useTracker } from '../../../../lib/ReactMeteorData/ReactMeteorData'
-import { PubSub } from '../../../../../lib/api/pubsub'
+import { MeteorPubSub } from '../../../../../lib/api/pubsub'
 import { TriggeredActionsObj } from '../../../../../lib/collections/TriggeredActions'
 import { faCaretDown, faCaretRight, faDownload, faPlus, faUpload } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -31,6 +31,7 @@ import { PartInstances, Parts, RundownPlaylists, Rundowns, TriggeredActions } fr
 import { applyAndValidateOverrides } from '@sofie-automation/corelib/dist/settings/objectWithOverrides'
 import { SourceLayers, OutputLayers } from '@sofie-automation/corelib/dist/dataModel/ShowStyleBase'
 import { RundownPlaylistCollectionUtil } from '../../../../../lib/collections/rundownPlaylistUtil'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 export interface PreviewContext {
 	rundownPlaylist: DBRundownPlaylist | null
@@ -90,8 +91,8 @@ export const TriggeredActionsEditor: React.FC<IProps> = function TriggeredAction
 		]),
 	}
 
-	useSubscription(PubSub.triggeredActions, showStyleBaseSelector)
-	useSubscription(PubSub.rundowns, null, showStyleBaseId ? [showStyleBaseId] : [])
+	useSubscription(MeteorPubSub.triggeredActions, showStyleBaseSelector)
+	useSubscription(CorelibPubSub.rundowns, null, showStyleBaseId ? [showStyleBaseId] : [])
 
 	useEffect(() => {
 		const debounce = setTimeout(() => {
@@ -166,7 +167,7 @@ export const TriggeredActionsEditor: React.FC<IProps> = function TriggeredAction
 		[showStyleBaseId, parsedTriggerFilter]
 	)
 
-	useSubscription(PubSub.rundownPlaylists, {})
+	useSubscription(CorelibPubSub.rundownPlaylists, {})
 
 	const rundown = useTracker(() => {
 		const activePlaylists = RundownPlaylists.find(
@@ -205,8 +206,8 @@ export const TriggeredActionsEditor: React.FC<IProps> = function TriggeredAction
 		null
 	)
 
-	useSubscription(PubSub.partInstances, rundown ? [rundown._id] : [], rundownPlaylist?.activationId)
-	useSubscription(PubSub.parts, rundown ? [rundown._id] : [])
+	useSubscription(CorelibPubSub.partInstances, rundown ? [rundown._id] : [], rundownPlaylist?.activationId)
+	useSubscription(CorelibPubSub.parts, rundown ? [rundown._id] : [])
 
 	const previewContext = useTracker(
 		() => {

--- a/meteor/client/ui/Settings/components/triggeredActions/triggerEditors/DeviceEditor.tsx
+++ b/meteor/client/ui/Settings/components/triggeredActions/triggerEditors/DeviceEditor.tsx
@@ -2,7 +2,7 @@ import { IBlueprintDeviceTrigger } from '@sofie-automation/blueprints-integratio
 import { protectString, unprotectString } from '@sofie-automation/corelib/dist/protectedString'
 import classNames from 'classnames'
 import React, { useMemo } from 'react'
-import { PubSub } from '../../../../../../lib/api/pubsub'
+import { MeteorPubSub } from '../../../../../../lib/api/pubsub'
 import { Studios } from '../../../../../collections'
 import { getCurrentTime } from '../../../../../../lib/lib'
 import { UIDeviceTriggerPreview } from '../../../../../../server/publications/deviceTriggersPreview'
@@ -33,7 +33,7 @@ export const DeviceEditor = function DeviceEditor({ trigger, modified, readonly,
 	)
 	const studio = useTracker(() => Studios.findOne(), [], undefined)
 
-	useSubscription(PubSub.deviceTriggersPreview, studio?._id ?? protectString(''))
+	useSubscription(MeteorPubSub.deviceTriggersPreview, studio?._id ?? protectString(''))
 
 	return (
 		<>

--- a/meteor/client/ui/Shelf/BucketPanel.tsx
+++ b/meteor/client/ui/Shelf/BucketPanel.tsx
@@ -23,7 +23,7 @@ import {
 	IBlueprintActionTriggerMode,
 	SomeContent,
 } from '@sofie-automation/blueprints-integration'
-import { PubSub } from '../../../lib/api/pubsub'
+import { MeteorPubSub } from '../../../lib/api/pubsub'
 import { doUserAction, getEventTimestamp, UserAction } from '../../../lib/clientUserAction'
 import { NotificationCenter, Notification, NoticeLevel } from '../../../lib/notifications/notifications'
 import { literal, unprotectString, partial, protectString } from '../../../lib/lib'
@@ -72,6 +72,7 @@ import {
 	ShowStyleVariantId,
 } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { RundownPlaylistCollectionUtil } from '../../../lib/collections/rundownPlaylistUtil'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 interface IBucketPanelDragObject {
 	id: BucketId
@@ -385,9 +386,9 @@ export const BucketPanel = translateWithTracker<Translated<IBucketPanelProps>, I
 				}
 
 				componentDidMount(): void {
-					this.subscribe(PubSub.buckets, this.props.playlist.studioId, this.props.bucket._id)
-					this.subscribe(PubSub.uiBucketContentStatuses, this.props.playlist.studioId, this.props.bucket._id)
-					this.subscribe(PubSub.uiStudio, this.props.playlist.studioId)
+					this.subscribe(MeteorPubSub.buckets, this.props.playlist.studioId, this.props.bucket._id)
+					this.subscribe(MeteorPubSub.uiBucketContentStatuses, this.props.playlist.studioId, this.props.bucket._id)
+					this.subscribe(MeteorPubSub.uiStudio, this.props.playlist.studioId)
 					this.autorun(() => {
 						const showStyles: Array<[ShowStyleBaseId, ShowStyleVariantId]> =
 							RundownPlaylistCollectionUtil.getRundownsUnordered(this.props.playlist).map((rundown) => [
@@ -396,14 +397,14 @@ export const BucketPanel = translateWithTracker<Translated<IBucketPanelProps>, I
 							])
 						const showStyleBases = showStyles.map((showStyle) => showStyle[0])
 						const showStyleVariants = showStyles.map((showStyle) => showStyle[1])
-						this.subscribe(PubSub.bucketAdLibPieces, {
+						this.subscribe(CorelibPubSub.bucketAdLibPieces, {
 							bucketId: this.props.bucket._id,
 							studioId: this.props.playlist.studioId,
 							showStyleVariantId: {
 								$in: [null, ...showStyleVariants], // null = valid for all variants
 							},
 						})
-						this.subscribe(PubSub.bucketAdLibActions, {
+						this.subscribe(CorelibPubSub.bucketAdLibActions, {
 							bucketId: this.props.bucket._id,
 							studioId: this.props.playlist.studioId,
 							showStyleVariantId: {
@@ -411,7 +412,7 @@ export const BucketPanel = translateWithTracker<Translated<IBucketPanelProps>, I
 							},
 						})
 						for (const showStyleBaseId of _.uniq(showStyleBases)) {
-							this.subscribe(PubSub.uiShowStyleBase, showStyleBaseId)
+							this.subscribe(MeteorPubSub.uiShowStyleBase, showStyleBaseId)
 						}
 					})
 

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -6,7 +6,6 @@ import ClassNames from 'classnames'
 import { Spinner } from '../../lib/Spinner'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { ISourceLayer, IBlueprintActionTriggerMode } from '@sofie-automation/blueprints-integration'
-import { PubSub } from '../../../lib/api/pubsub'
 import { doUserAction, UserAction } from '../../../lib/clientUserAction'
 import { NotificationCenter, Notification, NoticeLevel } from '../../../lib/notifications/notifications'
 import { DashboardLayoutFilter, DashboardPanelUnit } from '../../../lib/collections/RundownLayouts'
@@ -34,6 +33,7 @@ import { UIStudios } from '../Collections'
 import { Meteor } from 'meteor/meteor'
 import { PieceId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { RundownPlaylistCollectionUtil } from '../../../lib/collections/rundownPlaylistUtil'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 interface IState {
 	outputLayers: OutputLayers
@@ -167,7 +167,7 @@ export class DashboardPanelInner extends MeteorReactComponent<
 		this.autorun(() => {
 			const unorderedRundownIds = RundownPlaylistCollectionUtil.getRundownUnorderedIDs(this.props.playlist)
 			if (unorderedRundownIds.length > 0) {
-				this.subscribe(PubSub.pieceInstances, {
+				this.subscribe(CorelibPubSub.pieceInstances, {
 					rundownId: {
 						$in: unorderedRundownIds,
 					},

--- a/meteor/client/ui/Status.tsx
+++ b/meteor/client/ui/Status.tsx
@@ -9,9 +9,10 @@ import { ExternalMessages } from './Status/ExternalMessages'
 import { UserActivity } from './Status/UserActivity'
 import { EvaluationView } from './Status/Evaluations'
 import { MeteorReactComponent } from '../lib/MeteorReactComponent'
-import { PubSub } from '../../lib/api/pubsub'
+import { MeteorPubSub } from '../../lib/api/pubsub'
 import { ExpectedPackagesStatus } from './Status/package-status'
 import { MediaStatus } from './Status/media-status'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 interface IStatusMenuProps {
 	match?: any
@@ -79,10 +80,10 @@ class Status extends MeteorReactComponent<Translated<IStatusProps>> {
 	componentDidMount(): void {
 		// Subscribe to data:
 
-		this.subscribe(PubSub.peripheralDevices, {})
-		this.subscribe(PubSub.uiStudio, null)
-		this.subscribe(PubSub.showStyleBases, {})
-		this.subscribe(PubSub.showStyleVariants, {})
+		this.subscribe(CorelibPubSub.peripheralDevices, {})
+		this.subscribe(MeteorPubSub.uiStudio, null)
+		this.subscribe(CorelibPubSub.showStyleBases, {})
+		this.subscribe(CorelibPubSub.showStyleVariants, {})
 	}
 	render(): JSX.Element {
 		// const { t } = this.props

--- a/meteor/client/ui/Status/Evaluations.tsx
+++ b/meteor/client/ui/Status/Evaluations.tsx
@@ -9,7 +9,7 @@ import { Evaluation } from '../../../lib/collections/Evaluations'
 import { DatePickerFromTo } from '../../lib/datePicker'
 import moment from 'moment'
 import { getQuestionOptions } from '../AfterBroadcastForm'
-import { PubSub, meteorSubscribe } from '../../../lib/api/pubsub'
+import { MeteorPubSub, meteorSubscribe } from '../../../lib/api/pubsub'
 import { Evaluations } from '../../collections'
 
 interface IEvaluationProps {}
@@ -63,7 +63,7 @@ const EvaluationView = translateWithTracker<IEvaluationProps, IEvaluationState, 
 				if (this._sub) {
 					this._sub.stop()
 				}
-				this._sub = meteorSubscribe(PubSub.evaluations, {
+				this._sub = meteorSubscribe(MeteorPubSub.evaluations, {
 					timestamp: {
 						$gte: this.state.dateFrom,
 						$lt: this.state.dateTo,

--- a/meteor/client/ui/Status/ExternalMessages.tsx
+++ b/meteor/client/ui/Status/ExternalMessages.tsx
@@ -13,13 +13,14 @@ import ClassNames from 'classnames'
 import { DatePickerFromTo } from '../../lib/datePicker'
 import moment from 'moment'
 import { faTrash, faPause, faPlay, faRedo } from '@fortawesome/free-solid-svg-icons'
-import { PubSub, meteorSubscribe } from '../../../lib/api/pubsub'
+import { MeteorPubSub, meteorSubscribe } from '../../../lib/api/pubsub'
 import { MeteorCall } from '../../../lib/api/methods'
 import { UIStudios } from '../Collections'
 import { UIStudio } from '../../../lib/api/studios'
 import { StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { ExternalMessageQueue } from '../../collections'
 import { catchError } from '../../lib/lib'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 interface IExternalMessagesProps {}
 interface IExternalMessagesState {
@@ -49,7 +50,7 @@ const ExternalMessages = translateWithTracker<
 			}
 		}
 		componentDidMount(): void {
-			this.subscribe(PubSub.uiStudio, null)
+			this.subscribe(MeteorPubSub.uiStudio, null)
 		}
 		onClickStudio = (studio: UIStudio) => {
 			this.setState({
@@ -159,7 +160,7 @@ const ExternalMessagesInStudio = translateWithTracker<
 				if (this._sub) {
 					this._sub.stop()
 				}
-				this._sub = meteorSubscribe(PubSub.externalMessageQueue, {
+				this._sub = meteorSubscribe(CorelibPubSub.externalMessageQueue, {
 					studioId: this.props.studioId,
 					created: {
 						$gte: this.state.dateFrom,

--- a/meteor/client/ui/Status/MediaManager.tsx
+++ b/meteor/client/ui/Status/MediaManager.tsx
@@ -14,7 +14,7 @@ import * as i18next from 'react-i18next'
 import { extendMandadory, unprotectString } from '../../../lib/lib'
 import * as _ from 'underscore'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
-import { PubSub } from '../../../lib/api/pubsub'
+import { MeteorPubSub } from '../../../lib/api/pubsub'
 import { Spinner } from '../../lib/Spinner'
 import { sofieWarningIcon as WarningIcon } from '../../lib/notifications/warningIcon'
 import { doUserAction, UserAction } from '../../../lib/clientUserAction'
@@ -378,8 +378,8 @@ export const MediaManagerStatus = translateWithTracker<IMediaManagerStatusProps,
 
 		componentDidMount(): void {
 			// Subscribe to data:
-			this.subscribe(PubSub.mediaWorkFlows, {}) // TODO: add some limit
-			this.subscribe(PubSub.mediaWorkFlowSteps, {})
+			this.subscribe(MeteorPubSub.mediaWorkFlows, {}) // TODO: add some limit
+			this.subscribe(MeteorPubSub.mediaWorkFlowSteps, {})
 		}
 
 		toggleExpanded = (workFlowId: MediaWorkFlowId) => {

--- a/meteor/client/ui/Status/SystemStatus.tsx
+++ b/meteor/client/ui/Status/SystemStatus.tsx
@@ -19,7 +19,6 @@ import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { callPeripheralDeviceAction, PeripheralDevicesAPI } from '../../lib/clientAPI'
 import { NotificationCenter, NoticeLevel, Notification } from '../../../lib/notifications/notifications'
 import { getAllowConfigure, getAllowDeveloper, getAllowStudio, getHelpMode } from '../../lib/localStorage'
-import { PubSub } from '../../../lib/api/pubsub'
 import ClassNames from 'classnames'
 import { StatusCode, TSR } from '@sofie-automation/blueprints-integration'
 import { ICoreSystem } from '../../../lib/collections/CoreSystem'
@@ -40,6 +39,7 @@ import { JSONBlobParse } from '@sofie-automation/shared-lib/dist/lib/JSONBlob'
 import { ClientAPI } from '../../../lib/api/client'
 import { catchError } from '../../lib/lib'
 import { logger } from '../../../lib/logging'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 interface IDeviceItemProps {
 	parentDevice: PeripheralDevice | null
@@ -546,7 +546,7 @@ export default translateWithTracker<ISystemStatusProps, ISystemStatusState, ISys
 			this.refreshDebugStatesInterval = setInterval(this.refreshDebugStates, 1000)
 
 			// Subscribe to data:
-			this.subscribe(PubSub.peripheralDevices, {})
+			this.subscribe(CorelibPubSub.peripheralDevices, {})
 		}
 
 		componentWillUnmount(): void {

--- a/meteor/client/ui/Status/UserActivity.tsx
+++ b/meteor/client/ui/Status/UserActivity.tsx
@@ -4,7 +4,7 @@ import { Time, unprotectString } from '../../../lib/lib'
 import { UserActionsLogItem } from '../../../lib/collections/UserActionsLog'
 import { DatePickerFromTo } from '../../lib/datePicker'
 import moment from 'moment'
-import { PubSub } from '../../../lib/api/pubsub'
+import { MeteorPubSub } from '../../../lib/api/pubsub'
 import { useTranslation } from 'react-i18next'
 import { parse as queryStringParse } from 'query-string'
 import { Link, useHistory, useLocation } from 'react-router-dom'
@@ -149,7 +149,7 @@ function UserActivity(): JSX.Element {
 	const [dateFrom, setDateFrom] = useState<Time>(moment().startOf('day').valueOf())
 	const [dateTo, setDateTo] = useState<Time>(moment().add(1, 'days').startOf('day').valueOf())
 
-	useSubscription(PubSub.userActionsLog, {
+	useSubscription(MeteorPubSub.userActionsLog, {
 		timestamp: {
 			$gte: dateFrom,
 			$lt: dateTo,

--- a/meteor/client/ui/Status/media-status/index.tsx
+++ b/meteor/client/ui/Status/media-status/index.tsx
@@ -8,7 +8,6 @@ import {
 } from '../../MediaStatus/MediaStatus'
 import { useSubscription, useTracker } from '../../../lib/ReactMeteorData/ReactMeteorData'
 import { RundownPlaylists } from '../../../collections'
-import { PubSub } from '../../../../lib/api/pubsub'
 import { Spinner } from '../../../lib/Spinner'
 import { MediaStatusListItem } from './MediaStatusListItem'
 import { unprotectString } from '@sofie-automation/corelib/dist/protectedString'
@@ -18,6 +17,7 @@ import { translateMessage } from '@sofie-automation/corelib/dist/TranslatableMes
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faTimes } from '@fortawesome/free-solid-svg-icons'
 import { mapOrFallback, useDebounce } from '../../../lib/lib'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 export function MediaStatus(): JSX.Element | null {
 	const scrollBox = useRef<HTMLDivElement>(null)
@@ -35,7 +35,7 @@ export function MediaStatus(): JSX.Element | null {
 		setSortBy(sortBy)
 	}
 
-	useSubscription(PubSub.rundownPlaylists, {})
+	useSubscription(CorelibPubSub.rundownPlaylists, {})
 
 	const { t } = useTranslation()
 

--- a/meteor/client/ui/Status/package-status/index.tsx
+++ b/meteor/client/ui/Status/package-status/index.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from 'react'
 import { useSubscription, useTracker } from '../../../lib/ReactMeteorData/react-meteor-data'
-import { PubSub } from '../../../../lib/api/pubsub'
 import { ExpectedPackageWorkStatus } from '@sofie-automation/corelib/dist/dataModel/ExpectedPackageWorkStatuses'
 import { normalizeArrayToMap, unprotectString } from '../../../../lib/lib'
 import { ExpectedPackageDB } from '@sofie-automation/corelib/dist/dataModel/ExpectedPackages'
@@ -20,6 +19,7 @@ import {
 } from '../../../collections'
 import { PeripheralDeviceId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { PeripheralDevice } from '@sofie-automation/corelib/dist/dataModel/PeripheralDevice'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 export const ExpectedPackagesStatus: React.FC<{}> = function ExpectedPackagesStatus(_props: {}) {
 	const { t } = useTranslation()
@@ -34,13 +34,13 @@ export const ExpectedPackagesStatus: React.FC<{}> = function ExpectedPackagesSta
 
 	const allSubsReady: boolean =
 		[
-			useSubscription(PubSub.expectedPackageWorkStatuses, {
+			useSubscription(CorelibPubSub.expectedPackageWorkStatuses, {
 				studioId: { $in: studioIds },
 			}),
-			useSubscription(PubSub.expectedPackages, {
+			useSubscription(CorelibPubSub.expectedPackages, {
 				studioId: { $in: studioIds },
 			}),
-			useSubscription(PubSub.packageContainerStatuses, {
+			useSubscription(CorelibPubSub.packageContainerStatuses, {
 				studioId: { $in: studioIds },
 			}),
 			studioIds && studioIds.length > 0,
@@ -56,7 +56,7 @@ export const ExpectedPackagesStatus: React.FC<{}> = function ExpectedPackagesSta
 		expectedPackageWorkStatuses.forEach((epws) => devices.add(epws.deviceId))
 		return Array.from(devices)
 	}, [packageContainerStatuses, expectedPackageWorkStatuses])
-	const peripheralDeviceSubReady = useSubscription(PubSub.peripheralDevices, {
+	const peripheralDeviceSubReady = useSubscription(CorelibPubSub.peripheralDevices, {
 		_id: { $in: deviceIds },
 	})
 	const peripheralDevices = useTracker(() => PeripheralDevices.find().fetch(), [], [])

--- a/meteor/client/ui/StudioScreenSaver/StudioScreenSaver.tsx
+++ b/meteor/client/ui/StudioScreenSaver/StudioScreenSaver.tsx
@@ -4,7 +4,7 @@ import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/Rund
 import { getCurrentTime } from '../../../lib/lib'
 import { invalidateAfter } from '../../../lib/invalidatingTime'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
-import { PubSub } from '../../../lib/api/pubsub'
+import { MeteorPubSub } from '../../../lib/api/pubsub'
 import classNames from 'classnames'
 import { Clock } from './Clock'
 import { Countdown } from './Countdown'
@@ -13,6 +13,7 @@ import { UIStudios } from '../Collections'
 import { UIStudio } from '../../../lib/api/studios'
 import { StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { RundownPlaylists } from '../../collections'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 interface IProps {
 	// the studio to be displayed in the screen saver
@@ -124,8 +125,8 @@ export const StudioScreenSaver = translateWithTracker(findNextPlaylist)(
 		}
 
 		componentDidMount(): void {
-			this.subscribe(PubSub.uiStudio, this.props.studioId)
-			this.subscribe(PubSub.rundownPlaylists, {
+			this.subscribe(MeteorPubSub.uiStudio, this.props.studioId)
+			this.subscribe(CorelibPubSub.rundownPlaylists, {
 				studioId: this.props.studioId,
 			})
 

--- a/meteor/client/ui/TestTools/DeviceTriggers.tsx
+++ b/meteor/client/ui/TestTools/DeviceTriggers.tsx
@@ -1,16 +1,25 @@
 import React, { Fragment, useState } from 'react'
 import { useSubscription, useTracker } from '../../lib/ReactMeteorData/react-meteor-data'
 import { Mongo } from 'meteor/mongo'
-import { CustomCollectionName, PubSub } from '../../../lib/api/pubsub'
+import {} from '../../../lib/api/pubsub'
 import { protectString, unprotectString } from '@sofie-automation/corelib/dist/protectedString'
 import { useTranslation } from 'react-i18next'
 import { Link, useParams } from 'react-router-dom'
 import { PeripheralDeviceId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { DeviceTriggerMountedAction, PreviewWrappedAdLib } from '../../../lib/api/triggers/MountedTriggers'
 import { PeripheralDevices } from '../../collections'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
+import {
+	PeripheralDevicePubSub,
+	PeripheralDevicePubSubCollectionsNames,
+} from '@sofie-automation/shared-lib/dist/pubsub/peripheralDevice'
 
-const MountedTriggers = new Mongo.Collection<DeviceTriggerMountedAction>(CustomCollectionName.MountedTriggers)
-const MountedTriggersPreviews = new Mongo.Collection<PreviewWrappedAdLib>(CustomCollectionName.MountedTriggersPreviews)
+const MountedTriggers = new Mongo.Collection<DeviceTriggerMountedAction>(
+	PeripheralDevicePubSubCollectionsNames.mountedTriggers
+)
+const MountedTriggersPreviews = new Mongo.Collection<PreviewWrappedAdLib>(
+	PeripheralDevicePubSubCollectionsNames.mountedTriggersPreviews
+)
 
 interface DeviceTriggersViewRouteParams {
 	peripheralDeviceId: string
@@ -41,8 +50,8 @@ interface IDatastoreControlsProps {
 }
 function DeviceTriggersControls({ peripheralDeviceId }: IDatastoreControlsProps) {
 	const [deviceIds, setDeviceIds] = useState<string[]>([])
-	useSubscription(PubSub.mountedTriggersForDevice, peripheralDeviceId, deviceIds)
-	useSubscription(PubSub.mountedTriggersForDevicePreview, peripheralDeviceId)
+	useSubscription(PeripheralDevicePubSub.mountedTriggersForDevice, peripheralDeviceId, deviceIds)
+	useSubscription(PeripheralDevicePubSub.mountedTriggersForDevicePreview, peripheralDeviceId)
 
 	const mountedTriggers = useTracker<DeviceTriggerMountedAction[]>(
 		() =>
@@ -121,7 +130,7 @@ function DeviceTriggersControls({ peripheralDeviceId }: IDatastoreControlsProps)
 }
 
 const DeviceTriggersDeviceSelect: React.FC = function DeviceTriggersDeviceSelect() {
-	useSubscription(PubSub.peripheralDevices, {})
+	useSubscription(CorelibPubSub.peripheralDevices, {})
 	const devices = useTracker(() => PeripheralDevices.find().fetch(), [])
 
 	if (!devices) return null

--- a/meteor/client/ui/TestTools/Mappings.tsx
+++ b/meteor/client/ui/TestTools/Mappings.tsx
@@ -3,16 +3,19 @@ import { Translated, translateWithTracker, withTracker } from '../../lib/ReactMe
 import * as _ from 'underscore'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { omit, Time, unprotectString } from '../../../lib/lib'
-import { CustomCollectionName, PubSub } from '../../../lib/api/pubsub'
+import { MeteorPubSub } from '../../../lib/api/pubsub'
 import { makeTableOfObject } from '../../lib/utilComponents'
 import { StudioSelect } from './StudioSelect'
 import { MappingExt } from '@sofie-automation/corelib/dist/dataModel/Studio'
 import { LookaheadMode, TSR } from '@sofie-automation/blueprints-integration'
-import { createSyncCustomPublicationMongoCollection } from '../../../lib/collections/lib'
+import { createSyncPeripheralDeviceCustomPublicationMongoCollection } from '../../../lib/collections/lib'
 import { StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { RoutedMappings } from '@sofie-automation/shared-lib/dist/core/model/Timeline'
+import { PeripheralDevicePubSubCollectionsNames } from '@sofie-automation/shared-lib/dist/pubsub/peripheralDevice'
 
-const StudioMappings = createSyncCustomPublicationMongoCollection(CustomCollectionName.StudioMappings)
+const StudioMappings = createSyncPeripheralDeviceCustomPublicationMongoCollection(
+	PeripheralDevicePubSubCollectionsNames.studioMappings
+)
 
 interface IMappingsViewProps {
 	match?: {
@@ -88,7 +91,7 @@ export const ComponentMappingsTable = withTracker<IMappingsTableProps, IMappings
 			}
 		}
 		componentDidMount(): void {
-			this.subscribe(PubSub.mappingsForStudio, this.props.studioId)
+			this.subscribe(MeteorPubSub.mappingsForStudio, this.props.studioId)
 		}
 		renderMappingsState(state: RoutedMappings) {
 			const rows = _.sortBy(Object.entries<MappingExt>(state.mappings), (o) => o[0])

--- a/meteor/client/ui/TestTools/Timeline.tsx
+++ b/meteor/client/ui/TestTools/Timeline.tsx
@@ -3,7 +3,7 @@ import { useSubscription, useTracker } from '../../lib/ReactMeteorData/react-met
 import * as _ from 'underscore'
 import { deserializeTimelineBlob, TimelineHash } from '@sofie-automation/corelib/dist/dataModel/Timeline'
 import { applyToArray, clone, normalizeArray, protectString } from '../../../lib/lib'
-import { CustomCollectionName, PubSub } from '../../../lib/api/pubsub'
+import { MeteorPubSub } from '../../../lib/api/pubsub'
 import {
 	TimelineState,
 	ResolvedTimelineObjectInstance,
@@ -20,10 +20,13 @@ import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router-dom'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import Classnames from 'classnames'
-import { createSyncCustomPublicationMongoCollection } from '../../../lib/collections/lib'
+import { createSyncPeripheralDeviceCustomPublicationMongoCollection } from '../../../lib/collections/lib'
 import { StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { PeripheralDevicePubSubCollectionsNames } from '@sofie-automation/shared-lib/dist/pubsub/peripheralDevice'
 
-export const StudioTimeline = createSyncCustomPublicationMongoCollection(CustomCollectionName.StudioTimeline)
+export const StudioTimeline = createSyncPeripheralDeviceCustomPublicationMongoCollection(
+	PeripheralDevicePubSubCollectionsNames.studioTimeline
+)
 
 interface TimelineViewRouteParams {
 	studioId: string | undefined
@@ -53,7 +56,7 @@ interface ITimelineSimulateProps {
 	studioId: StudioId
 }
 function ComponentTimelineSimulate({ studioId }: ITimelineSimulateProps) {
-	useSubscription(PubSub.timelineForStudio, studioId)
+	useSubscription(MeteorPubSub.timelineForStudio, studioId)
 
 	const now = useCurrentTime()
 	const tlComplete = useTracker(() => StudioTimeline.findOne(studioId), [studioId])

--- a/meteor/client/ui/TestTools/TimelineDatastore.tsx
+++ b/meteor/client/ui/TestTools/TimelineDatastore.tsx
@@ -3,11 +3,11 @@ import { useSubscription, useTracker } from '../../lib/ReactMeteorData/react-met
 import { StudioSelect } from './StudioSelect'
 import { Mongo } from 'meteor/mongo'
 import { DBTimelineDatastoreEntry } from '@sofie-automation/corelib/dist/dataModel/TimelineDatastore'
-import { PubSub } from '../../../lib/api/pubsub'
 import { protectString, unprotectString } from '@sofie-automation/corelib/dist/protectedString'
 import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router-dom'
 import { StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 const TimelineDatastore = new Mongo.Collection<DBTimelineDatastoreEntry>('timelineDatastore')
 
@@ -39,7 +39,7 @@ interface IDatastoreControlsProps {
 	studioId: StudioId
 }
 function ComponentDatastoreControls({ studioId }: IDatastoreControlsProps) {
-	useSubscription(PubSub.timelineDatastore, studioId)
+	useSubscription(CorelibPubSub.timelineDatastore, studioId)
 
 	const datastore = useTracker(() => TimelineDatastore.find().fetch(), [studioId])
 

--- a/meteor/client/ui/TestTools/index.tsx
+++ b/meteor/client/ui/TestTools/index.tsx
@@ -5,10 +5,11 @@ import { Route, Switch, NavLink, Redirect } from 'react-router-dom'
 
 import { TimelineView, TimelineStudioSelect } from './Timeline'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
-import { PubSub } from '../../../lib/api/pubsub'
+import { MeteorPubSub } from '../../../lib/api/pubsub'
 import { MappingsStudioSelect, MappingsView } from './Mappings'
 import { TimelineDatastoreStudioSelect, TimelineDatastoreView } from './TimelineDatastore'
 import { DeviceTriggersDeviceSelect, DeviceTriggersView } from './DeviceTriggers'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 interface IStatusMenuProps {
 	match?: any
@@ -62,9 +63,9 @@ class Status extends MeteorReactComponent<Translated<IStatusProps>> {
 	componentDidMount(): void {
 		// Subscribe to data:
 
-		this.subscribe(PubSub.uiStudio, null)
-		this.subscribe(PubSub.showStyleBases, {})
-		this.subscribe(PubSub.showStyleVariants, {})
+		this.subscribe(MeteorPubSub.uiStudio, null)
+		this.subscribe(CorelibPubSub.showStyleBases, {})
+		this.subscribe(CorelibPubSub.showStyleVariants, {})
 	}
 	render(): JSX.Element {
 		return (

--- a/meteor/client/ui/i18n.ts
+++ b/meteor/client/ui/i18n.ts
@@ -5,7 +5,7 @@ import Backend from 'i18next-http-backend'
 import LanguageDetector from 'i18next-browser-languagedetector'
 import { initReactI18next } from 'react-i18next'
 import { WithManagedTracker } from '../lib/reactiveData/reactiveDataHelper'
-import { PubSub } from '../../lib/api/pubsub'
+import { MeteorPubSub } from '../../lib/api/pubsub'
 import { Translation, TranslationsBundle } from '../../lib/collections/TranslationsBundles'
 import { I18NextData } from '@sofie-automation/blueprints-integration'
 import { MeteorCall } from '../../lib/api/methods'
@@ -103,7 +103,7 @@ class I18nContainer extends WithManagedTracker {
 			})
 			.catch(catchError('i18nInstance.init'))
 
-		this.subscribe(PubSub.translationsBundles, {})
+		this.subscribe(MeteorPubSub.translationsBundles, {})
 		this.autorun(() => {
 			const bundlesInfo = TranslationsBundles.find().fetch() as Omit<TranslationsBundle, 'data'>[]
 

--- a/meteor/lib/api/__tests__/pubsub.test.ts
+++ b/meteor/lib/api/__tests__/pubsub.test.ts
@@ -1,12 +1,24 @@
-import { PubSub } from '../pubsub'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
+import { MeteorPubSub } from '../pubsub'
+import { PeripheralDevicePubSub } from '@sofie-automation/shared-lib/dist/pubsub/peripheralDevice'
 
 describe('Pubsub', () => {
 	it('Ensures that PubSub values are unique', () => {
-		const values: { [key: string]: true } = {}
-		for (const key in PubSub) {
-			expect(values[key]).toBeFalsy()
-			values[key] = true
+		const values = new Set<string>()
+		const runForEnum = (enumType: any) => {
+			for (const key in enumType) {
+				if (values.has(key))
+					// Throw a meaningful error
+					throw new Error(`Key "${key}" is already defined`)
+
+				values.add(key)
+			}
 		}
-		expect(Object.keys(values).length).toBeGreaterThan(10)
+
+		runForEnum(MeteorPubSub)
+		runForEnum(CorelibPubSub)
+		runForEnum(PeripheralDevicePubSub)
+
+		expect(values.size).toBeGreaterThan(10)
 	})
 })

--- a/meteor/lib/api/pubsub.ts
+++ b/meteor/lib/api/pubsub.ts
@@ -72,7 +72,15 @@ export enum MeteorPubSub {
 	uiBucketContentStatuses = 'uiBucketContentStatuses',
 	uiBlueprintUpgradeStatuses = 'uiBlueprintUpgradeStatuses',
 }
-export type AllPubSub = MeteorPubSub | CorelibPubSub | PeripheralDevicePubSub
+
+/**
+ * Names of all the known DDP publications
+ */
+export const AllPubSubNames: string[] = [
+	...Object.values<string>(MeteorPubSub),
+	...Object.values<string>(CorelibPubSub),
+	...Object.values<string>(PeripheralDevicePubSub),
+]
 
 /**
  * Type definitions for all DDP subscriptions.

--- a/meteor/lib/api/pubsub.ts
+++ b/meteor/lib/api/pubsub.ts
@@ -1,50 +1,20 @@
-import { IngestDataCacheObj } from '@sofie-automation/corelib/dist/dataModel/IngestDataCache'
 import {
 	BucketId,
 	OrganizationId,
-	PeripheralDeviceId,
-	RundownId,
-	RundownPlaylistActivationId,
 	RundownPlaylistId,
 	ShowStyleBaseId,
 	StudioId,
 } from '@sofie-automation/corelib/dist/dataModel/Ids'
-import { DBTimelineDatastoreEntry } from '@sofie-automation/corelib/dist/dataModel/TimelineDatastore'
 import { Meteor } from 'meteor/meteor'
-import { AdLibAction } from '@sofie-automation/corelib/dist/dataModel/AdlibAction'
-import { AdLibPiece } from '@sofie-automation/corelib/dist/dataModel/AdLibPiece'
-import { Blueprint } from '@sofie-automation/corelib/dist/dataModel/Blueprint'
-import { BucketAdLibAction } from '@sofie-automation/corelib/dist/dataModel/BucketAdLibAction'
-import { BucketAdLib } from '@sofie-automation/corelib/dist/dataModel/BucketAdLibPiece'
 import { Bucket } from '../collections/Buckets'
 import { ICoreSystem } from '../collections/CoreSystem'
 import { Evaluation } from '../collections/Evaluations'
-import { ExpectedMediaItem } from '@sofie-automation/corelib/dist/dataModel/ExpectedMediaItem'
-import { ExpectedPackageDB } from '@sofie-automation/corelib/dist/dataModel/ExpectedPackages'
-import { ExpectedPackageWorkStatus } from '@sofie-automation/corelib/dist/dataModel/ExpectedPackageWorkStatuses'
 import { ExpectedPlayoutItem } from '@sofie-automation/corelib/dist/dataModel/ExpectedPlayoutItem'
-import { ExternalMessageQueueObj } from '@sofie-automation/corelib/dist/dataModel/ExternalMessageQueue'
 import { MediaWorkFlow } from '@sofie-automation/shared-lib/dist/core/model/MediaWorkFlows'
 import { MediaWorkFlowStep } from '@sofie-automation/shared-lib/dist/core/model/MediaWorkFlowSteps'
 import { DBOrganization } from '../collections/Organization'
-import { PackageContainerStatusDB } from '@sofie-automation/corelib/dist/dataModel/PackageContainerStatus'
-import { PartInstance } from '../collections/PartInstances'
-import { DBPart } from '@sofie-automation/corelib/dist/dataModel/Part'
-import { PeripheralDeviceCommand } from '@sofie-automation/corelib/dist/dataModel/PeripheralDeviceCommand'
-import { PeripheralDevice } from '@sofie-automation/corelib/dist/dataModel/PeripheralDevice'
-import { PieceInstance } from '@sofie-automation/corelib/dist/dataModel/PieceInstance'
-import { Piece } from '@sofie-automation/corelib/dist/dataModel/Piece'
-import { RundownBaselineAdLibAction } from '@sofie-automation/corelib/dist/dataModel/RundownBaselineAdLibAction'
-import { RundownBaselineAdLibItem } from '@sofie-automation/corelib/dist/dataModel/RundownBaselineAdLibPiece'
 import { RundownLayoutBase } from '../collections/RundownLayouts'
-import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
-import { DBRundown } from '@sofie-automation/corelib/dist/dataModel/Rundown'
-import { DBSegment } from '@sofie-automation/corelib/dist/dataModel/Segment'
-import { DBShowStyleBase } from '@sofie-automation/corelib/dist/dataModel/ShowStyleBase'
-import { DBShowStyleVariant } from '@sofie-automation/corelib/dist/dataModel/ShowStyleVariant'
 import { SnapshotItem } from '../collections/Snapshots'
-import { DBStudio } from '@sofie-automation/corelib/dist/dataModel/Studio'
-import { RoutedTimeline, TimelineComplete } from '@sofie-automation/corelib/dist/dataModel/Timeline'
 import { TranslationsBundle } from '../collections/TranslationsBundles'
 import { DBTriggeredActions, UITriggeredActionsObj } from '../collections/TriggeredActions'
 import { UserActionsLogItem } from '../collections/UserActionsLog'
@@ -53,53 +23,28 @@ import { UIBucketContentStatus, UIPieceContentStatus, UISegmentPartNote } from '
 import { UIShowStyleBase } from './showStyles'
 import { UIStudio } from './studios'
 import { UIDeviceTriggerPreview } from '../../server/publications/deviceTriggersPreview'
-import { DeviceTriggerMountedAction, PreviewWrappedAdLib } from './triggers/MountedTriggers'
-import { PeripheralDeviceForDevice } from '@sofie-automation/shared-lib/dist/core/model/peripheralDevice'
-import {
-	PackageManagerExpectedPackage,
-	PackageManagerPackageContainers,
-	PackageManagerPlayoutContext,
-} from '@sofie-automation/shared-lib/dist/package-manager/publications'
 import { MongoQuery } from '@sofie-automation/corelib/dist/mongo'
-import { RoutedMappings } from '@sofie-automation/shared-lib/dist/core/model/Timeline'
 import { logger } from '../logging'
 import { UIBlueprintUpgradeStatus } from './upgradeStatus'
+import {
+	PeripheralDevicePubSub,
+	PeripheralDevicePubSubTypes,
+	PeripheralDevicePubSubCollections,
+	PeripheralDevicePubSubCollectionsNames,
+} from '@sofie-automation/shared-lib/dist/pubsub/peripheralDevice'
+import { CorelibPubSub, CorelibPubSubCollections, CorelibPubSubTypes } from '@sofie-automation/corelib/dist/pubsub'
+import { CollectionName } from '@sofie-automation/corelib/dist/dataModel/Collections'
 
 /**
  * Ids of possible DDP subscriptions
  */
-export enum PubSub {
-	blueprints = 'blueprints',
+export enum MeteorPubSub {
 	coreSystem = 'coreSystem',
 	evaluations = 'evaluations',
 	expectedPlayoutItems = 'expectedPlayoutItems',
-	expectedMediaItems = 'expectedMediaItems',
-	externalMessageQueue = 'externalMessageQueue',
-	peripheralDeviceCommands = 'peripheralDeviceCommands',
-	peripheralDevices = 'peripheralDevices',
-	peripheralDevicesAndSubDevices = ' peripheralDevicesAndSubDevices',
-	rundownBaselineAdLibPieces = 'rundownBaselineAdLibPieces',
-	rundownBaselineAdLibActions = 'rundownBaselineAdLibActions',
-	ingestDataCache = 'ingestDataCache',
-	rundownPlaylists = 'rundownPlaylists',
-	rundowns = 'rundowns',
-	adLibActions = 'adLibActions',
-	adLibPieces = 'adLibPieces',
-	pieces = 'pieces',
-	pieceInstances = 'pieceInstances',
-	pieceInstancesSimple = 'pieceInstancesSimple',
-	parts = 'parts',
-	partInstances = 'partInstances',
-	partInstancesSimple = 'partInstancesSimple',
-	partInstancesForSegmentPlayout = 'partInstancesForSegmentPlayout',
-	segments = 'segments',
-	showStyleBases = 'showStyleBases',
-	showStyleVariants = 'showStyleVariants',
+
 	triggeredActions = 'triggeredActions',
 	snapshots = 'snapshots',
-	studios = 'studios',
-	timeline = 'timeline',
-	timelineDatastore = 'timelineDatastore',
 	userActionsLog = 'userActionsLog',
 	/** @deprecated */
 	mediaWorkFlows = 'mediaWorkFlows',
@@ -110,22 +55,9 @@ export enum PubSub {
 	usersInOrganization = 'usersInOrganization',
 	organization = 'organization',
 	buckets = 'buckets',
-	bucketAdLibPieces = 'bucketAdLibPieces',
 	translationsBundles = 'translationsBundles',
-	bucketAdLibActions = 'bucketAdLibActions',
-	expectedPackages = 'expectedPackages',
-	expectedPackageWorkStatuses = 'expectedPackageWorkStatuses',
-	packageContainerStatuses = 'packageContainerStatuses',
-	packageInfos = 'packageInfos',
-
-	// For a PeripheralDevice
-	rundownsForDevice = 'rundownsForDevice',
 
 	// custom publications:
-	peripheralDeviceForDevice = 'peripheralDeviceForDevice',
-	mappingsForDevice = 'mappingsForDevice',
-	timelineForDevice = 'timelineForDevice',
-	timelineDatastoreForDevice = 'timelineDatastoreForDevice',
 	mappingsForStudio = 'mappingsForStudio',
 	timelineForStudio = 'timelineForStudio',
 
@@ -133,187 +65,139 @@ export enum PubSub {
 	uiStudio = 'uiStudio',
 	uiTriggeredActions = 'uiTriggeredActions',
 
-	mountedTriggersForDevice = 'mountedTriggersForDevice',
-	mountedTriggersForDevicePreview = 'mountedTriggersForDevicePreview',
 	deviceTriggersPreview = 'deviceTriggersPreview',
 
 	uiSegmentPartNotes = 'uiSegmentPartNotes',
 	uiPieceContentStatuses = 'uiPieceContentStatuses',
 	uiBucketContentStatuses = 'uiBucketContentStatuses',
 	uiBlueprintUpgradeStatuses = 'uiBlueprintUpgradeStatuses',
-
-	packageManagerPlayoutContext = 'packageManagerPlayoutContext',
-	packageManagerPackageContainers = 'packageManagerPackageContainers',
-	packageManagerExpectedPackages = 'packageManagerExpectedPackages',
 }
+export type AllPubSub = MeteorPubSub | CorelibPubSub | PeripheralDevicePubSub
 
 /**
  * Type definitions for all DDP subscriptions.
  * All the PubSub ids must be present here, or they will produce type errors when used
  */
-export interface PubSubTypes {
-	[PubSub.blueprints]: (selector: MongoQuery<Blueprint>, token?: string) => Blueprint
-	[PubSub.coreSystem]: (token?: string) => ICoreSystem
-	[PubSub.evaluations]: (selector: MongoQuery<Evaluation>, token?: string) => Evaluation
-	[PubSub.expectedPlayoutItems]: (selector: MongoQuery<ExpectedPlayoutItem>, token?: string) => ExpectedPlayoutItem
-	[PubSub.expectedMediaItems]: (selector: MongoQuery<ExpectedMediaItem>, token?: string) => ExpectedMediaItem
-	[PubSub.externalMessageQueue]: (
-		selector: MongoQuery<ExternalMessageQueueObj>,
-		token?: string
-	) => ExternalMessageQueueObj
-	[PubSub.peripheralDeviceCommands]: (deviceId: PeripheralDeviceId, token?: string) => PeripheralDeviceCommand
-	[PubSub.peripheralDevices]: (selector: MongoQuery<PeripheralDevice>, token?: string) => PeripheralDevice
-	[PubSub.peripheralDevicesAndSubDevices]: (selector: MongoQuery<PeripheralDevice>) => PeripheralDevice
-	[PubSub.rundownBaselineAdLibPieces]: (
-		selector: MongoQuery<RundownBaselineAdLibItem>,
-		token?: string
-	) => RundownBaselineAdLibItem
-	[PubSub.rundownBaselineAdLibActions]: (
-		selector: MongoQuery<RundownBaselineAdLibAction>,
-		token?: string
-	) => RundownBaselineAdLibAction
-	[PubSub.ingestDataCache]: (selector: MongoQuery<IngestDataCacheObj>, token?: string) => IngestDataCacheObj
-	[PubSub.rundownPlaylists]: (selector: MongoQuery<DBRundownPlaylist>, token?: string) => DBRundownPlaylist
-	[PubSub.rundowns]: (
-		/** RundownPlaylistId to fetch for, or null to not check */
-		playlistIds: RundownPlaylistId[] | null,
-		/** ShowStyleBaseId to fetch for, or null to not check */
-		showStyleBaseIds: ShowStyleBaseId[] | null,
-		token?: string
-	) => DBRundown
-	[PubSub.adLibActions]: (selector: MongoQuery<AdLibAction>, token?: string) => AdLibAction
-	[PubSub.adLibPieces]: (selector: MongoQuery<AdLibPiece>, token?: string) => AdLibPiece
-	[PubSub.pieces]: (selector: MongoQuery<Piece>, token?: string) => Piece
-	[PubSub.pieceInstances]: (selector: MongoQuery<PieceInstance>, token?: string) => PieceInstance
-	[PubSub.pieceInstancesSimple]: (selector: MongoQuery<PieceInstance>, token?: string) => PieceInstance
-	[PubSub.parts]: (rundownIds: RundownId[], token?: string) => DBPart
-	[PubSub.partInstances]: (
-		rundownIds: RundownId[],
-		playlistActivationId: RundownPlaylistActivationId | undefined,
-		token?: string
-	) => PartInstance
-	[PubSub.partInstancesSimple]: (selector: MongoQuery<PartInstance>, token?: string) => PartInstance
-	[PubSub.partInstancesForSegmentPlayout]: (selector: MongoQuery<PartInstance>, token?: string) => PartInstance
-	[PubSub.segments]: (selector: MongoQuery<DBSegment>, token?: string) => DBSegment
-	[PubSub.showStyleBases]: (selector: MongoQuery<DBShowStyleBase>, token?: string) => DBShowStyleBase
-	[PubSub.showStyleVariants]: (selector: MongoQuery<DBShowStyleVariant>, token?: string) => DBShowStyleVariant
-	[PubSub.triggeredActions]: (selector: MongoQuery<DBTriggeredActions>, token?: string) => DBTriggeredActions
-	[PubSub.snapshots]: (selector: MongoQuery<SnapshotItem>, token?: string) => SnapshotItem
-	[PubSub.studios]: (selector: MongoQuery<DBStudio>, token?: string) => DBStudio
-	[PubSub.timeline]: (selector: MongoQuery<TimelineComplete>, token?: string) => TimelineComplete
-	[PubSub.timelineDatastore]: (studioId: StudioId, token?: string) => DBTimelineDatastoreEntry
-	[PubSub.userActionsLog]: (selector: MongoQuery<UserActionsLogItem>, token?: string) => UserActionsLogItem
-	/** @deprecated */
-	[PubSub.mediaWorkFlows]: (selector: MongoQuery<MediaWorkFlow>, token?: string) => MediaWorkFlow
-	/** @deprecated */
-	[PubSub.mediaWorkFlowSteps]: (selector: MongoQuery<MediaWorkFlowStep>, token?: string) => MediaWorkFlowStep
-	[PubSub.rundownLayouts]: (selector: MongoQuery<RundownLayoutBase>, token?: string) => RundownLayoutBase
-	[PubSub.loggedInUser]: (token?: string) => DBUser
-	[PubSub.usersInOrganization]: (selector: MongoQuery<DBUser>, token?: string) => DBUser
-	[PubSub.organization]: (organizationId: OrganizationId | null, token?: string) => DBOrganization
-	[PubSub.buckets]: (studioId: StudioId, bucketId: BucketId | null, token?: string) => Bucket
-	[PubSub.bucketAdLibPieces]: (selector: MongoQuery<BucketAdLib>, token?: string) => BucketAdLib
-	[PubSub.bucketAdLibActions]: (selector: MongoQuery<BucketAdLibAction>, token?: string) => BucketAdLibAction
-	[PubSub.translationsBundles]: (selector: MongoQuery<TranslationsBundle>, token?: string) => TranslationsBundle
-	[PubSub.expectedPackages]: (selector: MongoQuery<ExpectedPackageDB>, token?: string) => ExpectedPackageDB
-	[PubSub.expectedPackageWorkStatuses]: (
-		selector: MongoQuery<ExpectedPackageWorkStatus>,
-		token?: string
-	) => ExpectedPackageWorkStatus
-	[PubSub.packageContainerStatuses]: (
-		selector: MongoQuery<PackageContainerStatusDB>,
-		token?: string
-	) => PackageContainerStatusDB
+export type AllPubSubTypes = CorelibPubSubTypes & PeripheralDevicePubSubTypes & MeteorPubSubTypes
 
-	// For a PeripheralDevice
-	[PubSub.rundownsForDevice]: (deviceId: PeripheralDeviceId, token: string) => DBRundown
+export interface MeteorPubSubTypes {
+	[MeteorPubSub.coreSystem]: (token?: string) => CollectionName.CoreSystem
+	[MeteorPubSub.evaluations]: (selector: MongoQuery<Evaluation>, token?: string) => CollectionName.Evaluations
+	[MeteorPubSub.expectedPlayoutItems]: (
+		selector: MongoQuery<ExpectedPlayoutItem>,
+		token?: string
+	) => CollectionName.ExpectedPlayoutItems
+
+	[MeteorPubSub.triggeredActions]: (
+		selector: MongoQuery<DBTriggeredActions>,
+		token?: string
+	) => CollectionName.TriggeredActions
+	[MeteorPubSub.snapshots]: (selector: MongoQuery<SnapshotItem>, token?: string) => CollectionName.Snapshots
+	[MeteorPubSub.userActionsLog]: (
+		selector: MongoQuery<UserActionsLogItem>,
+		token?: string
+	) => CollectionName.UserActionsLog
+	/** @deprecated */
+	[MeteorPubSub.mediaWorkFlows]: (
+		selector: MongoQuery<MediaWorkFlow>,
+		token?: string
+	) => CollectionName.MediaWorkFlows
+	/** @deprecated */
+	[MeteorPubSub.mediaWorkFlowSteps]: (
+		selector: MongoQuery<MediaWorkFlowStep>,
+		token?: string
+	) => CollectionName.MediaWorkFlowSteps
+	[MeteorPubSub.rundownLayouts]: (
+		selector: MongoQuery<RundownLayoutBase>,
+		token?: string
+	) => CollectionName.RundownLayouts
+	[MeteorPubSub.loggedInUser]: (token?: string) => CollectionName.Users
+	[MeteorPubSub.usersInOrganization]: (selector: MongoQuery<DBUser>, token?: string) => CollectionName.Users
+	[MeteorPubSub.organization]: (organizationId: OrganizationId | null, token?: string) => CollectionName.Organizations
+	[MeteorPubSub.buckets]: (studioId: StudioId, bucketId: BucketId | null, token?: string) => CollectionName.Buckets
+	[MeteorPubSub.translationsBundles]: (
+		selector: MongoQuery<TranslationsBundle>,
+		token?: string
+	) => CollectionName.TranslationsBundles
 
 	// custom publications:
-	[PubSub.peripheralDeviceForDevice]: (deviceId: PeripheralDeviceId, token?: string) => PeripheralDeviceForDevice
-	[PubSub.mappingsForDevice]: (deviceId: PeripheralDeviceId, token?: string) => RoutedMappings
-	[PubSub.timelineForDevice]: (deviceId: PeripheralDeviceId, token?: string) => RoutedTimeline
-	[PubSub.timelineDatastoreForDevice]: (deviceId: PeripheralDeviceId, token?: string) => DBTimelineDatastoreEntry
-	[PubSub.mappingsForStudio]: (studioId: StudioId, token?: string) => RoutedMappings
-	[PubSub.timelineForStudio]: (studioId: StudioId, token?: string) => RoutedTimeline
-	[PubSub.uiShowStyleBase]: (showStyleBaseId: ShowStyleBaseId) => UIShowStyleBase
-	/** Subscribe to one or all studios */
-	[PubSub.uiStudio]: (studioId: StudioId | null) => UIStudio
-	[PubSub.uiTriggeredActions]: (showStyleBaseId: ShowStyleBaseId | null) => UITriggeredActionsObj
 
-	[PubSub.mountedTriggersForDevice]: (
-		deviceId: PeripheralDeviceId,
-		deviceIds: string[],
+	[MeteorPubSub.mappingsForStudio]: (
+		studioId: StudioId,
 		token?: string
-	) => DeviceTriggerMountedAction
-	[PubSub.mountedTriggersForDevicePreview]: (deviceId: PeripheralDeviceId, token?: string) => PreviewWrappedAdLib
-	[PubSub.deviceTriggersPreview]: (studioId: StudioId, token?: string) => UIDeviceTriggerPreview
+	) => PeripheralDevicePubSubCollectionsNames.studioMappings
+	[MeteorPubSub.timelineForStudio]: (
+		studioId: StudioId,
+		token?: string
+	) => PeripheralDevicePubSubCollectionsNames.studioTimeline
+	[MeteorPubSub.uiShowStyleBase]: (showStyleBaseId: ShowStyleBaseId) => CustomCollectionName.UIShowStyleBase
+	/** Subscribe to one or all studios */
+	[MeteorPubSub.uiStudio]: (studioId: StudioId | null) => CustomCollectionName.UIStudio
+	[MeteorPubSub.uiTriggeredActions]: (
+		showStyleBaseId: ShowStyleBaseId | null
+	) => CustomCollectionName.UITriggeredActions
+
+	[MeteorPubSub.deviceTriggersPreview]: (
+		studioId: StudioId,
+		token?: string
+	) => CustomCollectionName.UIDeviceTriggerPreviews
 
 	/** Custom publications for the UI */
-	[PubSub.uiSegmentPartNotes]: (playlistId: RundownPlaylistId | null) => UISegmentPartNote
-	[PubSub.uiPieceContentStatuses]: (rundownPlaylistId: RundownPlaylistId | null) => UIPieceContentStatus
-	[PubSub.uiBucketContentStatuses]: (studioId: StudioId, bucketId: BucketId) => UIBucketContentStatus
-	[PubSub.uiBlueprintUpgradeStatuses]: () => UIBlueprintUpgradeStatus
-
-	/** Custom publications for package-manager */
-	[PubSub.packageManagerPlayoutContext]: (
-		deviceId: PeripheralDeviceId,
-		token: string | undefined
-	) => PackageManagerPlayoutContext
-	[PubSub.packageManagerPackageContainers]: (
-		deviceId: PeripheralDeviceId,
-		token: string | undefined
-	) => PackageManagerPackageContainers
-	[PubSub.packageManagerExpectedPackages]: (
-		deviceId: PeripheralDeviceId,
-		filterPlayoutDeviceIds: PeripheralDeviceId[] | undefined,
-		token: string | undefined
-	) => PackageManagerExpectedPackage
+	[MeteorPubSub.uiSegmentPartNotes]: (playlistId: RundownPlaylistId | null) => CustomCollectionName.UISegmentPartNotes
+	[MeteorPubSub.uiPieceContentStatuses]: (
+		rundownPlaylistId: RundownPlaylistId | null
+	) => CustomCollectionName.UIPieceContentStatuses
+	[MeteorPubSub.uiBucketContentStatuses]: (
+		studioId: StudioId,
+		bucketId: BucketId
+	) => CustomCollectionName.UIBucketContentStatuses
+	[MeteorPubSub.uiBlueprintUpgradeStatuses]: () => CustomCollectionName.UIBlueprintUpgradeStatuses
 }
+
+export type AllPubSubCollections = PeripheralDevicePubSubCollections &
+	CorelibPubSubCollections &
+	MeteorPubSubCollections
 
 /**
  * Ids of possible Custom collections, populated by DDP subscriptions
  */
 export enum CustomCollectionName {
-	PeripheralDeviceForDevice = 'peripheralDeviceForDevice',
-	StudioMappings = 'studioMappings',
-	StudioTimeline = 'studioTimeline',
 	UIShowStyleBase = 'uiShowStyleBase',
 	UIStudio = 'uiStudio',
 	UITriggeredActions = 'uiTriggeredActions',
 	UIDeviceTriggerPreviews = 'deviceTriggerPreviews',
-	MountedTriggers = 'mountedTriggers',
-	MountedTriggersPreviews = 'mountedTriggersPreviews',
 	UISegmentPartNotes = 'uiSegmentPartNotes',
 	UIPieceContentStatuses = 'uiPieceContentStatuses',
 	UIBucketContentStatuses = 'uiBucketContentStatuses',
 	UIBlueprintUpgradeStatuses = 'uiBlueprintUpgradeStatuses',
-
-	PackageManagerPlayoutContext = 'packageManagerPlayoutContext',
-	PackageManagerPackageContainers = 'packageManagerPackageContainers',
-	PackageManagerExpectedPackages = 'packageManagerExpectedPackages',
 }
 
-/**
- * Type definitions for all custom collections.
- * All the CustomCollectionName ids must be present here, or they will produce type errors when used
- */
-export type CustomCollectionType = {
-	[CustomCollectionName.PeripheralDeviceForDevice]: PeripheralDeviceForDevice
-	[CustomCollectionName.StudioMappings]: RoutedMappings
-	[CustomCollectionName.StudioTimeline]: RoutedTimeline
+export type MeteorPubSubCollections = {
+	[CollectionName.CoreSystem]: ICoreSystem
+	[CollectionName.Evaluations]: Evaluation
+	[CollectionName.TriggeredActions]: DBTriggeredActions
+	[CollectionName.Snapshots]: SnapshotItem
+	[CollectionName.UserActionsLog]: UserActionsLogItem
+	[CollectionName.RundownLayouts]: RundownLayoutBase
+	[CollectionName.Organizations]: DBOrganization
+	[CollectionName.Buckets]: Bucket
+	[CollectionName.TranslationsBundles]: TranslationsBundle
+	[CollectionName.Users]: DBUser
+	[CollectionName.ExpectedPlayoutItems]: ExpectedPlayoutItem
+
+	[CollectionName.MediaWorkFlows]: MediaWorkFlow
+	[CollectionName.MediaWorkFlowSteps]: MediaWorkFlowStep
+} & MeteorPubSubCustomCollections
+
+export type MeteorPubSubCustomCollections = {
 	[CustomCollectionName.UIShowStyleBase]: UIShowStyleBase
 	[CustomCollectionName.UIStudio]: UIStudio
 	[CustomCollectionName.UITriggeredActions]: UITriggeredActionsObj
 	[CustomCollectionName.UIDeviceTriggerPreviews]: UIDeviceTriggerPreview
-	[CustomCollectionName.MountedTriggers]: DeviceTriggerMountedAction
-	[CustomCollectionName.MountedTriggersPreviews]: PreviewWrappedAdLib
 	[CustomCollectionName.UISegmentPartNotes]: UISegmentPartNote
 	[CustomCollectionName.UIPieceContentStatuses]: UIPieceContentStatus
 	[CustomCollectionName.UIBucketContentStatuses]: UIBucketContentStatus
 	[CustomCollectionName.UIBlueprintUpgradeStatuses]: UIBlueprintUpgradeStatus
-	[CustomCollectionName.PackageManagerPlayoutContext]: PackageManagerPlayoutContext
-	[CustomCollectionName.PackageManagerPackageContainers]: PackageManagerPackageContainers
-	[CustomCollectionName.PackageManagerExpectedPackages]: PackageManagerExpectedPackage
 }
 
 /**
@@ -322,9 +206,9 @@ export type CustomCollectionType = {
  * @param args arguments to the subscription
  * @returns Meteor subscription handle
  */
-export function meteorSubscribe<K extends keyof PubSubTypes>(
+export function meteorSubscribe<K extends keyof AllPubSubTypes>(
 	name: K,
-	...args: Parameters<PubSubTypes[K]>
+	...args: Parameters<AllPubSubTypes[K]>
 ): Meteor.SubscriptionHandle {
 	if (Meteor.isClient) {
 		const callbacks = {

--- a/meteor/lib/collections/lib.ts
+++ b/meteor/lib/collections/lib.ts
@@ -5,7 +5,11 @@ import { stringifyError } from '@sofie-automation/shared-lib/dist/lib/stringifyE
 import type { Collection as RawCollection, Db as RawDb } from 'mongodb'
 import { CollectionName } from '@sofie-automation/corelib/dist/dataModel/Collections'
 import { MongoFieldSpecifier, MongoModifier, MongoQuery, SortSpecifier } from '@sofie-automation/corelib/dist/mongo'
-import { CustomCollectionName, CustomCollectionType } from '../api/pubsub'
+import { CustomCollectionName, MeteorPubSubCustomCollections } from '../api/pubsub'
+import {
+	PeripheralDevicePubSubCollections,
+	PeripheralDevicePubSubCollectionsNames,
+} from '@sofie-automation/shared-lib/dist/pubsub/peripheralDevice'
 
 export const ClientCollections = new Map<CollectionName, MongoCollection<any> | WrappedMongoReadOnlyCollection<any>>()
 function registerClientCollection(
@@ -16,7 +20,10 @@ function registerClientCollection(
 	ClientCollections.set(name, collection)
 }
 
-export const PublicationCollections = new Map<CustomCollectionName, WrappedMongoReadOnlyCollection<any>>()
+export const PublicationCollections = new Map<
+	CustomCollectionName | PeripheralDevicePubSubCollectionsNames,
+	WrappedMongoReadOnlyCollection<any>
+>()
 
 /**
  * Map of current collection objects.
@@ -95,11 +102,23 @@ export function createSyncReadOnlyMongoCollection<DBInterface extends { _id: Pro
  * Create a Mongo Collection for a virtual collection populated by a custom-publication
  * @param name Name of the custom-collection
  */
-export function createSyncCustomPublicationMongoCollection<K extends keyof CustomCollectionType>(
-	name: K
-): MongoReadOnlyCollection<CustomCollectionType[K]> {
-	const collection = new Mongo.Collection<CustomCollectionType[K]>(name)
-	const wrapped = new WrappedMongoReadOnlyCollection<CustomCollectionType[K]>(collection, name)
+export function createSyncCustomPublicationMongoCollection<
+	K extends CustomCollectionName & keyof MeteorPubSubCustomCollections
+>(name: K): MongoReadOnlyCollection<MeteorPubSubCustomCollections[K]> {
+	const collection = new Mongo.Collection<MeteorPubSubCustomCollections[K]>(name)
+	const wrapped = new WrappedMongoReadOnlyCollection<MeteorPubSubCustomCollections[K]>(collection, name)
+
+	if (PublicationCollections.has(name)) throw new Meteor.Error(`Cannot re-register collection "${name}"`)
+	PublicationCollections.set(name, wrapped)
+
+	return wrapped
+}
+
+export function createSyncPeripheralDeviceCustomPublicationMongoCollection<
+	K extends PeripheralDevicePubSubCollectionsNames & keyof PeripheralDevicePubSubCollections
+>(name: K): MongoReadOnlyCollection<PeripheralDevicePubSubCollections[K]> {
+	const collection = new Mongo.Collection<PeripheralDevicePubSubCollections[K]>(name)
+	const wrapped = new WrappedMongoReadOnlyCollection<PeripheralDevicePubSubCollections[K]>(collection, name)
 
 	if (PublicationCollections.has(name)) throw new Meteor.Error(`Cannot re-register collection "${name}"`)
 	PublicationCollections.set(name, wrapped)

--- a/meteor/server/api/rest/v0/index.ts
+++ b/meteor/server/api/rest/v0/index.ts
@@ -115,13 +115,13 @@ export function createLegacyApiRouter(): KoaRouter {
 	}
 
 	// Expose publications:
-	for (const [pubName, pubValue] of Object.entries<any>(MeteorPubSub)) {
+	for (const [pubName, pubValue] of Object.entries<string>(MeteorPubSub)) {
 		exposePublication(pubName, pubValue)
 	}
-	for (const [pubName, pubValue] of Object.entries<any>(CorelibPubSub)) {
+	for (const [pubName, pubValue] of Object.entries<string>(CorelibPubSub)) {
 		exposePublication(pubName, pubValue)
 	}
-	for (const [pubName, pubValue] of Object.entries<any>(PeripheralDevicePubSub)) {
+	for (const [pubName, pubValue] of Object.entries<string>(PeripheralDevicePubSub)) {
 		exposePublication(pubName, pubValue)
 	}
 

--- a/meteor/server/api/rest/v0/index.ts
+++ b/meteor/server/api/rest/v0/index.ts
@@ -7,13 +7,15 @@
 import * as _ from 'underscore'
 import { Meteor } from 'meteor/meteor'
 import { MeteorMethodSignatures } from '../../../methods'
-import { PubSub } from '../../../../lib/api/pubsub'
+import { MeteorPubSub } from '../../../../lib/api/pubsub'
 import { MeteorPublications, MeteorPublicationSignatures } from '../../../publications/lib'
 import { UserActionAPIMethods } from '../../../../lib/api/userActions'
 import { logger } from '../../../../lib/logging'
 import { ClientAPI } from '../../../../lib/api/client'
 import Koa from 'koa'
 import KoaRouter from '@koa/router'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
+import { PeripheralDevicePubSub } from '@sofie-automation/shared-lib/dist/pubsub/peripheralDevice'
 
 const LEGACY_API_VERSION = 0
 
@@ -82,8 +84,7 @@ export function createLegacyApiRouter(): KoaRouter {
 		})
 	}
 
-	// Expose publications:
-	for (const [pubName, pubValue] of Object.entries<any>(PubSub)) {
+	function exposePublication(pubName: string, pubValue: string) {
 		const signature = MeteorPublicationSignatures[pubValue] || []
 
 		const f = MeteorPublications[pubValue]
@@ -111,6 +112,17 @@ export function createLegacyApiRouter(): KoaRouter {
 				return []
 			})
 		}
+	}
+
+	// Expose publications:
+	for (const [pubName, pubValue] of Object.entries<any>(MeteorPubSub)) {
+		exposePublication(pubName, pubValue)
+	}
+	for (const [pubName, pubValue] of Object.entries<any>(CorelibPubSub)) {
+		exposePublication(pubName, pubValue)
+	}
+	for (const [pubName, pubValue] of Object.entries<any>(PeripheralDevicePubSub)) {
+		exposePublication(pubName, pubValue)
 	}
 
 	router.get('/', async (ctx) => {

--- a/meteor/server/publications/_publications.ts
+++ b/meteor/server/publications/_publications.ts
@@ -25,25 +25,17 @@ import './triggeredActionsUI'
 import './mountedTriggers'
 import './deviceTriggersPreview'
 
-import { MeteorPubSub } from '../../lib/api/pubsub'
-import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
-import { PeripheralDevicePubSub } from '@sofie-automation/shared-lib/dist/pubsub/peripheralDevice'
+import { AllPubSubNames } from '../../lib/api/pubsub'
 import { MeteorPublications } from './lib'
 import { logger } from '../logging'
 
 // Ensure all the publications were registered at startup
 if (Meteor.isDevelopment) {
-	function checkPublications(pubNames: string[]) {
-		for (const pubName of pubNames) {
+	Meteor.startup(() => {
+		for (const pubName of AllPubSubNames) {
 			if (!MeteorPublications[pubName]) {
 				logger.error(`Publication "${pubName}" is not setup!`)
 			}
 		}
-	}
-
-	Meteor.startup(() => {
-		checkPublications(Object.values<string>(MeteorPubSub))
-		checkPublications(Object.values<string>(CorelibPubSub))
-		checkPublications(Object.values<string>(PeripheralDevicePubSub))
 	})
 }

--- a/meteor/server/publications/_publications.ts
+++ b/meteor/server/publications/_publications.ts
@@ -1,3 +1,4 @@
+import { Meteor } from 'meteor/meteor'
 import './lib'
 
 import './buckets'
@@ -23,3 +24,26 @@ import './translationsBundles'
 import './triggeredActionsUI'
 import './mountedTriggers'
 import './deviceTriggersPreview'
+
+import { MeteorPubSub } from '../../lib/api/pubsub'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
+import { PeripheralDevicePubSub } from '@sofie-automation/shared-lib/dist/pubsub/peripheralDevice'
+import { MeteorPublications } from './lib'
+import { logger } from '../logging'
+
+// Ensure all the publications were registered at startup
+if (Meteor.isDevelopment) {
+	function checkPublications(pubNames: string[]) {
+		for (const pubName of pubNames) {
+			if (!MeteorPublications[pubName]) {
+				logger.error(`Publication "${pubName}" is not setup!`)
+			}
+		}
+	}
+
+	Meteor.startup(() => {
+		checkPublications(Object.values<string>(MeteorPubSub))
+		checkPublications(Object.values<string>(CorelibPubSub))
+		checkPublications(Object.values<string>(PeripheralDevicePubSub))
+	})
+}

--- a/meteor/server/publications/blueprintUpgradeStatus/publication.ts
+++ b/meteor/server/publications/blueprintUpgradeStatus/publication.ts
@@ -1,7 +1,7 @@
 import { BlueprintId, ShowStyleBaseId, StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { MongoFieldSpecifierOnesStrict } from '@sofie-automation/corelib/dist/mongo'
 import { ReadonlyDeep } from 'type-fest'
-import { CustomCollectionName, PubSub } from '../../../lib/api/pubsub'
+import { CustomCollectionName, MeteorPubSub } from '../../../lib/api/pubsub'
 import { literal, ProtectedString, protectString } from '../../../lib/lib'
 import {
 	CustomPublish,
@@ -238,7 +238,7 @@ export async function createBlueprintUpgradeStatusSubscriptionHandle(
 		BlueprintUpgradeStatusState,
 		BlueprintUpgradeStatusUpdateProps
 	>(
-		`pub_${PubSub.uiBlueprintUpgradeStatuses}`,
+		`pub_${MeteorPubSub.uiBlueprintUpgradeStatuses}`,
 		{},
 		setupBlueprintUpgradeStatusPublicationObservers,
 		manipulateBlueprintUpgradeStatusPublicationData,
@@ -248,7 +248,7 @@ export async function createBlueprintUpgradeStatusSubscriptionHandle(
 }
 
 meteorCustomPublish(
-	PubSub.uiBlueprintUpgradeStatuses,
+	MeteorPubSub.uiBlueprintUpgradeStatuses,
 	CustomCollectionName.UIBlueprintUpgradeStatuses,
 	async function (pub) {
 		const cred = await resolveCredentials({ userId: this.userId, token: undefined })

--- a/meteor/server/publications/buckets.ts
+++ b/meteor/server/publications/buckets.ts
@@ -2,7 +2,7 @@ import { Meteor } from 'meteor/meteor'
 import { FindOptions } from '../../lib/collections/lib'
 import { BucketSecurity } from '../security/buckets'
 import { meteorPublish } from './lib'
-import { PubSub } from '../../lib/api/pubsub'
+import { MeteorPubSub } from '../../lib/api/pubsub'
 import { Bucket } from '../../lib/collections/Buckets'
 import { BucketAdLib } from '@sofie-automation/corelib/dist/dataModel/BucketAdLibPiece'
 import { BucketAdLibAction } from '@sofie-automation/corelib/dist/dataModel/BucketAdLibAction'
@@ -12,9 +12,10 @@ import { BucketAdLibActions, BucketAdLibs, Buckets } from '../collections'
 import { check, Match } from 'meteor/check'
 import { MongoQuery } from '@sofie-automation/corelib/dist/mongo'
 import { StudioId, BucketId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 meteorPublish(
-	PubSub.buckets,
+	MeteorPubSub.buckets,
 	async function (studioId: StudioId, bucketId: BucketId | null, _token: string | undefined) {
 		check(studioId, String)
 		check(bucketId, Match.Maybe(String))
@@ -42,21 +43,24 @@ meteorPublish(
 	}
 )
 
-meteorPublish(PubSub.bucketAdLibPieces, async function (selector: MongoQuery<BucketAdLib>, _token: string | undefined) {
-	if (!selector) throw new Meteor.Error(400, 'selector argument missing')
-	const modifier: FindOptions<BucketAdLib> = {
-		fields: {
-			ingestInfo: 0, // This is a large blob, and is not of interest to the UI
-		},
+meteorPublish(
+	CorelibPubSub.bucketAdLibPieces,
+	async function (selector: MongoQuery<BucketAdLib>, _token: string | undefined) {
+		if (!selector) throw new Meteor.Error(400, 'selector argument missing')
+		const modifier: FindOptions<BucketAdLib> = {
+			fields: {
+				ingestInfo: 0, // This is a large blob, and is not of interest to the UI
+			},
+		}
+		if (isProtectedString(selector.bucketId) && (await BucketSecurity.allowReadAccess(this, selector.bucketId))) {
+			return BucketAdLibs.findWithCursor(selector, modifier)
+		}
+		return null
 	}
-	if (isProtectedString(selector.bucketId) && (await BucketSecurity.allowReadAccess(this, selector.bucketId))) {
-		return BucketAdLibs.findWithCursor(selector, modifier)
-	}
-	return null
-})
+)
 
 meteorPublish(
-	PubSub.bucketAdLibActions,
+	CorelibPubSub.bucketAdLibActions,
 	async function (selector: MongoQuery<BucketAdLibAction>, _token: string | undefined) {
 		if (!selector) throw new Meteor.Error(400, 'selector argument missing')
 		const modifier: FindOptions<BucketAdLibAction> = {

--- a/meteor/server/publications/deviceTriggersPreview.ts
+++ b/meteor/server/publications/deviceTriggersPreview.ts
@@ -4,7 +4,7 @@ import { ProtectedString, unprotectString } from '@sofie-automation/corelib/dist
 import { check } from 'meteor/check'
 import { Meteor } from 'meteor/meteor'
 import { ReadonlyDeep } from 'type-fest'
-import { CustomCollectionName, PubSub } from '../../lib/api/pubsub'
+import { CustomCollectionName, MeteorPubSub } from '../../lib/api/pubsub'
 import { DeviceTriggerArguments } from '../../lib/api/triggers/MountedTriggers'
 import { getCurrentTime } from '../../lib/lib'
 import { setUpOptimizedObserverArray, TriggerUpdate } from '../lib/customPublication'
@@ -28,7 +28,7 @@ export interface UIDeviceTriggerPreview {
 }
 
 meteorCustomPublish(
-	PubSub.deviceTriggersPreview,
+	MeteorPubSub.deviceTriggersPreview,
 	CustomCollectionName.UIDeviceTriggerPreviews,
 	async function (pub, studioId: StudioId, token: string | undefined) {
 		check(studioId, String)
@@ -36,7 +36,7 @@ meteorCustomPublish(
 		if (!studioId) throw new Meteor.Error(400, 'One of studioId must be provided')
 
 		if (await StudioReadAccess.studioContent(studioId, { userId: this.userId, token })) {
-			await createObserverForDeviceTriggersPreviewsPublication(pub, PubSub.mountedTriggersForDevice, studioId)
+			await createObserverForDeviceTriggersPreviewsPublication(pub, MeteorPubSub.deviceTriggersPreview, studioId)
 		}
 	}
 )
@@ -105,7 +105,7 @@ async function setupDeviceTriggersPreviewsObservers(
 
 async function createObserverForDeviceTriggersPreviewsPublication(
 	pub: CustomPublish<UIDeviceTriggerPreview>,
-	observerId: PubSub,
+	observerId: MeteorPubSub,
 	studioId: StudioId
 ) {
 	return setUpOptimizedObserverArray<

--- a/meteor/server/publications/lib.ts
+++ b/meteor/server/publications/lib.ts
@@ -1,5 +1,5 @@
 import { Meteor, Subscription } from 'meteor/meteor'
-import { PubSubTypes } from '../../lib/api/pubsub'
+import { AllPubSubCollections, AllPubSubTypes } from '../../lib/api/pubsub'
 import { extractFunctionSignature } from '../lib'
 import { MongoQuery } from '@sofie-automation/corelib/dist/mongo'
 import { ResolvedCredentials, resolveCredentials } from '../security/lib/credentials'
@@ -59,17 +59,23 @@ export function meteorPublishUnsafe(
 	})
 }
 
+export type PublishDocType<K extends keyof AllPubSubTypes> = ReturnType<
+	AllPubSubTypes[K]
+> extends keyof AllPubSubCollections
+	? AllPubSubCollections[ReturnType<AllPubSubTypes[K]>]
+	: never
+
 /**
  * Wrapper around Meteor.publish with stricter typings
  * @param name
  * @param callback
  */
-export function meteorPublish<K extends keyof PubSubTypes>(
+export function meteorPublish<K extends keyof AllPubSubTypes>(
 	name: K,
 	callback: (
 		this: SubscriptionContext,
-		...args: Parameters<PubSubTypes[K]>
-	) => Promise<MongoCursor<ReturnType<PubSubTypes[K]>> | null>
+		...args: Parameters<AllPubSubTypes[K]>
+	) => Promise<MongoCursor<PublishDocType<K>> | null>
 ): void {
 	meteorPublishUnsafe(name, callback)
 }

--- a/meteor/server/publications/mountedTriggers.ts
+++ b/meteor/server/publications/mountedTriggers.ts
@@ -1,6 +1,5 @@
 import { Meteor } from 'meteor/meteor'
 import { CustomPublish, meteorCustomPublish } from '../lib/customPublication'
-import { CustomCollectionName, PubSub } from '../../lib/api/pubsub'
 import { PeripheralDeviceId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { PeripheralDeviceReadAccess } from '../security/peripheralDevice'
 import { logger } from '../logging'
@@ -10,12 +9,16 @@ import { ProtectedString } from '@sofie-automation/corelib/dist/protectedString'
 import _ from 'underscore'
 import { PeripheralDevices } from '../collections'
 import { check } from 'meteor/check'
+import {
+	PeripheralDevicePubSub,
+	PeripheralDevicePubSubCollectionsNames,
+} from '@sofie-automation/shared-lib/dist/pubsub/peripheralDevice'
 
 const PUBLICATION_DEBOUNCE = 20
 
 meteorCustomPublish(
-	PubSub.mountedTriggersForDevice,
-	CustomCollectionName.MountedTriggers,
+	PeripheralDevicePubSub.mountedTriggersForDevice,
+	PeripheralDevicePubSubCollectionsNames.mountedTriggers,
 	async function (pub, deviceId: PeripheralDeviceId, deviceIds: string[], token: string | undefined) {
 		check(deviceId, String)
 		check(deviceIds, [String])
@@ -44,8 +47,8 @@ meteorCustomPublish(
 )
 
 meteorCustomPublish(
-	PubSub.mountedTriggersForDevicePreview,
-	CustomCollectionName.MountedTriggersPreviews,
+	PeripheralDevicePubSub.mountedTriggersForDevicePreview,
+	PeripheralDevicePubSubCollectionsNames.mountedTriggersPreviews,
 	async function (pub, deviceId: PeripheralDeviceId, token: string | undefined) {
 		check(deviceId, String)
 

--- a/meteor/server/publications/packageManager/expectedPackages/publication.ts
+++ b/meteor/server/publications/packageManager/expectedPackages/publication.ts
@@ -1,5 +1,4 @@
 import { Meteor } from 'meteor/meteor'
-import { CustomCollectionName, PubSub } from '../../../../lib/api/pubsub'
 import { PeripheralDeviceReadAccess } from '../../../security/peripheralDevice'
 import { DBStudio } from '@sofie-automation/corelib/dist/dataModel/Studio'
 import {
@@ -26,6 +25,10 @@ import { ExpectedPackagesContentObserver } from './contentObserver'
 import { createReactiveContentCache, ExpectedPackagesContentCache } from './contentCache'
 import { buildMappingsToDeviceIdMap } from './util'
 import { updateCollectionForExpectedPackageIds, updateCollectionForPieceInstanceIds } from './generate'
+import {
+	PeripheralDevicePubSub,
+	PeripheralDevicePubSubCollectionsNames,
+} from '@sofie-automation/shared-lib/dist/pubsub/peripheralDevice'
 
 interface ExpectedPackagesPublicationArgs {
 	readonly studioId: StudioId
@@ -182,8 +185,8 @@ async function manipulateExpectedPackagesPublicationData(
 }
 
 meteorCustomPublish(
-	PubSub.packageManagerExpectedPackages,
-	CustomCollectionName.PackageManagerExpectedPackages,
+	PeripheralDevicePubSub.packageManagerExpectedPackages,
+	PeripheralDevicePubSubCollectionsNames.packageManagerExpectedPackages,
 	async function (
 		pub,
 		deviceId: PeripheralDeviceId,
@@ -210,7 +213,7 @@ meteorCustomPublish(
 				ExpectedPackagesPublicationState,
 				ExpectedPackagesPublicationUpdateProps
 			>(
-				`${PubSub.packageManagerExpectedPackages}_${studioId}_${deviceId}_${JSON.stringify(
+				`${PeripheralDevicePubSub.packageManagerExpectedPackages}_${studioId}_${deviceId}_${JSON.stringify(
 					(filterPlayoutDeviceIds || []).sort()
 				)}`,
 				{ studioId, deviceId, filterPlayoutDeviceIds },

--- a/meteor/server/publications/packageManager/packageContainers.ts
+++ b/meteor/server/publications/packageManager/packageContainers.ts
@@ -7,11 +7,14 @@ import { PackageManagerPackageContainers } from '@sofie-automation/shared-lib/di
 import { check } from 'meteor/check'
 import { Meteor } from 'meteor/meteor'
 import { ReadonlyDeep } from 'type-fest'
-import { PubSub, CustomCollectionName } from '../../../lib/api/pubsub'
 import { PeripheralDevices, Studios } from '../../collections'
 import { meteorCustomPublish, setUpOptimizedObserverArray, TriggerUpdate } from '../../lib/customPublication'
 import { logger } from '../../logging'
 import { PeripheralDeviceReadAccess } from '../../security/peripheralDevice'
+import {
+	PeripheralDevicePubSub,
+	PeripheralDevicePubSubCollectionsNames,
+} from '@sofie-automation/shared-lib/dist/pubsub/peripheralDevice'
 
 type StudioFields = '_id' | 'packageContainers'
 const studioFieldSpecifier = literal<MongoFieldSpecifierOnesStrict<Pick<DBStudio, StudioFields>>>({
@@ -81,8 +84,8 @@ async function manipulateExpectedPackagesPublicationData(
 }
 
 meteorCustomPublish(
-	PubSub.packageManagerPackageContainers,
-	CustomCollectionName.PackageManagerPackageContainers,
+	PeripheralDevicePubSub.packageManagerPackageContainers,
+	PeripheralDevicePubSubCollectionsNames.packageManagerPackageContainers,
 	async function (pub, deviceId: PeripheralDeviceId, token: string | undefined) {
 		check(deviceId, String)
 
@@ -103,7 +106,7 @@ meteorCustomPublish(
 				PackageManagerPackageContainersState,
 				PackageManagerPackageContainersUpdateProps
 			>(
-				`${PubSub.packageManagerPackageContainers}_${studioId}_${deviceId}`,
+				`${PeripheralDevicePubSub.packageManagerPackageContainers}_${studioId}_${deviceId}`,
 				{ studioId, deviceId },
 				setupExpectedPackagesPublicationObservers,
 				manipulateExpectedPackagesPublicationData,

--- a/meteor/server/publications/packageManager/playoutContext.ts
+++ b/meteor/server/publications/packageManager/playoutContext.ts
@@ -7,11 +7,14 @@ import { PackageManagerPlayoutContext } from '@sofie-automation/shared-lib/dist/
 import { check } from 'meteor/check'
 import { Meteor } from 'meteor/meteor'
 import { ReadonlyDeep } from 'type-fest'
-import { PubSub, CustomCollectionName } from '../../../lib/api/pubsub'
 import { PeripheralDevices, RundownPlaylists, Rundowns } from '../../collections'
 import { meteorCustomPublish, setUpOptimizedObserverArray, TriggerUpdate } from '../../lib/customPublication'
 import { logger } from '../../logging'
 import { PeripheralDeviceReadAccess } from '../../security/peripheralDevice'
+import {
+	PeripheralDevicePubSub,
+	PeripheralDevicePubSubCollectionsNames,
+} from '@sofie-automation/shared-lib/dist/pubsub/peripheralDevice'
 
 export type RundownPlaylistCompact = Pick<DBRundownPlaylist, '_id' | 'activationId' | 'rehearsal' | 'rundownIdsInOrder'>
 const rundownPlaylistFieldSpecifier = literal<MongoFieldSpecifierOnesStrict<RundownPlaylistCompact>>({
@@ -101,8 +104,8 @@ async function manipulateExpectedPackagesPublicationData(
 }
 
 meteorCustomPublish(
-	PubSub.packageManagerPlayoutContext,
-	CustomCollectionName.PackageManagerPlayoutContext,
+	PeripheralDevicePubSub.packageManagerPlayoutContext,
+	PeripheralDevicePubSubCollectionsNames.packageManagerPlayoutContext,
 	async function (pub, deviceId: PeripheralDeviceId, token: string | undefined) {
 		check(deviceId, String)
 
@@ -123,7 +126,7 @@ meteorCustomPublish(
 				PackageManagerPlayoutContextState,
 				PackageManagerPlayoutContextUpdateProps
 			>(
-				`${PubSub.packageManagerPlayoutContext}_${studioId}_${deviceId}`,
+				`${PeripheralDevicePubSub.packageManagerPlayoutContext}_${studioId}_${deviceId}`,
 				{ studioId, deviceId },
 				setupExpectedPackagesPublicationObservers,
 				manipulateExpectedPackagesPublicationData,

--- a/meteor/server/publications/peripheralDeviceForDevice.ts
+++ b/meteor/server/publications/peripheralDeviceForDevice.ts
@@ -1,5 +1,4 @@
 import { Meteor } from 'meteor/meteor'
-import { CustomCollectionName, PubSub } from '../../lib/api/pubsub'
 import { PeripheralDeviceReadAccess } from '../security/peripheralDevice'
 import { PeripheralDevice, PeripheralDeviceCategory } from '@sofie-automation/corelib/dist/dataModel/PeripheralDevice'
 import { PeripheralDeviceId } from '@sofie-automation/corelib/dist/dataModel/Ids'
@@ -18,6 +17,10 @@ import {
 } from '@sofie-automation/corelib/dist/dataModel/Studio'
 import { applyAndValidateOverrides } from '@sofie-automation/corelib/dist/settings/objectWithOverrides'
 import { check } from 'meteor/check'
+import {
+	PeripheralDevicePubSub,
+	PeripheralDevicePubSubCollectionsNames,
+} from '@sofie-automation/shared-lib/dist/pubsub/peripheralDevice'
 
 interface PeripheralDeviceForDeviceArgs {
 	readonly deviceId: PeripheralDeviceId
@@ -194,8 +197,8 @@ async function manipulatePeripheralDevicePublicationData(
 }
 
 meteorCustomPublish(
-	PubSub.peripheralDeviceForDevice,
-	CustomCollectionName.PeripheralDeviceForDevice,
+	PeripheralDevicePubSub.peripheralDeviceForDevice,
+	PeripheralDevicePubSubCollectionsNames.peripheralDeviceForDevice,
 	async function (pub, deviceId: PeripheralDeviceId, token: string | undefined) {
 		check(deviceId, String)
 
@@ -213,7 +216,7 @@ meteorCustomPublish(
 				PeripheralDeviceForDeviceState,
 				PeripheralDeviceForDeviceUpdateProps
 			>(
-				`${CustomCollectionName.PeripheralDeviceForDevice}_${deviceId}`,
+				`${PeripheralDevicePubSubCollectionsNames.peripheralDeviceForDevice}_${deviceId}`,
 				{ deviceId },
 				setupPeripheralDevicePublicationObservers,
 				manipulatePeripheralDevicePublicationData,

--- a/meteor/server/publications/pieceContentStatusUI/bucket/publication.ts
+++ b/meteor/server/publications/pieceContentStatusUI/bucket/publication.ts
@@ -9,7 +9,7 @@ import {
 } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { MongoFieldSpecifierOnesStrict } from '@sofie-automation/corelib/dist/mongo'
 import { ReadonlyDeep } from 'type-fest'
-import { CustomCollectionName, PubSub } from '../../../../lib/api/pubsub'
+import { CustomCollectionName, MeteorPubSub } from '../../../../lib/api/pubsub'
 import { UIBucketContentStatus } from '../../../../lib/api/rundownNotifications'
 import { Buckets, MediaObjects, PackageContainerPackageStatuses, PackageInfos, Studios } from '../../../collections'
 import { literal, protectString } from '../../../../lib/lib'
@@ -243,7 +243,7 @@ async function manipulateUIBucketContentStatusesPublicationData(
 }
 
 meteorCustomPublish(
-	PubSub.uiBucketContentStatuses,
+	MeteorPubSub.uiBucketContentStatuses,
 	CustomCollectionName.UIBucketContentStatuses,
 	async function (pub, studioId: StudioId, bucketId: BucketId) {
 		check(studioId, String)
@@ -264,7 +264,7 @@ meteorCustomPublish(
 				UIBucketContentStatusesState,
 				UIBucketContentStatusesUpdateProps
 			>(
-				`pub_${PubSub.uiBucketContentStatuses}_${studioId}_${bucketId}`,
+				`pub_${MeteorPubSub.uiBucketContentStatuses}_${studioId}_${bucketId}`,
 				{ studioId, bucketId },
 				setupUIBucketContentStatusesPublicationObservers,
 				manipulateUIBucketContentStatusesPublicationData,

--- a/meteor/server/publications/pieceContentStatusUI/rundown/publication.ts
+++ b/meteor/server/publications/pieceContentStatusUI/rundown/publication.ts
@@ -12,7 +12,7 @@ import {
 } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { MongoFieldSpecifierOnesStrict } from '@sofie-automation/corelib/dist/mongo'
 import { ReadonlyDeep } from 'type-fest'
-import { CustomCollectionName, PubSub } from '../../../../lib/api/pubsub'
+import { CustomCollectionName, MeteorPubSub } from '../../../../lib/api/pubsub'
 import { UIPieceContentStatus } from '../../../../lib/api/rundownNotifications'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import {
@@ -445,7 +445,7 @@ function updatePartAndSegmentInfoForExistingDocs(
 }
 
 meteorCustomPublish(
-	PubSub.uiPieceContentStatuses,
+	MeteorPubSub.uiPieceContentStatuses,
 	CustomCollectionName.UIPieceContentStatuses,
 	async function (pub, rundownPlaylistId: RundownPlaylistId | null) {
 		check(rundownPlaylistId, Match.Maybe(String))
@@ -464,7 +464,7 @@ meteorCustomPublish(
 				UIPieceContentStatusesState,
 				UIPieceContentStatusesUpdateProps
 			>(
-				`pub_${PubSub.uiPieceContentStatuses}_${rundownPlaylistId}`,
+				`pub_${MeteorPubSub.uiPieceContentStatuses}_${rundownPlaylistId}`,
 				{ rundownPlaylistId },
 				setupUIPieceContentStatusesPublicationObservers,
 				manipulateUIPieceContentStatusesPublicationData,

--- a/meteor/server/publications/rundownPlaylist.ts
+++ b/meteor/server/publications/rundownPlaylist.ts
@@ -1,6 +1,5 @@
 import { RundownPlaylistReadAccess } from '../security/rundownPlaylist'
 import { meteorPublish, AutoFillSelector } from './lib'
-import { PubSub } from '../../lib/api/pubsub'
 import { StudioReadAccess } from '../security/studio'
 import { OrganizationReadAccess } from '../security/organization'
 import { NoSecurityReadAccess } from '../security/noSecurity'
@@ -8,9 +7,10 @@ import { isProtectedString } from '@sofie-automation/corelib/dist/protectedStrin
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { RundownPlaylists } from '../collections'
 import { MongoQuery } from '@sofie-automation/corelib/dist/mongo'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 meteorPublish(
-	PubSub.rundownPlaylists,
+	CorelibPubSub.rundownPlaylists,
 	async function (selector0: MongoQuery<DBRundownPlaylist>, token: string | undefined) {
 		const { cred, selector } = await AutoFillSelector.organizationId<DBRundownPlaylist>(
 			this.userId,

--- a/meteor/server/publications/segmentPartNotesUI/publication.ts
+++ b/meteor/server/publications/segmentPartNotesUI/publication.ts
@@ -1,7 +1,7 @@
 import { RundownId, RundownPlaylistId, SegmentId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { MongoFieldSpecifierOnesStrict } from '@sofie-automation/corelib/dist/mongo'
 import { ReadonlyDeep } from 'type-fest'
-import { CustomCollectionName, PubSub } from '../../../lib/api/pubsub'
+import { CustomCollectionName, MeteorPubSub } from '../../../lib/api/pubsub'
 import { UISegmentPartNote } from '../../../lib/api/rundownNotifications'
 import { DBPartInstance } from '@sofie-automation/corelib/dist/dataModel/PartInstance'
 import { DBPart } from '@sofie-automation/corelib/dist/dataModel/Part'
@@ -210,7 +210,7 @@ function updateNotesForSegment(
 }
 
 meteorCustomPublish(
-	PubSub.uiSegmentPartNotes,
+	MeteorPubSub.uiSegmentPartNotes,
 	CustomCollectionName.UISegmentPartNotes,
 	async function (pub, playlistId: RundownPlaylistId | null) {
 		check(playlistId, Match.Maybe(String))
@@ -229,7 +229,7 @@ meteorCustomPublish(
 				UISegmentPartNotesState,
 				UISegmentPartNotesUpdateProps
 			>(
-				`pub_${PubSub.uiSegmentPartNotes}_${playlistId}`,
+				`pub_${MeteorPubSub.uiSegmentPartNotes}_${playlistId}`,
 				{ playlistId },
 				setupUISegmentPartNotesPublicationObservers,
 				manipulateUISegmentPartNotesPublicationData,

--- a/meteor/server/publications/showStyle.ts
+++ b/meteor/server/publications/showStyle.ts
@@ -1,5 +1,5 @@
 import { meteorPublish, AutoFillSelector } from './lib'
-import { PubSub } from '../../lib/api/pubsub'
+import { MeteorPubSub } from '../../lib/api/pubsub'
 import { DBShowStyleBase } from '@sofie-automation/corelib/dist/dataModel/ShowStyleBase'
 import { DBShowStyleVariant } from '@sofie-automation/corelib/dist/dataModel/ShowStyleVariant'
 import { RundownLayoutBase } from '../../lib/collections/RundownLayouts'
@@ -10,9 +10,10 @@ import { NoSecurityReadAccess } from '../security/noSecurity'
 import { RundownLayouts, ShowStyleBases, ShowStyleVariants, TriggeredActions } from '../collections'
 import { MongoQuery } from '@sofie-automation/corelib/dist/mongo'
 import { DBTriggeredActions } from '../../lib/collections/TriggeredActions'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 meteorPublish(
-	PubSub.showStyleBases,
+	CorelibPubSub.showStyleBases,
 	async function (selector0: MongoQuery<DBShowStyleBase>, token: string | undefined) {
 		const { cred, selector } = await AutoFillSelector.organizationId<DBShowStyleBase>(this.userId, selector0, token)
 		const modifier: FindOptions<DBShowStyleBase> = {
@@ -32,7 +33,7 @@ meteorPublish(
 )
 
 meteorPublish(
-	PubSub.showStyleVariants,
+	CorelibPubSub.showStyleVariants,
 	async function (selector0: MongoQuery<DBShowStyleVariant>, token: string | undefined) {
 		const { cred, selector } = await AutoFillSelector.showStyleBaseId(this.userId, selector0, token)
 
@@ -52,7 +53,7 @@ meteorPublish(
 )
 
 meteorPublish(
-	PubSub.rundownLayouts,
+	MeteorPubSub.rundownLayouts,
 	async function (selector0: MongoQuery<RundownLayoutBase>, token: string | undefined) {
 		const { cred, selector } = await AutoFillSelector.showStyleBaseId(this.userId, selector0, token)
 
@@ -67,7 +68,7 @@ meteorPublish(
 )
 
 meteorPublish(
-	PubSub.triggeredActions,
+	MeteorPubSub.triggeredActions,
 	async function (selector0: MongoQuery<DBTriggeredActions>, token: string | undefined) {
 		const { cred, selector } = await AutoFillSelector.showStyleBaseId(this.userId, selector0, token)
 

--- a/meteor/server/publications/showStyleUI.ts
+++ b/meteor/server/publications/showStyleUI.ts
@@ -3,7 +3,7 @@ import { MongoFieldSpecifierOnesStrict } from '@sofie-automation/corelib/dist/mo
 import { applyAndValidateOverrides } from '@sofie-automation/corelib/dist/settings/objectWithOverrides'
 import { Meteor } from 'meteor/meteor'
 import { ReadonlyDeep } from 'type-fest'
-import { CustomCollectionName, PubSub } from '../../lib/api/pubsub'
+import { CustomCollectionName, MeteorPubSub } from '../../lib/api/pubsub'
 import { UIShowStyleBase } from '../../lib/api/showStyles'
 import { DBShowStyleBase } from '@sofie-automation/corelib/dist/dataModel/ShowStyleBase'
 import { Complete, literal } from '../../lib/lib'
@@ -83,7 +83,7 @@ async function manipulateUIShowStyleBasePublicationData(
 }
 
 meteorCustomPublish(
-	PubSub.uiShowStyleBase,
+	MeteorPubSub.uiShowStyleBase,
 	CustomCollectionName.UIShowStyleBase,
 	async function (pub, showStyleBaseId: ShowStyleBaseId) {
 		check(showStyleBaseId, String)
@@ -107,7 +107,7 @@ meteorCustomPublish(
 				UIShowStyleBaseState,
 				UIShowStyleBaseUpdateProps
 			>(
-				`pub_${PubSub.uiShowStyleBase}_${showStyleBaseId}`,
+				`pub_${MeteorPubSub.uiShowStyleBase}_${showStyleBaseId}`,
 				{ showStyleBaseId },
 				setupUIShowStyleBasePublicationObservers,
 				manipulateUIShowStyleBasePublicationData,

--- a/meteor/server/publications/studio.ts
+++ b/meteor/server/publications/studio.ts
@@ -1,7 +1,7 @@
 import { Meteor } from 'meteor/meteor'
 import { check } from '../../lib/check'
 import { meteorPublish, AutoFillSelector } from './lib'
-import { CustomCollectionName, PubSub } from '../../lib/api/pubsub'
+import { MeteorPubSub } from '../../lib/api/pubsub'
 import { getActiveRoutes, getRoutedMappings } from '../../lib/collections/Studios'
 import { PeripheralDeviceReadAccess } from '../security/peripheralDevice'
 import { ExternalMessageQueueObj } from '@sofie-automation/corelib/dist/dataModel/ExternalMessageQueue'
@@ -33,8 +33,13 @@ import { PackageContainerStatusDB } from '@sofie-automation/corelib/dist/dataMod
 import { MongoQuery } from '@sofie-automation/corelib/dist/mongo'
 import { RoutedMappings } from '@sofie-automation/shared-lib/dist/core/model/Timeline'
 import { DBStudio } from '@sofie-automation/corelib/dist/dataModel/Studio'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
+import {
+	PeripheralDevicePubSub,
+	PeripheralDevicePubSubCollectionsNames,
+} from '@sofie-automation/shared-lib/dist/pubsub/peripheralDevice'
 
-meteorPublish(PubSub.studios, async function (selector0: MongoQuery<DBStudio>, token: string | undefined) {
+meteorPublish(CorelibPubSub.studios, async function (selector0: MongoQuery<DBStudio>, token: string | undefined) {
 	const { cred, selector } = await AutoFillSelector.organizationId<DBStudio>(this.userId, selector0, token)
 	const modifier: FindOptions<DBStudio> = {
 		fields: {},
@@ -51,7 +56,7 @@ meteorPublish(PubSub.studios, async function (selector0: MongoQuery<DBStudio>, t
 })
 
 meteorPublish(
-	PubSub.externalMessageQueue,
+	CorelibPubSub.externalMessageQueue,
 	async function (selector: MongoQuery<ExternalMessageQueueObj>, token: string | undefined) {
 		if (!selector) throw new Meteor.Error(400, 'selector argument missing')
 		const modifier: FindOptions<ExternalMessageQueueObj> = {
@@ -65,7 +70,7 @@ meteorPublish(
 )
 
 meteorPublish(
-	PubSub.expectedPackages,
+	CorelibPubSub.expectedPackages,
 	async function (selector: MongoQuery<ExpectedPackageDB>, token: string | undefined) {
 		// Note: This differs from the expected packages sent to the Package Manager, instead @see PubSub.expectedPackagesForDevice
 		if (!selector) throw new Meteor.Error(400, 'selector argument missing')
@@ -79,7 +84,7 @@ meteorPublish(
 	}
 )
 meteorPublish(
-	PubSub.expectedPackageWorkStatuses,
+	CorelibPubSub.expectedPackageWorkStatuses,
 	async function (selector: MongoQuery<ExpectedPackageWorkStatus>, token: string | undefined) {
 		if (!selector) throw new Meteor.Error(400, 'selector argument missing')
 		const modifier: FindOptions<ExpectedPackageWorkStatus> = {
@@ -92,7 +97,7 @@ meteorPublish(
 	}
 )
 meteorPublish(
-	PubSub.packageContainerStatuses,
+	CorelibPubSub.packageContainerStatuses,
 	async function (selector: MongoQuery<PackageContainerStatusDB>, token: string | undefined) {
 		if (!selector) throw new Meteor.Error(400, 'selector argument missing')
 		const modifier: FindOptions<ExpectedPackageWorkStatus> = {
@@ -106,8 +111,8 @@ meteorPublish(
 )
 
 meteorCustomPublish(
-	PubSub.mappingsForDevice,
-	CustomCollectionName.StudioMappings,
+	PeripheralDevicePubSub.mappingsForDevice,
+	PeripheralDevicePubSubCollectionsNames.studioMappings,
 	async function (pub, deviceId: PeripheralDeviceId, token: string | undefined) {
 		check(deviceId, String)
 
@@ -125,8 +130,8 @@ meteorCustomPublish(
 )
 
 meteorCustomPublish(
-	PubSub.mappingsForStudio,
-	CustomCollectionName.StudioMappings,
+	MeteorPubSub.mappingsForStudio,
+	PeripheralDevicePubSubCollectionsNames.studioMappings,
 	async function (pub, studioId: StudioId, token: string | undefined) {
 		check(studioId, String)
 
@@ -202,7 +207,7 @@ async function createObserverForMappingsPublication(pub: CustomPublish<RoutedMap
 		RoutedMappingsState,
 		RoutedMappingsUpdateProps
 	>(
-		`${CustomCollectionName.StudioMappings}_${studioId}`,
+		`${PeripheralDevicePubSubCollectionsNames.studioMappings}_${studioId}`,
 		{ studioId },
 		setupMappingsPublicationObservers,
 		manipulateMappingsPublicationData,

--- a/meteor/server/publications/studioUI.ts
+++ b/meteor/server/publications/studioUI.ts
@@ -3,7 +3,7 @@ import { MongoFieldSpecifierOnesStrict } from '@sofie-automation/corelib/dist/mo
 import { applyAndValidateOverrides } from '@sofie-automation/corelib/dist/settings/objectWithOverrides'
 import { Meteor } from 'meteor/meteor'
 import { ReadonlyDeep } from 'type-fest'
-import { CustomCollectionName, PubSub } from '../../lib/api/pubsub'
+import { CustomCollectionName, MeteorPubSub } from '../../lib/api/pubsub'
 import { UIStudio } from '../../lib/api/studios'
 import { DBStudio } from '@sofie-automation/corelib/dist/dataModel/Studio'
 import { Complete, literal } from '../../lib/lib'
@@ -119,20 +119,24 @@ async function manipulateUIStudioPublicationData(
 	}
 }
 
-meteorCustomPublish(PubSub.uiStudio, CustomCollectionName.UIStudio, async function (pub, studioId: StudioId | null) {
-	check(studioId, Match.Maybe(String))
+meteorCustomPublish(
+	MeteorPubSub.uiStudio,
+	CustomCollectionName.UIStudio,
+	async function (pub, studioId: StudioId | null) {
+		check(studioId, Match.Maybe(String))
 
-	const cred = await resolveCredentials({ userId: this.userId, token: undefined })
+		const cred = await resolveCredentials({ userId: this.userId, token: undefined })
 
-	if (!cred || NoSecurityReadAccess.any() || (studioId && (await StudioReadAccess.studio(studioId, cred)))) {
-		await setUpCollectionOptimizedObserver<UIStudio, UIStudioArgs, UIStudioState, UIStudioUpdateProps>(
-			`pub_${PubSub.uiStudio}_${studioId}`,
-			{ studioId },
-			setupUIStudioPublicationObservers,
-			manipulateUIStudioPublicationData,
-			pub
-		)
-	} else {
-		logger.warn(`Pub.${CustomCollectionName.UIStudio}: Not allowed: "${studioId}"`)
+		if (!cred || NoSecurityReadAccess.any() || (studioId && (await StudioReadAccess.studio(studioId, cred)))) {
+			await setUpCollectionOptimizedObserver<UIStudio, UIStudioArgs, UIStudioState, UIStudioUpdateProps>(
+				`pub_${MeteorPubSub.uiStudio}_${studioId}`,
+				{ studioId },
+				setupUIStudioPublicationObservers,
+				manipulateUIStudioPublicationData,
+				pub
+			)
+		} else {
+			logger.warn(`Pub.${CustomCollectionName.UIStudio}: Not allowed: "${studioId}"`)
+		}
 	}
-})
+)

--- a/meteor/server/publications/timeline.ts
+++ b/meteor/server/publications/timeline.ts
@@ -9,7 +9,7 @@ import {
 	TimelineBlob,
 } from '@sofie-automation/corelib/dist/dataModel/Timeline'
 import { meteorPublish } from './lib'
-import { CustomCollectionName, PubSub } from '../../lib/api/pubsub'
+import { MeteorPubSub } from '../../lib/api/pubsub'
 import { FindOptions } from '../../lib/collections/lib'
 import {
 	CustomPublish,
@@ -32,18 +32,26 @@ import { PeripheralDevices, Studios, Timeline, TimelineDatastore } from '../coll
 import { check } from 'meteor/check'
 import { MongoQuery } from '@sofie-automation/corelib/dist/mongo'
 import { ResultingMappingRoutes, StudioLight } from '@sofie-automation/corelib/dist/dataModel/Studio'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
+import {
+	PeripheralDevicePubSub,
+	PeripheralDevicePubSubCollectionsNames,
+} from '@sofie-automation/shared-lib/dist/pubsub/peripheralDevice'
 
-meteorPublish(PubSub.timeline, async function (selector: MongoQuery<TimelineComplete>, token: string | undefined) {
-	if (!selector) throw new Meteor.Error(400, 'selector argument missing')
-	const modifier: FindOptions<TimelineComplete> = {
-		fields: {},
+meteorPublish(
+	CorelibPubSub.timeline,
+	async function (selector: MongoQuery<TimelineComplete>, token: string | undefined) {
+		if (!selector) throw new Meteor.Error(400, 'selector argument missing')
+		const modifier: FindOptions<TimelineComplete> = {
+			fields: {},
+		}
+		if (await StudioReadAccess.studioContent(selector._id, { userId: this.userId, token })) {
+			return Timeline.findWithCursor(selector, modifier)
+		}
+		return null
 	}
-	if (await StudioReadAccess.studioContent(selector._id, { userId: this.userId, token })) {
-		return Timeline.findWithCursor(selector, modifier)
-	}
-	return null
-})
-meteorPublish(PubSub.timelineDatastore, async function (studioId: StudioId, token: string | undefined) {
+)
+meteorPublish(CorelibPubSub.timelineDatastore, async function (studioId: StudioId, token: string | undefined) {
 	if (!studioId) throw new Meteor.Error(400, 'selector argument missing')
 	const modifier: FindOptions<DBTimelineDatastoreEntry> = {
 		fields: {},
@@ -55,8 +63,8 @@ meteorPublish(PubSub.timelineDatastore, async function (studioId: StudioId, toke
 })
 
 meteorCustomPublish(
-	PubSub.timelineForDevice,
-	CustomCollectionName.StudioTimeline,
+	PeripheralDevicePubSub.timelineForDevice,
+	PeripheralDevicePubSubCollectionsNames.studioTimeline,
 	async function (pub, deviceId: PeripheralDeviceId, token: string | undefined) {
 		check(deviceId, String)
 
@@ -73,7 +81,7 @@ meteorCustomPublish(
 	}
 )
 meteorPublish(
-	PubSub.timelineDatastoreForDevice,
+	PeripheralDevicePubSub.timelineDatastoreForDevice,
 	async function (deviceId: PeripheralDeviceId, token: string | undefined) {
 		check(deviceId, String)
 
@@ -95,8 +103,8 @@ meteorPublish(
 )
 
 meteorCustomPublish(
-	PubSub.timelineForStudio,
-	CustomCollectionName.StudioTimeline,
+	MeteorPubSub.timelineForStudio,
+	PeripheralDevicePubSubCollectionsNames.studioTimeline,
 	async function (pub, studioId: StudioId, token: string | undefined) {
 		if (await StudioReadAccess.studio(studioId, { userId: this.userId, token })) {
 			await createObserverForTimelinePublication(pub, studioId)
@@ -250,7 +258,7 @@ async function createObserverForTimelinePublication(pub: CustomPublish<RoutedTim
 		RoutedTimelineState,
 		RoutedTimelineUpdateProps
 	>(
-		`${CustomCollectionName.StudioTimeline}_${studioId}`,
+		`${PeripheralDevicePubSubCollectionsNames.studioTimeline}_${studioId}`,
 		{ studioId },
 		setupTimelinePublicationObservers,
 		manipulateTimelinePublicationData,

--- a/meteor/server/publications/translationsBundles.ts
+++ b/meteor/server/publications/translationsBundles.ts
@@ -2,13 +2,13 @@ import { Meteor } from 'meteor/meteor'
 
 import { TranslationsBundlesSecurity } from '../security/translationsBundles'
 import { meteorPublish } from './lib'
-import { PubSub } from '../../lib/api/pubsub'
+import { MeteorPubSub } from '../../lib/api/pubsub'
 import { TranslationsBundles } from '../collections'
 import { MongoQuery } from '@sofie-automation/corelib/dist/mongo'
 import { TranslationsBundle } from '../../lib/collections/TranslationsBundles'
 
 meteorPublish(
-	PubSub.translationsBundles,
+	MeteorPubSub.translationsBundles,
 	async (selector: MongoQuery<TranslationsBundle>, token: string | undefined) => {
 		if (!selector) throw new Meteor.Error(400, 'selector argument missing')
 

--- a/meteor/server/publications/triggeredActionsUI.ts
+++ b/meteor/server/publications/triggeredActionsUI.ts
@@ -2,7 +2,7 @@ import { ShowStyleBaseId, TriggeredActionId } from '@sofie-automation/corelib/di
 import { applyAndValidateOverrides } from '@sofie-automation/corelib/dist/settings/objectWithOverrides'
 import { Meteor } from 'meteor/meteor'
 import { ReadonlyDeep } from 'type-fest'
-import { CustomCollectionName, PubSub } from '../../lib/api/pubsub'
+import { CustomCollectionName, MeteorPubSub } from '../../lib/api/pubsub'
 import { DBTriggeredActions, UITriggeredActionsObj } from '../../lib/collections/TriggeredActions'
 import { Complete, literal } from '../../lib/lib'
 import {
@@ -104,7 +104,7 @@ async function manipulateUITriggeredActionsPublicationData(
 }
 
 meteorCustomPublish(
-	PubSub.uiTriggeredActions,
+	MeteorPubSub.uiTriggeredActions,
 	CustomCollectionName.UITriggeredActions,
 	async function (pub, showStyleBaseId: ShowStyleBaseId | null) {
 		check(showStyleBaseId, Match.Maybe(String))
@@ -122,7 +122,7 @@ meteorCustomPublish(
 				UITriggeredActionsState,
 				UITriggeredActionsUpdateProps
 			>(
-				`pub_${PubSub.uiTriggeredActions}_${showStyleBaseId}`,
+				`pub_${MeteorPubSub.uiTriggeredActions}_${showStyleBaseId}`,
 				{ showStyleBaseId },
 				setupUITriggeredActionsPublicationObservers,
 				manipulateUITriggeredActionsPublicationData,

--- a/packages/blueprints-integration/src/documents/expectedPlayoutItem.ts
+++ b/packages/blueprints-integration/src/documents/expectedPlayoutItem.ts
@@ -1,13 +1,1 @@
-import type { TSR } from '../timeline'
-
-export interface ExpectedPlayoutItemGeneric {
-	/** What type of playout device this item should be handled by */
-	deviceSubType: TSR.DeviceType // subset of PeripheralDeviceAPI.DeviceSubType
-	/** Which playout device this item should be handled by */
-	// deviceId: string // Todo: implement deviceId support (later)
-	/** Content of the expectedPlayoutItem */
-	content: TSR.ExpectedPlayoutItemContent
-}
-
-type ExpectedPlayoutItemContent = TSR.ExpectedPlayoutItemContent
-export { ExpectedPlayoutItemContent }
+export * from '@sofie-automation/shared-lib/dist/expectedPlayoutItem'

--- a/packages/corelib/src/pubsub.ts
+++ b/packages/corelib/src/pubsub.ts
@@ -34,6 +34,9 @@ import {
 } from '@sofie-automation/shared-lib/dist/core/model/Ids'
 import { RundownPlaylistActivationId } from './dataModel/Ids'
 
+/**
+ * Ids of possible DDP subscriptions for any the UI and gateways accessing the Rundown & RundownPlaylist model.
+ */
 export enum CorelibPubSub {
 	rundownPlaylists = 'rundownPlaylists',
 	rundowns = 'rundowns',
@@ -73,11 +76,11 @@ export enum CorelibPubSub {
 	studios = 'studios',
 
 	peripheralDevices = 'peripheralDevices',
-	peripheralDevicesAndSubDevices = ' peripheralDevicesAndSubDevices',
+	peripheralDevicesAndSubDevices = 'peripheralDevicesAndSubDevices',
 }
 
 /**
- * Type definitions for DDP subscriptions of corelib types.
+ * Type definitions for DDP subscriptions for any the UI and gateways accessing the Rundown & RundownPlaylist model.
  */
 export interface CorelibPubSubTypes {
 	[CorelibPubSub.blueprints]: (selector: MongoQuery<Blueprint>, token?: string) => CollectionName.Blueprints

--- a/packages/corelib/src/pubsub.ts
+++ b/packages/corelib/src/pubsub.ts
@@ -1,0 +1,209 @@
+import { DBPart } from './dataModel/Part'
+import { CollectionName } from './dataModel/Collections'
+import { MongoQuery } from './mongo'
+import { AdLibAction } from './dataModel/AdlibAction'
+import { AdLibPiece } from './dataModel/AdLibPiece'
+import { RundownBaselineAdLibAction } from './dataModel/RundownBaselineAdLibAction'
+import { RundownBaselineAdLibItem } from './dataModel/RundownBaselineAdLibPiece'
+import { DBPartInstance } from './dataModel/PartInstance'
+import { DBRundown } from './dataModel/Rundown'
+import { DBRundownPlaylist } from './dataModel/RundownPlaylist'
+import { DBSegment } from './dataModel/Segment'
+import { DBShowStyleBase } from './dataModel/ShowStyleBase'
+import { DBShowStyleVariant } from './dataModel/ShowStyleVariant'
+import { DBStudio } from './dataModel/Studio'
+import { IngestDataCacheObj } from './dataModel/IngestDataCache'
+import { DBTimelineDatastoreEntry } from '@sofie-automation/shared-lib/dist/core/model/TimelineDatastore'
+import { Blueprint } from './dataModel/Blueprint'
+import { BucketAdLibAction } from './dataModel/BucketAdLibAction'
+import { BucketAdLib } from './dataModel/BucketAdLibPiece'
+import { ExpectedMediaItem } from './dataModel/ExpectedMediaItem'
+import { ExpectedPackageWorkStatus } from './dataModel/ExpectedPackageWorkStatuses'
+import { ExpectedPackageDB, ExpectedPackageDBBase } from './dataModel/ExpectedPackages'
+import { ExternalMessageQueueObj } from './dataModel/ExternalMessageQueue'
+import { PackageContainerStatusDB } from './dataModel/PackageContainerStatus'
+import { PeripheralDevice } from './dataModel/PeripheralDevice'
+import { Piece } from './dataModel/Piece'
+import { PieceInstance } from './dataModel/PieceInstance'
+import { TimelineComplete } from './dataModel/Timeline'
+import {
+	RundownId,
+	RundownPlaylistId,
+	ShowStyleBaseId,
+	StudioId,
+} from '@sofie-automation/shared-lib/dist/core/model/Ids'
+import { RundownPlaylistActivationId } from './dataModel/Ids'
+
+export enum CorelibPubSub {
+	rundownPlaylists = 'rundownPlaylists',
+	rundowns = 'rundowns',
+	ingestDataCache = 'ingestDataCache',
+
+	rundownBaselineAdLibPieces = 'rundownBaselineAdLibPieces',
+	rundownBaselineAdLibActions = 'rundownBaselineAdLibActions',
+	adLibActions = 'adLibActions',
+	adLibPieces = 'adLibPieces',
+
+	segments = 'segments',
+	parts = 'parts',
+	partInstances = 'partInstances',
+	partInstancesSimple = 'partInstancesSimple',
+	partInstancesForSegmentPlayout = 'partInstancesForSegmentPlayout',
+	pieces = 'pieces',
+	pieceInstances = 'pieceInstances',
+	pieceInstancesSimple = 'pieceInstancesSimple',
+
+	timeline = 'timeline',
+	timelineDatastore = 'timelineDatastore',
+
+	expectedMediaItems = 'expectedMediaItems',
+
+	expectedPackages = 'expectedPackages',
+	expectedPackageWorkStatuses = 'expectedPackageWorkStatuses',
+	packageContainerStatuses = 'packageContainerStatuses',
+
+	bucketAdLibPieces = 'bucketAdLibPieces',
+	bucketAdLibActions = 'bucketAdLibActions',
+
+	externalMessageQueue = 'externalMessageQueue',
+
+	blueprints = 'blueprints',
+	showStyleBases = 'showStyleBases',
+	showStyleVariants = 'showStyleVariants',
+	studios = 'studios',
+
+	peripheralDevices = 'peripheralDevices',
+	peripheralDevicesAndSubDevices = ' peripheralDevicesAndSubDevices',
+}
+
+/**
+ * Type definitions for DDP subscriptions of corelib types.
+ */
+export interface CorelibPubSubTypes {
+	[CorelibPubSub.blueprints]: (selector: MongoQuery<Blueprint>, token?: string) => CollectionName.Blueprints
+
+	[CorelibPubSub.expectedMediaItems]: (
+		selector: MongoQuery<ExpectedMediaItem>,
+		token?: string
+	) => CollectionName.ExpectedMediaItems
+	[CorelibPubSub.externalMessageQueue]: (
+		selector: MongoQuery<ExternalMessageQueueObj>,
+		token?: string
+	) => CollectionName.ExternalMessageQueue
+	[CorelibPubSub.peripheralDevices]: (
+		selector: MongoQuery<PeripheralDevice>,
+		token?: string
+	) => CollectionName.PeripheralDevices
+	[CorelibPubSub.peripheralDevicesAndSubDevices]: (
+		selector: MongoQuery<PeripheralDevice>
+	) => CollectionName.PeripheralDevices
+	[CorelibPubSub.rundownBaselineAdLibPieces]: (
+		selector: MongoQuery<RundownBaselineAdLibItem>,
+		token?: string
+	) => CollectionName.RundownBaselineAdLibPieces
+	[CorelibPubSub.rundownBaselineAdLibActions]: (
+		selector: MongoQuery<RundownBaselineAdLibAction>,
+		token?: string
+	) => CollectionName.RundownBaselineAdLibActions
+	[CorelibPubSub.ingestDataCache]: (
+		selector: MongoQuery<IngestDataCacheObj>,
+		token?: string
+	) => CollectionName.IngestDataCache
+	[CorelibPubSub.rundownPlaylists]: (
+		selector: MongoQuery<DBRundownPlaylist>,
+		token?: string
+	) => CollectionName.RundownPlaylists
+	[CorelibPubSub.rundowns]: (
+		/** RundownPlaylistId to fetch for, or null to not check */
+		playlistIds: RundownPlaylistId[] | null,
+		/** ShowStyleBaseId to fetch for, or null to not check */
+		showStyleBaseIds: ShowStyleBaseId[] | null,
+		token?: string
+	) => CollectionName.Rundowns
+	[CorelibPubSub.adLibActions]: (selector: MongoQuery<AdLibAction>, token?: string) => CollectionName.AdLibActions
+	[CorelibPubSub.adLibPieces]: (selector: MongoQuery<AdLibPiece>, token?: string) => CollectionName.AdLibPieces
+	[CorelibPubSub.pieces]: (selector: MongoQuery<Piece>, token?: string) => CollectionName.Pieces
+	[CorelibPubSub.pieceInstances]: (
+		selector: MongoQuery<PieceInstance>,
+		token?: string
+	) => CollectionName.PieceInstances
+	[CorelibPubSub.pieceInstancesSimple]: (
+		selector: MongoQuery<PieceInstance>,
+		token?: string
+	) => CollectionName.PieceInstances
+	[CorelibPubSub.parts]: (rundownIds: RundownId[], token?: string) => CollectionName.Parts
+	[CorelibPubSub.partInstances]: (
+		rundownIds: RundownId[],
+		playlistActivationId: RundownPlaylistActivationId | undefined,
+		token?: string
+	) => CollectionName.PartInstances
+	[CorelibPubSub.partInstancesSimple]: (
+		selector: MongoQuery<DBPartInstance>,
+		token?: string
+	) => CollectionName.PartInstances
+	[CorelibPubSub.partInstancesForSegmentPlayout]: (
+		selector: MongoQuery<DBPartInstance>,
+		token?: string
+	) => CollectionName.PartInstances
+	[CorelibPubSub.segments]: (selector: MongoQuery<DBSegment>, token?: string) => CollectionName.Segments
+	[CorelibPubSub.showStyleBases]: (
+		selector: MongoQuery<DBShowStyleBase>,
+		token?: string
+	) => CollectionName.ShowStyleBases
+	[CorelibPubSub.showStyleVariants]: (
+		selector: MongoQuery<DBShowStyleVariant>,
+		token?: string
+	) => CollectionName.ShowStyleVariants
+	[CorelibPubSub.studios]: (selector: MongoQuery<DBStudio>, token?: string) => CollectionName.Studios
+	[CorelibPubSub.timeline]: (selector: MongoQuery<TimelineComplete>, token?: string) => CollectionName.Timelines
+	[CorelibPubSub.timelineDatastore]: (studioId: StudioId, token?: string) => CollectionName.TimelineDatastore
+	[CorelibPubSub.bucketAdLibPieces]: (
+		selector: MongoQuery<BucketAdLib>,
+		token?: string
+	) => CollectionName.BucketAdLibPieces
+	[CorelibPubSub.bucketAdLibActions]: (
+		selector: MongoQuery<BucketAdLibAction>,
+		token?: string
+	) => CollectionName.BucketAdLibActions
+	[CorelibPubSub.expectedPackages]: (
+		selector: MongoQuery<ExpectedPackageDB>,
+		token?: string
+	) => CollectionName.ExpectedPackages
+	[CorelibPubSub.expectedPackageWorkStatuses]: (
+		selector: MongoQuery<ExpectedPackageWorkStatus>,
+		token?: string
+	) => CollectionName.ExpectedPackageWorkStatuses
+	[CorelibPubSub.packageContainerStatuses]: (
+		selector: MongoQuery<PackageContainerStatusDB>,
+		token?: string
+	) => CollectionName.PackageContainerStatuses
+}
+
+export type CorelibPubSubCollections = {
+	[CollectionName.AdLibActions]: AdLibAction
+	[CollectionName.AdLibPieces]: AdLibPiece
+	[CollectionName.Blueprints]: Blueprint
+	[CollectionName.BucketAdLibActions]: BucketAdLibAction
+	[CollectionName.BucketAdLibPieces]: BucketAdLib
+	[CollectionName.ExpectedMediaItems]: ExpectedMediaItem
+	[CollectionName.ExpectedPackages]: ExpectedPackageDBBase
+	[CollectionName.ExpectedPackageWorkStatuses]: ExpectedPackageWorkStatus
+	[CollectionName.ExternalMessageQueue]: ExternalMessageQueueObj
+	[CollectionName.IngestDataCache]: IngestDataCacheObj
+	[CollectionName.PartInstances]: DBPartInstance
+	[CollectionName.PackageContainerStatuses]: PackageContainerStatusDB
+	[CollectionName.Parts]: DBPart
+	[CollectionName.PeripheralDevices]: PeripheralDevice
+	[CollectionName.PieceInstances]: PieceInstance
+	[CollectionName.Pieces]: Piece
+	[CollectionName.RundownBaselineAdLibActions]: RundownBaselineAdLibAction
+	[CollectionName.RundownBaselineAdLibPieces]: RundownBaselineAdLibItem
+	[CollectionName.RundownPlaylists]: DBRundownPlaylist
+	[CollectionName.Rundowns]: DBRundown
+	[CollectionName.Segments]: DBSegment
+	[CollectionName.ShowStyleBases]: DBShowStyleBase
+	[CollectionName.ShowStyleVariants]: DBShowStyleVariant
+	[CollectionName.Studios]: DBStudio
+	[CollectionName.Timelines]: TimelineComplete
+	[CollectionName.TimelineDatastore]: DBTimelineDatastoreEntry
+}

--- a/packages/live-status-gateway/src/collections/adLibActions.ts
+++ b/packages/live-status-gateway/src/collections/adLibActions.ts
@@ -1,33 +1,31 @@
 import { Logger } from 'winston'
 import { CoreHandler } from '../coreHandler'
 import { CollectionBase, Collection, CollectionObserver } from '../wsHandler'
-import { CoreConnection } from '@sofie-automation/server-core-integration'
 import { AdLibAction } from '@sofie-automation/corelib/dist/dataModel/AdlibAction'
 import { DBPartInstance } from '@sofie-automation/corelib/dist/dataModel/PartInstance'
-import { unprotectString } from '@sofie-automation/shared-lib/dist/lib/protectedString'
 import { PartInstanceName } from './partInstances'
 import { CollectionName } from '@sofie-automation/corelib/dist/dataModel/Collections'
 import _ = require('underscore')
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
+import { AdLibActionId, RundownId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 
 export class AdLibActionsHandler
-	extends CollectionBase<AdLibAction[]>
+	extends CollectionBase<AdLibAction[], CorelibPubSub.adLibActions, CollectionName.AdLibActions>
 	implements Collection<AdLibAction[]>, CollectionObserver<Map<PartInstanceName, DBPartInstance | undefined>>
 {
 	public observerName: string
-	private _core: CoreConnection
-	private _curRundownId: string | undefined
+	private _curRundownId: RundownId | undefined
 	private _curPartInstance: DBPartInstance | undefined
 
 	constructor(logger: Logger, coreHandler: CoreHandler) {
-		super(AdLibActionsHandler.name, CollectionName.AdLibActions, 'adLibActions', logger, coreHandler)
-		this._core = coreHandler.coreConnection
+		super(AdLibActionsHandler.name, CollectionName.AdLibActions, CorelibPubSub.adLibActions, logger, coreHandler)
 		this.observerName = this._name
 	}
 
-	async changed(id: string, changeType: string): Promise<void> {
+	async changed(id: AdLibActionId, changeType: string): Promise<void> {
 		this._logger.info(`${this._name} ${changeType} ${id}`)
 		if (!this._collectionName) return
-		const col = this._core.getCollection<AdLibAction>(this._collectionName)
+		const col = this._core.getCollection(this._collectionName)
 		if (!col) throw new Error(`collection '${this._collectionName}' not found!`)
 		this._collectionData = col.find({ rundownId: this._curRundownId })
 		await this.notify(this._collectionData)
@@ -38,7 +36,7 @@ export class AdLibActionsHandler
 		const prevRundownId = this._curRundownId
 		const prevCurPartInstance = this._curPartInstance
 		this._curPartInstance = data ? data.get(PartInstanceName.current) ?? data.get(PartInstanceName.next) : undefined
-		this._curRundownId = this._curPartInstance ? unprotectString(this._curPartInstance.rundownId) : undefined
+		this._curRundownId = this._curPartInstance ? this._curPartInstance.rundownId : undefined
 
 		await new Promise(process.nextTick.bind(this))
 		if (!this._collectionName) return
@@ -51,14 +49,14 @@ export class AdLibActionsHandler
 					rundownId: this._curRundownId,
 				})
 				this._dbObserver = this._coreHandler.setupObserver(this._collectionName)
-				this._dbObserver.added = (id: string) => {
+				this._dbObserver.added = (id) => {
 					void this.changed(id, 'added').catch(this._logger.error)
 				}
-				this._dbObserver.changed = (id: string) => {
+				this._dbObserver.changed = (id) => {
 					void this.changed(id, 'changed').catch(this._logger.error)
 				}
 
-				const collection = this._core.getCollection<AdLibAction>(this._collectionName)
+				const collection = this._core.getCollection(this._collectionName)
 				if (!collection) throw new Error(`collection '${this._collectionName}' not found!`)
 				this._collectionData = collection.find({
 					rundownId: this._curRundownId,

--- a/packages/live-status-gateway/src/collections/globalAdLibActions.ts
+++ b/packages/live-status-gateway/src/collections/globalAdLibActions.ts
@@ -1,39 +1,41 @@
 import { Logger } from 'winston'
 import { CoreHandler } from '../coreHandler'
 import { CollectionBase, Collection, CollectionObserver } from '../wsHandler'
-import { CoreConnection } from '@sofie-automation/server-core-integration'
 import { RundownBaselineAdLibAction } from '@sofie-automation/corelib/dist/dataModel/RundownBaselineAdLibAction'
 import { DBPartInstance } from '@sofie-automation/corelib/dist/dataModel/PartInstance'
-import { unprotectString } from '@sofie-automation/shared-lib/dist/lib/protectedString'
 import { PartInstanceName } from './partInstances'
 import { CollectionName } from '@sofie-automation/corelib/dist/dataModel/Collections'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
+import { RundownBaselineAdLibActionId, RundownId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 
 export class GlobalAdLibActionsHandler
-	extends CollectionBase<RundownBaselineAdLibAction[]>
+	extends CollectionBase<
+		RundownBaselineAdLibAction[],
+		CorelibPubSub.rundownBaselineAdLibActions,
+		CollectionName.RundownBaselineAdLibActions
+	>
 	implements
 		Collection<RundownBaselineAdLibAction[]>,
 		CollectionObserver<Map<PartInstanceName, DBPartInstance | undefined>>
 {
 	public observerName: string
-	private _core: CoreConnection
-	private _curRundownId: string | undefined
+	private _curRundownId: RundownId | undefined
 
 	constructor(logger: Logger, coreHandler: CoreHandler) {
 		super(
 			GlobalAdLibActionsHandler.name,
 			CollectionName.RundownBaselineAdLibActions,
-			'rundownBaselineAdLibActions',
+			CorelibPubSub.rundownBaselineAdLibActions,
 			logger,
 			coreHandler
 		)
-		this._core = coreHandler.coreConnection
 		this.observerName = this._name
 	}
 
-	async changed(id: string, changeType: string): Promise<void> {
+	async changed(id: RundownBaselineAdLibActionId, changeType: string): Promise<void> {
 		this._logger.info(`${this._name} ${changeType} ${id}`)
 		if (!this._collectionName) return
-		const col = this._core.getCollection<RundownBaselineAdLibAction>(this._collectionName)
+		const col = this._core.getCollection(this._collectionName)
 		if (!col) throw new Error(`collection '${this._collectionName}' not found!`)
 		this._collectionData = col.find({ rundownId: this._curRundownId })
 		await this.notify(this._collectionData)
@@ -43,7 +45,7 @@ export class GlobalAdLibActionsHandler
 		this._logger.info(`${this._name} received partInstances update from ${source}`)
 		const prevRundownId = this._curRundownId
 		const partInstance = data ? data.get(PartInstanceName.current) ?? data.get(PartInstanceName.next) : undefined
-		this._curRundownId = partInstance ? unprotectString(partInstance.rundownId) : undefined
+		this._curRundownId = partInstance ? partInstance.rundownId : undefined
 
 		await new Promise(process.nextTick.bind(this))
 		if (!this._collectionName) return
@@ -56,14 +58,14 @@ export class GlobalAdLibActionsHandler
 					rundownId: this._curRundownId,
 				})
 				this._dbObserver = this._coreHandler.setupObserver(this._collectionName)
-				this._dbObserver.added = (id: string) => {
+				this._dbObserver.added = (id) => {
 					void this.changed(id, 'added').catch(this._logger.error)
 				}
-				this._dbObserver.changed = (id: string) => {
+				this._dbObserver.changed = (id) => {
 					void this.changed(id, 'changed').catch(this._logger.error)
 				}
 
-				const collection = this._core.getCollection<RundownBaselineAdLibAction>(this._collectionName)
+				const collection = this._core.getCollection(this._collectionName)
 				if (!collection) throw new Error(`collection '${this._collectionName}' not found!`)
 				this._collectionData = collection.find({ rundownId: this._curRundownId })
 				await this.notify(this._collectionData)

--- a/packages/live-status-gateway/src/collections/globalAdLibs.ts
+++ b/packages/live-status-gateway/src/collections/globalAdLibs.ts
@@ -1,39 +1,41 @@
 import { Logger } from 'winston'
 import { CoreHandler } from '../coreHandler'
 import { CollectionBase, Collection, CollectionObserver } from '../wsHandler'
-import { CoreConnection } from '@sofie-automation/server-core-integration'
 import { RundownBaselineAdLibItem } from '@sofie-automation/corelib/dist/dataModel/RundownBaselineAdLibPiece'
 import { DBPartInstance } from '@sofie-automation/corelib/dist/dataModel/PartInstance'
-import { unprotectString } from '@sofie-automation/shared-lib/dist/lib/protectedString'
 import { PartInstanceName } from './partInstances'
 import { CollectionName } from '@sofie-automation/corelib/dist/dataModel/Collections'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
+import { PieceId, RundownId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 
 export class GlobalAdLibsHandler
-	extends CollectionBase<RundownBaselineAdLibItem[]>
+	extends CollectionBase<
+		RundownBaselineAdLibItem[],
+		CorelibPubSub.rundownBaselineAdLibPieces,
+		CollectionName.RundownBaselineAdLibPieces
+	>
 	implements
 		Collection<RundownBaselineAdLibItem[]>,
 		CollectionObserver<Map<PartInstanceName, DBPartInstance | undefined>>
 {
 	public observerName: string
-	private _core: CoreConnection
-	private _curRundownId: string | undefined
+	private _curRundownId: RundownId | undefined
 
 	constructor(logger: Logger, coreHandler: CoreHandler) {
 		super(
 			GlobalAdLibsHandler.name,
 			CollectionName.RundownBaselineAdLibPieces,
-			'rundownBaselineAdLibPieces',
+			CorelibPubSub.rundownBaselineAdLibPieces,
 			logger,
 			coreHandler
 		)
-		this._core = coreHandler.coreConnection
 		this.observerName = this._name
 	}
 
-	async changed(id: string, changeType: string): Promise<void> {
+	async changed(id: PieceId, changeType: string): Promise<void> {
 		this._logger.info(`${this._name} ${changeType} ${id}`)
 		if (!this._collectionName) return
-		const collection = this._core.getCollection<RundownBaselineAdLibItem>(this._collectionName)
+		const collection = this._core.getCollection(this._collectionName)
 		if (!collection) throw new Error(`collection '${this._collectionName}' not found!`)
 		this._collectionData = collection.find({ rundownId: this._curRundownId })
 		await this.notify(this._collectionData)
@@ -43,7 +45,7 @@ export class GlobalAdLibsHandler
 		this._logger.info(`${this._name} received globalAdLibs update from ${source}`)
 		const prevRundownId = this._curRundownId
 		const partInstance = data ? data.get(PartInstanceName.current) ?? data.get(PartInstanceName.next) : undefined
-		this._curRundownId = partInstance ? unprotectString(partInstance.rundownId) : undefined
+		this._curRundownId = partInstance ? partInstance.rundownId : undefined
 
 		await new Promise(process.nextTick.bind(this))
 		if (!this._collectionName) return
@@ -56,14 +58,14 @@ export class GlobalAdLibsHandler
 					rundownId: this._curRundownId,
 				})
 				this._dbObserver = this._coreHandler.setupObserver(this._collectionName)
-				this._dbObserver.added = (id: string) => {
+				this._dbObserver.added = (id) => {
 					void this.changed(id, 'added').catch(this._logger.error)
 				}
-				this._dbObserver.changed = (id: string) => {
+				this._dbObserver.changed = (id) => {
 					void this.changed(id, 'changed').catch(this._logger.error)
 				}
 
-				const collection = this._core.getCollection<RundownBaselineAdLibItem>(this._collectionName)
+				const collection = this._core.getCollection(this._collectionName)
 				if (!collection) throw new Error(`collection '${this._collectionName}' not found!`)
 				this._collectionData = collection.find({ rundownId: this._curRundownId })
 				await this.notify(this._collectionData)

--- a/packages/live-status-gateway/src/collections/partInstances.ts
+++ b/packages/live-status-gateway/src/collections/partInstances.ts
@@ -1,12 +1,12 @@
 import { Logger } from 'winston'
 import { CoreHandler } from '../coreHandler'
 import { CollectionBase, Collection, CollectionObserver } from '../wsHandler'
-import { CoreConnection } from '@sofie-automation/server-core-integration'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { DBPartInstance } from '@sofie-automation/corelib/dist/dataModel/PartInstance'
-import { unprotectString } from '@sofie-automation/corelib/dist/protectedString'
 import { CollectionName } from '@sofie-automation/corelib/dist/dataModel/Collections'
 import isShallowEqual from '@sofie-automation/shared-lib/dist/lib/isShallowEqual'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
+import { PartInstanceId, RundownId, RundownPlaylistActivationId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 
 export enum PartInstanceName {
 	current = 'current',
@@ -14,28 +14,30 @@ export enum PartInstanceName {
 }
 
 export class PartInstancesHandler
-	extends CollectionBase<Map<PartInstanceName, DBPartInstance | undefined>>
+	extends CollectionBase<
+		Map<PartInstanceName, DBPartInstance | undefined>,
+		CorelibPubSub.partInstances,
+		CollectionName.PartInstances
+	>
 	implements Collection<Map<PartInstanceName, DBPartInstance | undefined>>, CollectionObserver<DBRundownPlaylist>
 {
 	public observerName: string
-	private _core: CoreConnection
 	private _curPlaylist: DBRundownPlaylist | undefined
-	private _rundownIds: string[] = []
-	private _activationId: string | undefined
+	private _rundownIds: RundownId[] = []
+	private _activationId: RundownPlaylistActivationId | undefined
 
 	constructor(logger: Logger, coreHandler: CoreHandler) {
-		super(PartInstancesHandler.name, CollectionName.PartInstances, 'partInstances', logger, coreHandler)
-		this._core = coreHandler.coreConnection
+		super(PartInstancesHandler.name, CollectionName.PartInstances, CorelibPubSub.partInstances, logger, coreHandler)
 		this.observerName = this._name
 		this._collectionData = new Map()
 		this._collectionData.set(PartInstanceName.current, undefined)
 		this._collectionData.set(PartInstanceName.next, undefined)
 	}
 
-	async changed(id: string, changeType: string): Promise<void> {
+	async changed(id: PartInstanceId, changeType: string): Promise<void> {
 		this._logger.info(`${this._name} ${changeType} ${id}`)
 		if (!this._collectionName) return
-		const collection = this._core.getCollection<DBPartInstance>(this._collectionName)
+		const collection = this._core.getCollection(this._collectionName)
 		if (!collection) throw new Error(`collection '${this._collectionName}' not found!`)
 		const curPartInstance = this._curPlaylist?.currentPartInfo?.partInstanceId
 			? collection.findOne(this._curPlaylist.currentPartInfo.partInstanceId)
@@ -63,8 +65,8 @@ export class PartInstancesHandler
 		this._curPlaylist = data
 		if (!this._collectionName) return
 
-		this._rundownIds = this._curPlaylist ? this._curPlaylist.rundownIdsInOrder.map((r) => unprotectString(r)) : []
-		this._activationId = unprotectString(this._curPlaylist?.activationId)
+		this._rundownIds = this._curPlaylist ? this._curPlaylist.rundownIdsInOrder : []
+		this._activationId = this._curPlaylist?.activationId
 		if (this._curPlaylist && this._rundownIds.length && this._activationId) {
 			const sameSubscription =
 				isShallowEqual(this._rundownIds, prevRundownIds) && prevActivationId === this._activationId
@@ -80,14 +82,14 @@ export class PartInstancesHandler
 					this._activationId
 				)
 				this._dbObserver = this._coreHandler.setupObserver(this._collectionName)
-				this._dbObserver.added = (id: string) => {
+				this._dbObserver.added = (id) => {
 					void this.changed(id, 'added').catch(this._logger.error)
 				}
-				this._dbObserver.changed = (id: string) => {
+				this._dbObserver.changed = (id) => {
 					void this.changed(id, 'changed').catch(this._logger.error)
 				}
 
-				const collection = this._core.getCollection<DBPartInstance>(this._collectionName)
+				const collection = this._core.getCollection(this._collectionName)
 				if (!collection) throw new Error(`collection '${this._collectionName}' not found!`)
 				const curPartInstance = this._curPlaylist?.currentPartInfo?.partInstanceId
 					? collection.findOne(this._curPlaylist.currentPartInfo.partInstanceId)
@@ -101,7 +103,7 @@ export class PartInstancesHandler
 				})
 				await this.notify(this._collectionData)
 			} else if (this._subscriptionId) {
-				const collection = this._core.getCollection<DBPartInstance>(this._collectionName)
+				const collection = this._core.getCollection(this._collectionName)
 				if (!collection) throw new Error(`collection '${this._collectionName}' not found!`)
 				const curPartInstance = this._curPlaylist?.currentPartInfo?.partInstanceId
 					? collection.findOne(this._curPlaylist.currentPartInfo.partInstanceId)

--- a/packages/live-status-gateway/src/collections/playlist.ts
+++ b/packages/live-status-gateway/src/collections/playlist.ts
@@ -1,11 +1,15 @@
 import { Logger } from 'winston'
 import { CoreHandler } from '../coreHandler'
 import { CollectionBase, Collection } from '../wsHandler'
-import { CoreConnection } from '@sofie-automation/server-core-integration'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { CollectionName } from '@sofie-automation/corelib/dist/dataModel/Collections'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
+import { RundownPlaylistId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 
-export class PlaylistsHandler extends CollectionBase<DBRundownPlaylist[]> implements Collection<DBRundownPlaylist[]> {
+export class PlaylistsHandler
+	extends CollectionBase<DBRundownPlaylist[], undefined, undefined>
+	implements Collection<DBRundownPlaylist[]>
+{
 	public observerName: string
 
 	constructor(logger: Logger, coreHandler: CoreHandler) {
@@ -32,14 +36,21 @@ export class PlaylistsHandler extends CollectionBase<DBRundownPlaylist[]> implem
 	}
 }
 
-export class PlaylistHandler extends CollectionBase<DBRundownPlaylist> implements Collection<DBRundownPlaylist> {
+export class PlaylistHandler
+	extends CollectionBase<DBRundownPlaylist, CorelibPubSub.rundownPlaylists, CollectionName.RundownPlaylists>
+	implements Collection<DBRundownPlaylist>
+{
 	public observerName: string
-	private _core: CoreConnection
 	private _playlistsHandler: PlaylistsHandler
 
 	constructor(logger: Logger, coreHandler: CoreHandler) {
-		super(PlaylistHandler.name, CollectionName.RundownPlaylists, 'rundownPlaylists', logger, coreHandler)
-		this._core = coreHandler.coreConnection
+		super(
+			PlaylistHandler.name,
+			CollectionName.RundownPlaylists,
+			CorelibPubSub.rundownPlaylists,
+			logger,
+			coreHandler
+		)
 		this.observerName = this._name
 		this._playlistsHandler = new PlaylistsHandler(this._logger, this._coreHandler)
 	}
@@ -54,24 +65,24 @@ export class PlaylistHandler extends CollectionBase<DBRundownPlaylist> implement
 		})
 		this._dbObserver = this._coreHandler.setupObserver(this._collectionName)
 		if (this._collectionName) {
-			const col = this._core.getCollection<DBRundownPlaylist>(this._collectionName)
+			const col = this._core.getCollection(this._collectionName)
 			if (!col) throw new Error(`collection '${this._collectionName}' not found!`)
 			const playlists = col.find(undefined)
 			this._collectionData = playlists.find((p) => p.activationId)
 			await this._playlistsHandler.setPlaylists(playlists)
-			this._dbObserver.added = (id: string) => {
+			this._dbObserver.added = (id) => {
 				void this.changed(id, 'added').catch(this._logger.error)
 			}
-			this._dbObserver.changed = (id: string) => {
+			this._dbObserver.changed = (id) => {
 				void this.changed(id, 'changed').catch(this._logger.error)
 			}
 		}
 	}
 
-	async changed(id: string, changeType: string): Promise<void> {
+	async changed(id: RundownPlaylistId, changeType: string): Promise<void> {
 		this._logger.info(`${this._name} ${changeType} ${id}`)
 		if (!this._collectionName) return
-		const collection = this._core.getCollection<DBRundownPlaylist>(this._collectionName)
+		const collection = this._core.getCollection(this._collectionName)
 		if (!collection) throw new Error(`collection '${this._collectionName}' not found!`)
 		const playlists = collection.find(undefined)
 		await this._playlistsHandler.setPlaylists(playlists)

--- a/packages/live-status-gateway/src/collections/rundownHandler.ts
+++ b/packages/live-status-gateway/src/collections/rundownHandler.ts
@@ -1,41 +1,38 @@
 import { Logger } from 'winston'
 import { CoreHandler } from '../coreHandler'
 import { CollectionBase, Collection, CollectionObserver } from '../wsHandler'
-import { CoreConnection } from '@sofie-automation/server-core-integration'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { DBPartInstance } from '@sofie-automation/corelib/dist/dataModel/PartInstance'
 import { DBRundown } from '@sofie-automation/corelib/dist/dataModel/Rundown'
-import { protectString } from '@sofie-automation/shared-lib/dist/lib/protectedString'
 import { PartInstanceName, PartInstancesHandler } from './partInstances'
 import { RundownId, RundownPlaylistId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { CollectionName } from '@sofie-automation/corelib/dist/dataModel/Collections'
 import { PlaylistHandler } from './playlist'
 import { RundownsHandler } from './rundownsHandler'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 export class RundownHandler
-	extends CollectionBase<DBRundown>
+	extends CollectionBase<DBRundown, CorelibPubSub.rundowns, CollectionName.Rundowns>
 	implements
 		Collection<DBRundown>,
 		CollectionObserver<DBRundownPlaylist>,
 		CollectionObserver<Map<PartInstanceName, DBPartInstance | undefined>>
 {
 	public observerName: string
-	private _core: CoreConnection
 	private _curPlaylistId: RundownPlaylistId | undefined
 	private _curRundownId: RundownId | undefined
 
 	constructor(logger: Logger, coreHandler: CoreHandler, private _rundownsHandler?: RundownsHandler) {
-		super(RundownHandler.name, CollectionName.Rundowns, 'rundowns', logger, coreHandler)
-		this._core = coreHandler.coreConnection
+		super(RundownHandler.name, CollectionName.Rundowns, CorelibPubSub.rundowns, logger, coreHandler)
 		this.observerName = this._name
 	}
 
-	async changed(id: string, changeType: string): Promise<void> {
+	async changed(id: RundownId, changeType: string): Promise<void> {
 		this._logger.info(`${this._name} ${changeType} ${id}`)
-		if (protectString(id) !== this._curRundownId)
+		if (id !== this._curRundownId)
 			throw new Error(`${this._name} received change with unexpected id ${id} !== ${this._curRundownId}`)
 		if (!this._collectionName) return
-		const collection = this._core.getCollection<DBRundown>(this._collectionName)
+		const collection = this._core.getCollection(this._collectionName)
 		if (!collection) throw new Error(`collection '${this._collectionName}' not found!`)
 		await this._rundownsHandler?.setRundowns(collection.find(undefined))
 		if (this._collectionData) this._collectionData = collection.findOne(this._collectionData._id)
@@ -73,13 +70,13 @@ export class RundownHandler
 				this._subscriptionId = await this._coreHandler.setupSubscription(
 					this._publicationName,
 					[this._curPlaylistId],
-					undefined
+					null
 				)
 				this._dbObserver = this._coreHandler.setupObserver(this._collectionName)
-				this._dbObserver.added = (id: string) => {
+				this._dbObserver.added = (id) => {
 					void this.changed(id, 'added').catch(this._logger.error)
 				}
-				this._dbObserver.changed = (id: string) => {
+				this._dbObserver.changed = (id) => {
 					void this.changed(id, 'changed').catch(this._logger.error)
 				}
 			}
@@ -87,7 +84,7 @@ export class RundownHandler
 
 		if (prevCurRundownId !== this._curRundownId) {
 			if (this._curRundownId) {
-				const collection = this._core.getCollection<DBRundown>(this._collectionName)
+				const collection = this._core.getCollection(this._collectionName)
 				if (!collection) throw new Error(`collection '${this._collectionName}' not found!`)
 				const rundown = collection.findOne(this._curRundownId)
 				if (!rundown) throw new Error(`rundown '${this._curRundownId}' not found!`)

--- a/packages/live-status-gateway/src/collections/rundownsHandler.ts
+++ b/packages/live-status-gateway/src/collections/rundownsHandler.ts
@@ -3,7 +3,10 @@ import { CoreHandler } from '../coreHandler'
 import { CollectionBase, Collection } from '../wsHandler'
 import { DBRundown } from '@sofie-automation/corelib/dist/dataModel/Rundown'
 
-export class RundownsHandler extends CollectionBase<DBRundown[]> implements Collection<DBRundown[]> {
+export class RundownsHandler
+	extends CollectionBase<DBRundown[], undefined, undefined>
+	implements Collection<DBRundown[]>
+{
 	public observerName: string
 
 	constructor(logger: Logger, coreHandler: CoreHandler) {

--- a/packages/live-status-gateway/src/collections/segmentHandler.ts
+++ b/packages/live-status-gateway/src/collections/segmentHandler.ts
@@ -1,7 +1,6 @@
 import { Logger } from 'winston'
 import { CoreHandler } from '../coreHandler'
 import { CollectionBase, Collection, CollectionObserver } from '../wsHandler'
-import { CoreConnection } from '@sofie-automation/server-core-integration'
 import { DBSegment } from '@sofie-automation/corelib/dist/dataModel/Segment'
 import { DBPartInstance } from '@sofie-automation/corelib/dist/dataModel/PartInstance'
 import { PartInstanceName, PartInstancesHandler } from './partInstances'
@@ -11,29 +10,28 @@ import isShallowEqual from '@sofie-automation/shared-lib/dist/lib/isShallowEqual
 import { SegmentsHandler } from './segmentsHandler'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { PlaylistHandler } from './playlist'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 export class SegmentHandler
-	extends CollectionBase<DBSegment>
+	extends CollectionBase<DBSegment, CorelibPubSub.segments, CollectionName.Segments>
 	implements
 		Collection<DBSegment>,
 		CollectionObserver<Map<PartInstanceName, DBPartInstance | undefined>>,
 		CollectionObserver<DBRundownPlaylist>
 {
 	public observerName: string
-	private _core: CoreConnection
 	private _curSegmentId: SegmentId | undefined
 	private _rundownIds: RundownId[] = []
 
 	constructor(logger: Logger, coreHandler: CoreHandler, private _segmentsHandler: SegmentsHandler) {
-		super(SegmentHandler.name, CollectionName.Segments, 'segments', logger, coreHandler)
-		this._core = coreHandler.coreConnection
+		super(SegmentHandler.name, CollectionName.Segments, CorelibPubSub.segments, logger, coreHandler)
 		this.observerName = this._name
 	}
 
-	async changed(id: string, changeType: string): Promise<void> {
+	async changed(id: SegmentId, changeType: string): Promise<void> {
 		this._logger.info(`${this._name} ${changeType} ${id}`)
 		if (!this._collectionName) return
-		const collection = this._core.getCollection<DBSegment>(this._collectionName)
+		const collection = this._core.getCollection(this._collectionName)
 		if (!collection) throw new Error(`collection '${this._collectionName}' not found!`)
 		const allSegments = collection.find(undefined)
 		await this._segmentsHandler.setSegments(allSegments)
@@ -79,16 +77,16 @@ export class SegmentHandler
 					isHidden: { $ne: true },
 				})
 				this._dbObserver = this._coreHandler.setupObserver(this._collectionName)
-				this._dbObserver.added = (id: string) => {
+				this._dbObserver.added = (id) => {
 					void this.changed(id, 'added').catch(this._logger.error)
 				}
-				this._dbObserver.changed = (id: string) => {
+				this._dbObserver.changed = (id) => {
 					void this.changed(id, 'changed').catch(this._logger.error)
 				}
 			}
 		}
 
-		const collection = this._core.getCollection<DBSegment>(this._collectionName)
+		const collection = this._core.getCollection(this._collectionName)
 		if (!collection) throw new Error(`collection '${this._collectionName}' not found!`)
 		if (rundownsChanged) {
 			const allSegments = collection.find(undefined)

--- a/packages/live-status-gateway/src/collections/segmentsHandler.ts
+++ b/packages/live-status-gateway/src/collections/segmentsHandler.ts
@@ -6,7 +6,10 @@ import * as _ from 'underscore'
 
 const THROTTLE_PERIOD_MS = 200
 
-export class SegmentsHandler extends CollectionBase<DBSegment[]> implements Collection<DBSegment[]> {
+export class SegmentsHandler
+	extends CollectionBase<DBSegment[], undefined, undefined>
+	implements Collection<DBSegment[]>
+{
 	public observerName: string
 	private throttledNotify: (data: DBSegment[]) => Promise<void>
 

--- a/packages/live-status-gateway/src/collections/showStyleBase.ts
+++ b/packages/live-status-gateway/src/collections/showStyleBase.ts
@@ -1,30 +1,34 @@
 import { Logger } from 'winston'
 import { CoreHandler } from '../coreHandler'
 import { CollectionBase, Collection, CollectionObserver } from '../wsHandler'
-import { CoreConnection } from '@sofie-automation/server-core-integration'
 import { DBRundown } from '@sofie-automation/corelib/dist/dataModel/Rundown'
 import { DBShowStyleBase } from '@sofie-automation/corelib/dist/dataModel/ShowStyleBase'
 import { ShowStyleBaseId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { CollectionName } from '@sofie-automation/corelib/dist/dataModel/Collections'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 export class ShowStyleBaseHandler
-	extends CollectionBase<DBShowStyleBase>
+	extends CollectionBase<DBShowStyleBase, CorelibPubSub.showStyleBases, CollectionName.ShowStyleBases>
 	implements Collection<DBShowStyleBase>, CollectionObserver<DBRundown>
 {
 	public observerName: string
-	private _core: CoreConnection
 	private _showStyleBaseId: ShowStyleBaseId | undefined
 
 	constructor(logger: Logger, coreHandler: CoreHandler) {
-		super(ShowStyleBaseHandler.name, CollectionName.ShowStyleBases, 'showStyleBases', logger, coreHandler)
-		this._core = coreHandler.coreConnection
+		super(
+			ShowStyleBaseHandler.name,
+			CollectionName.ShowStyleBases,
+			CorelibPubSub.showStyleBases,
+			logger,
+			coreHandler
+		)
 		this.observerName = this._name
 	}
 
-	async changed(id: string, changeType: string): Promise<void> {
+	async changed(id: ShowStyleBaseId, changeType: string): Promise<void> {
 		this._logger.info(`${this._name} ${changeType} ${id}`)
 		if (!this._collectionName) return
-		const collection = this._core.getCollection<DBShowStyleBase>(this._collectionName)
+		const collection = this._core.getCollection(this._collectionName)
 		if (!collection) throw new Error(`collection '${this._collectionName}' not found!`)
 		if (this._showStyleBaseId) {
 			this._collectionData = collection.findOne(this._showStyleBaseId)
@@ -50,14 +54,14 @@ export class ShowStyleBaseHandler
 					_id: this._showStyleBaseId,
 				})
 				this._dbObserver = this._coreHandler.setupObserver(this._collectionName)
-				this._dbObserver.added = (id: string) => {
+				this._dbObserver.added = (id) => {
 					void this.changed(id, 'added').catch(this._logger.error)
 				}
-				this._dbObserver.changed = (id: string) => {
+				this._dbObserver.changed = (id) => {
 					void this.changed(id, 'changed').catch(this._logger.error)
 				}
 
-				const collection = this._core.getCollection<DBShowStyleBase>(this._collectionName)
+				const collection = this._core.getCollection(this._collectionName)
 				if (!collection) throw new Error(`collection '${this._collectionName}' not found!`)
 				this._collectionData = collection.findOne(this._showStyleBaseId)
 				await this.notify(this._collectionData)

--- a/packages/live-status-gateway/src/collections/studio.ts
+++ b/packages/live-status-gateway/src/collections/studio.ts
@@ -1,18 +1,19 @@
 import { Logger } from 'winston'
-import { CoreConnection } from '@sofie-automation/server-core-integration'
 import { DBStudio } from '@sofie-automation/corelib/dist/dataModel/Studio'
 import { CoreHandler } from '../coreHandler'
 import { CollectionBase, Collection } from '../wsHandler'
-import { protectString, unprotectString } from '@sofie-automation/shared-lib/dist/lib/protectedString'
 import { CollectionName } from '@sofie-automation/corelib/dist/dataModel/Collections'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
+import { StudioId } from '@sofie-automation/server-core-integration'
 
-export class StudioHandler extends CollectionBase<DBStudio> implements Collection<DBStudio> {
+export class StudioHandler
+	extends CollectionBase<DBStudio, CorelibPubSub.studios, CollectionName.Studios>
+	implements Collection<DBStudio>
+{
 	public observerName: string
-	private _core: CoreConnection
 
 	constructor(logger: Logger, coreHandler: CoreHandler) {
-		super(StudioHandler.name, CollectionName.Studios, 'studios', logger, coreHandler)
-		this._core = coreHandler.coreConnection
+		super(StudioHandler.name, CollectionName.Studios, CorelibPubSub.studios, logger, coreHandler)
 		this.observerName = this._name
 	}
 
@@ -25,26 +26,26 @@ export class StudioHandler extends CollectionBase<DBStudio> implements Collectio
 		this._dbObserver = this._coreHandler.setupObserver(this._collectionName)
 
 		if (this._collectionName) {
-			const col = this._core.getCollection<DBStudio>(this._collectionName)
+			const col = this._core.getCollection(this._collectionName)
 			if (!col) throw new Error(`collection '${this._collectionName}' not found!`)
 			const studio = col.findOne(this._studioId)
 			if (!studio) throw new Error(`studio '${this._studioId}' not found!`)
 			this._collectionData = studio
-			this._dbObserver.added = (id: string) => {
+			this._dbObserver.added = (id) => {
 				void this.changed(id, 'added').catch(this._logger.error)
 			}
-			this._dbObserver.changed = (id: string) => {
+			this._dbObserver.changed = (id) => {
 				void this.changed(id, 'changed').catch(this._logger.error)
 			}
 		}
 	}
 
-	async changed(id: string, changeType: string): Promise<void> {
+	async changed(id: StudioId, changeType: string): Promise<void> {
 		this._logger.info(`${this._name} ${changeType} ${id}`)
-		if (!(id === unprotectString(this._studioId) && this._collectionName)) return
-		const collection = this._core.getCollection<DBStudio>(this._collectionName)
+		if (!(id === this._studioId && this._collectionName)) return
+		const collection = this._core.getCollection(this._collectionName)
 		if (!collection) throw new Error(`collection '${this._collectionName}' not found!`)
-		const studio = collection.findOne(protectString(id))
+		const studio = collection.findOne(id)
 		if (!studio) throw new Error(`studio '${this._studioId}' not found on changed!`)
 		this._collectionData = studio
 		await this.notify(this._collectionData)

--- a/packages/mos-gateway/src/CoreMosDeviceHandler.ts
+++ b/packages/mos-gateway/src/CoreMosDeviceHandler.ts
@@ -3,6 +3,7 @@ import {
 	StatusCode,
 	protectString,
 	Observer,
+	PeripheralDevicePubSub,
 } from '@sofie-automation/server-core-integration'
 import {
 	IMOSConnectionStatus,
@@ -66,7 +67,7 @@ interface IStoryItemChange {
 
 export class CoreMosDeviceHandler {
 	core!: CoreConnectionChild
-	public _observers: Array<Observer> = []
+	public _observers: Array<Observer<any>> = []
 	public _mosDevice: IMOSDevice
 	private _coreParentHandler: CoreHandler
 	private _mosHandler: MosHandler
@@ -122,7 +123,9 @@ export class CoreMosDeviceHandler {
 				this._mosDevice.idPrimary +
 				' ..'
 		)
-		Promise.all([this.core.autoSubscribe('peripheralDeviceCommands', this.core.deviceId)]).catch((e) => {
+		Promise.all([
+			this.core.autoSubscribe(PeripheralDevicePubSub.peripheralDeviceCommands, this.core.deviceId),
+		]).catch((e) => {
 			this._coreParentHandler.logger.error(e)
 		})
 

--- a/packages/mos-gateway/src/coreHandler.ts
+++ b/packages/mos-gateway/src/coreHandler.ts
@@ -7,8 +7,9 @@ import {
 	PeripheralDeviceCommand,
 	protectString,
 	StatusCode,
-	unprotectString,
 	stringifyError,
+	PeripheralDevicePubSub,
+	PeripheralDevicePubSubCollectionsNames,
 } from '@sofie-automation/server-core-integration'
 import * as Winston from 'winston'
 
@@ -18,6 +19,7 @@ import { DeviceConfig } from './connector'
 import { MOS_DEVICE_CONFIG_MANIFEST } from './configManifest'
 import { getVersions } from './versions'
 import { CoreMosDeviceHandler } from './CoreMosDeviceHandler'
+import { PeripheralDeviceCommandId } from '@sofie-automation/shared-lib/dist/core/model/Ids'
 
 export interface CoreConfig {
 	host: string
@@ -30,12 +32,12 @@ export interface CoreConfig {
 export class CoreHandler {
 	core: CoreConnection | undefined
 	logger: Winston.Logger
-	public _observers: Array<Observer> = []
+	public _observers: Array<Observer<any>> = []
 	private _deviceOptions: DeviceConfig
 	private _coreMosHandlers: Array<CoreMosDeviceHandler> = []
 	private _onConnected?: () => any
 	private _isInitialized = false
-	private _executedFunctions: { [id: string]: boolean } = {}
+	private _executedFunctions = new Set<PeripheralDeviceCommandId>()
 	private _coreConfig?: CoreConfig
 	private _certificates?: Buffer[]
 
@@ -190,17 +192,17 @@ export class CoreHandler {
 
 		this.logger.info('Core: Setting up subscriptions for ' + this.core.deviceId + '..')
 		await Promise.all([
-			this.core.autoSubscribe('peripheralDeviceForDevice', this.core.deviceId),
-			this.core.autoSubscribe('peripheralDeviceCommands', this.core.deviceId),
+			this.core.autoSubscribe(PeripheralDevicePubSub.peripheralDeviceForDevice, this.core.deviceId),
+			this.core.autoSubscribe(PeripheralDevicePubSub.peripheralDeviceCommands, this.core.deviceId),
 		])
 
 		this.setupObserverForPeripheralDeviceCommands(this)
 	}
 	executeFunction(cmd: PeripheralDeviceCommand, fcnObject: CoreHandler | CoreMosDeviceHandler): void {
 		if (cmd) {
-			if (this._executedFunctions[unprotectString(cmd._id)]) return // prevent it from running multiple times
+			if (this._executedFunctions.has(cmd._id)) return // prevent it from running multiple times
 			this.logger.debug(cmd.functionName || cmd.actionId || '', cmd.args)
-			this._executedFunctions[unprotectString(cmd._id)] = true
+			this._executedFunctions.add(cmd._id)
 			// console.log('executeFunction', cmd)
 			const cb = (errStr: string | null, res?: any) => {
 				// console.log('cb', err, res)
@@ -239,25 +241,27 @@ export class CoreHandler {
 			}
 		}
 	}
-	retireExecuteFunction(cmdId: string): void {
-		delete this._executedFunctions[cmdId]
+	retireExecuteFunction(cmdId: PeripheralDeviceCommandId): void {
+		this._executedFunctions.delete(cmdId)
 	}
 	setupObserverForPeripheralDeviceCommands(functionObject: CoreMosDeviceHandler | CoreHandler): void {
 		if (!functionObject.core) {
 			throw Error('functionObject.core is undefined!')
 		}
 
-		const observer = functionObject.core.observe('peripheralDeviceCommands')
+		const observer = functionObject.core.observe(PeripheralDevicePubSubCollectionsNames.peripheralDeviceCommands)
 		functionObject._observers.push(observer)
-		const addedChangedCommand = (id: string) => {
+		const addedChangedCommand = (id: PeripheralDeviceCommandId) => {
 			if (!functionObject.core) {
 				throw Error('functionObject.core is undefined!')
 			}
 
-			const cmds = functionObject.core.getCollection<PeripheralDeviceCommand>('peripheralDeviceCommands')
+			const cmds = functionObject.core.getCollection(
+				PeripheralDevicePubSubCollectionsNames.peripheralDeviceCommands
+			)
 			if (!cmds) throw Error('"peripheralDeviceCommands" collection not found!')
-			const cmd = cmds.findOne(protectString(id))
-			if (!cmd) throw Error('PeripheralCommand "' + id + '" not found!')
+			const cmd = cmds.findOne(id)
+			if (!cmd) throw Error(`PeripheralCommand "${id}" not found!`)
 			// console.log('addedChangedCommand', id)
 			if (cmd.deviceId === functionObject.core.deviceId) {
 				this.executeFunction(cmd, functionObject)
@@ -265,16 +269,16 @@ export class CoreHandler {
 				// console.log('not mine', cmd.deviceId, this.core.deviceId)
 			}
 		}
-		observer.added = (id: string) => {
+		observer.added = (id) => {
 			addedChangedCommand(id)
 		}
-		observer.changed = (id: string) => {
+		observer.changed = (id) => {
 			addedChangedCommand(id)
 		}
-		observer.removed = (id: string) => {
+		observer.removed = (id) => {
 			this.retireExecuteFunction(id)
 		}
-		const cmds = functionObject.core.getCollection<PeripheralDeviceCommand>('peripheralDeviceCommands')
+		const cmds = functionObject.core.getCollection(PeripheralDevicePubSubCollectionsNames.peripheralDeviceCommands)
 		if (!cmds) throw Error('"peripheralDeviceCommands" collection not found!')
 		// any should be PeripheralDeviceCommand
 		cmds.find({}).forEach((cmd) => {

--- a/packages/mos-gateway/src/mosHandler.ts
+++ b/packages/mos-gateway/src/mosHandler.ts
@@ -27,7 +27,7 @@ import {
 import * as Winston from 'winston'
 import { CoreHandler } from './coreHandler'
 import { CoreMosDeviceHandler } from './CoreMosDeviceHandler'
-import { Observer } from '@sofie-automation/server-core-integration'
+import { Observer, PeripheralDevicePubSubCollectionsNames } from '@sofie-automation/server-core-integration'
 import {
 	DEFAULT_MOS_TIMEOUT_TIME,
 	DEFAULT_MOS_HEARTBEAT_INTERVAL,
@@ -60,7 +60,7 @@ export class MosHandler {
 	private _disposed = false
 	private _settings?: MosGatewayConfig
 	private _coreHandler: CoreHandler | undefined
-	private _observers: Array<Observer> = []
+	private _observers: Array<Observer<any>> = []
 	private _triggerupdateDevicesTimeout: any = null
 	private mosTypes: MosTypes
 
@@ -138,7 +138,9 @@ export class MosHandler {
 			throw Error('_coreHandler.core is undefined!')
 		}
 
-		const deviceObserver = this._coreHandler.core.observe('peripheralDeviceForDevice')
+		const deviceObserver = this._coreHandler.core.observe(
+			PeripheralDevicePubSubCollectionsNames.peripheralDeviceForDevice
+		)
 		deviceObserver.added = () => {
 			this._deviceOptionsChanged()
 		}
@@ -396,8 +398,9 @@ export class MosHandler {
 			throw Error('_coreHandler.core is undefined')
 		}
 
-		const peripheralDevices =
-			this._coreHandler.core.getCollection<PeripheralDeviceForDevice>('peripheralDeviceForDevice')
+		const peripheralDevices = this._coreHandler.core.getCollection(
+			PeripheralDevicePubSubCollectionsNames.peripheralDeviceForDevice
+		)
 		return peripheralDevices.findOne(this._coreHandler.core.deviceId)
 	}
 	private async _updateDevices(): Promise<void> {

--- a/packages/playout-gateway/src/coreHandler.ts
+++ b/packages/playout-gateway/src/coreHandler.ts
@@ -5,14 +5,12 @@ import {
 	PeripheralDeviceAPI,
 	PeripheralDeviceCommand,
 	PeripheralDeviceId,
-	PeripheralDeviceForDevice,
 	protectString,
 	StatusCode,
-	StudioId,
-	unprotectString,
 	Observer,
-	SubscriptionId,
 	stringifyError,
+	PeripheralDevicePubSub,
+	PeripheralDevicePubSubCollectionsNames,
 } from '@sofie-automation/server-core-integration'
 import { MediaObject, DeviceOptionsAny, ActionExecutionResult } from 'timeline-state-resolver'
 import * as _ from 'underscore'
@@ -26,6 +24,7 @@ import { BaseRemoteDeviceIntegration } from 'timeline-state-resolver/dist/servic
 import { getVersions } from './versions'
 import { CoreConnectionChild } from '@sofie-automation/server-core-integration/dist/lib/CoreConnectionChild'
 import { PlayoutGatewayConfig } from './generated/options'
+import { PeripheralDeviceCommandId } from '@sofie-automation/shared-lib/dist/core/model/Ids'
 
 export interface CoreConfig {
 	host: string
@@ -44,7 +43,7 @@ export interface MemoryUsageReport {
 export class CoreHandler {
 	core!: CoreConnection
 	logger: Logger
-	public _observers: Array<Observer> = []
+	public _observers: Array<Observer<any>> = []
 	public deviceSettings: PlayoutGatewayConfig = {}
 
 	public multithreading = false
@@ -52,14 +51,10 @@ export class CoreHandler {
 
 	private _deviceOptions: DeviceConfig
 	private _onConnected?: () => any
-	private _executedFunctions: { [id: string]: boolean } = {}
+	private _executedFunctions = new Set<PeripheralDeviceCommandId>()
 	private _tsrHandler?: TSRHandler
 	private _coreConfig?: CoreConfig
 	private _certificates?: Buffer[]
-
-	private _studioId: StudioId | undefined
-	private _timelineSubscription: SubscriptionId | null = null
-	private _expectedItemsSubscription: SubscriptionId | null = null
 
 	private _statusInitialized = false
 	private _statusDestroyed = false
@@ -114,12 +109,13 @@ export class CoreHandler {
 		this.logger.info('Core: Setting up subscriptions..')
 		this.logger.info('DeviceId: ' + this.core.deviceId)
 		await Promise.all([
-			this.core.autoSubscribe('peripheralDeviceForDevice', this.core.deviceId),
-			this.core.autoSubscribe('mappingsForDevice', this.core.deviceId),
-			this.core.autoSubscribe('timelineForDevice', this.core.deviceId),
-			this.core.autoSubscribe('timelineDatastoreForDevice', this.core.deviceId),
-			this.core.autoSubscribe('peripheralDeviceCommands', this.core.deviceId),
-			this.core.autoSubscribe('rundownsForDevice', this.core.deviceId),
+			this.core.autoSubscribe(PeripheralDevicePubSub.peripheralDeviceForDevice, this.core.deviceId),
+			this.core.autoSubscribe(PeripheralDevicePubSub.mappingsForDevice, this.core.deviceId),
+			this.core.autoSubscribe(PeripheralDevicePubSub.timelineForDevice, this.core.deviceId),
+			this.core.autoSubscribe(PeripheralDevicePubSub.timelineDatastoreForDevice, this.core.deviceId),
+			this.core.autoSubscribe(PeripheralDevicePubSub.peripheralDeviceCommands, this.core.deviceId),
+			this.core.autoSubscribe(PeripheralDevicePubSub.rundownsForDevice, this.core.deviceId),
+			this.core.autoSubscribe(PeripheralDevicePubSub.expectedPlayoutItemsForDevice, this.core.deviceId),
 		])
 
 		this.logger.info('Core: Subscriptions are set up!')
@@ -131,9 +127,9 @@ export class CoreHandler {
 			this._observers = []
 		}
 		// setup observers
-		const observer = this.core.observe('peripheralDeviceForDevice')
-		observer.added = (id: string) => this.onDeviceChanged(protectString(id))
-		observer.changed = (id: string) => this.onDeviceChanged(protectString(id))
+		const observer = this.core.observe(PeripheralDevicePubSubCollectionsNames.peripheralDeviceForDevice)
+		observer.added = (id) => this.onDeviceChanged(id)
+		observer.changed = (id) => this.onDeviceChanged(id)
 		this.setupObserverForPeripheralDeviceCommands(this)
 
 		// trigger this callback because the observer doesn't the first time..
@@ -179,7 +175,7 @@ export class CoreHandler {
 	}
 	onDeviceChanged(id: PeripheralDeviceId): void {
 		if (id === this.core.deviceId) {
-			const col = this.core.getCollection<PeripheralDeviceForDevice>('peripheralDeviceForDevice')
+			const col = this.core.getCollection(PeripheralDevicePubSubCollectionsNames.peripheralDeviceForDevice)
 			if (!col) throw new Error('collection "peripheralDevices" not found!')
 
 			const device = col.findOne(id)
@@ -206,43 +202,6 @@ export class CoreHandler {
 			const studioId = device?.studioId
 			if (!studioId) throw new Error('PeripheralDevice has no studio!')
 
-			if (studioId !== this._studioId) {
-				this._studioId = studioId
-
-				// Set up timeline data subscription:
-				if (this._timelineSubscription) {
-					this.core.unsubscribe(this._timelineSubscription)
-					this._timelineSubscription = null
-				}
-				this.core
-					.autoSubscribe('timeline', {
-						studioId: studioId,
-					})
-					.then((subscriptionId) => {
-						this._timelineSubscription = subscriptionId
-					})
-					.catch((err: any) => {
-						this.logger.error(err)
-					})
-
-				// Set up expectedPlayoutItems data subscription:
-				if (this._expectedItemsSubscription) {
-					this.core.unsubscribe(this._expectedItemsSubscription)
-					this._expectedItemsSubscription = null
-				}
-				this.core
-					.autoSubscribe('expectedPlayoutItems', {
-						studioId: studioId,
-					})
-					.then((subscriptionId) => {
-						this._expectedItemsSubscription = subscriptionId
-					})
-					.catch((err: any) => {
-						this.logger.error(err)
-					})
-				this.logger.debug('VIZDEBUG: Subscription to expectedPlayoutItems done')
-			}
-
 			if (this._tsrHandler) {
 				this._tsrHandler.onSettingsChanged()
 			}
@@ -262,7 +221,7 @@ export class CoreHandler {
 
 	executeFunction(cmd: PeripheralDeviceCommand, fcnObject: CoreHandler | CoreTSRDeviceHandler): void {
 		if (cmd) {
-			if (this._executedFunctions[unprotectString(cmd._id)]) return // prevent it from running multiple times
+			if (this._executedFunctions.has(cmd._id)) return // prevent it from running multiple times
 
 			const cb = (errStr: string | null, res?: any) => {
 				if (errStr) {
@@ -278,7 +237,7 @@ export class CoreHandler {
 				if (cmd.functionName !== 'getDebugStates') {
 					this.logger.debug(`Executing function "${cmd.functionName}", args: ${JSON.stringify(cmd.args)}`)
 				}
-				this._executedFunctions[unprotectString(cmd._id)] = true
+				this._executedFunctions.add(cmd._id)
 				// @ts-expect-error Untyped bunch of functions
 				// eslint-disable-next-line @typescript-eslint/ban-types
 				const fcn: Function = fcnObject[cmd.functionName]
@@ -297,7 +256,7 @@ export class CoreHandler {
 				}
 			} else if (cmd.actionId && 'executeAction' in fcnObject) {
 				this.logger.debug(`Executing action "${cmd.actionId}", payload: ${JSON.stringify(cmd.payload)}`)
-				this._executedFunctions[unprotectString(cmd._id)] = true
+				this._executedFunctions.add(cmd._id)
 
 				fcnObject
 					.executeAction(cmd.actionId, cmd.payload)
@@ -312,16 +271,18 @@ export class CoreHandler {
 			}
 		}
 	}
-	retireExecuteFunction(cmdId: string): void {
-		delete this._executedFunctions[cmdId]
+	retireExecuteFunction(cmdId: PeripheralDeviceCommandId): void {
+		this._executedFunctions.delete(cmdId)
 	}
 	setupObserverForPeripheralDeviceCommands(functionObject: CoreTSRDeviceHandler | CoreHandler): void {
-		const observer = functionObject.core.observe('peripheralDeviceCommands')
+		const observer = functionObject.core.observe(PeripheralDevicePubSubCollectionsNames.peripheralDeviceCommands)
 		functionObject._observers.push(observer)
-		const addedChangedCommand = (id: string) => {
-			const cmds = functionObject.core.getCollection<PeripheralDeviceCommand>('peripheralDeviceCommands')
+		const addedChangedCommand = (id: PeripheralDeviceCommandId) => {
+			const cmds = functionObject.core.getCollection(
+				PeripheralDevicePubSubCollectionsNames.peripheralDeviceCommands
+			)
 			if (!cmds) throw Error('"peripheralDeviceCommands" collection not found!')
-			const cmd = cmds.findOne(protectString(id))
+			const cmd = cmds.findOne(id)
 			if (!cmd) throw Error('PeripheralCommand "' + id + '" not found!')
 			// console.log('addedChangedCommand', id)
 			if (cmd.deviceId === functionObject.core.deviceId) {
@@ -330,16 +291,16 @@ export class CoreHandler {
 				// console.log('not mine', cmd.deviceId, this.core.deviceId)
 			}
 		}
-		observer.added = (id: string) => {
+		observer.added = (id) => {
 			addedChangedCommand(id)
 		}
-		observer.changed = (id: string) => {
+		observer.changed = (id) => {
 			addedChangedCommand(id)
 		}
-		observer.removed = (id: string) => {
+		observer.removed = (id) => {
 			this.retireExecuteFunction(id)
 		}
-		const cmds = functionObject.core.getCollection<PeripheralDeviceCommand>('peripheralDeviceCommands')
+		const cmds = functionObject.core.getCollection(PeripheralDevicePubSubCollectionsNames.peripheralDeviceCommands)
 		if (!cmds) throw Error('"peripheralDeviceCommands" collection not found!')
 		cmds.find({}).forEach((cmd) => {
 			if (cmd.deviceId === functionObject.core.deviceId) {
@@ -450,7 +411,7 @@ export class CoreHandler {
 
 export class CoreTSRDeviceHandler {
 	core!: CoreConnectionChild
-	public _observers: Array<Observer> = []
+	public _observers: Array<Observer<any>> = []
 	public _devicePr: Promise<BaseRemoteDeviceIntegration<DeviceOptionsAny>>
 	public _deviceId: string
 	public _device!: BaseRemoteDeviceIntegration<DeviceOptionsAny>
@@ -519,7 +480,7 @@ export class CoreTSRDeviceHandler {
 			'CoreTSRDevice: Setting up subscriptions for ' + this.core.deviceId + ' for device ' + deviceId + ' ..'
 		)
 		try {
-			await this.core.autoSubscribe('peripheralDeviceCommands', this.core.deviceId)
+			await this.core.autoSubscribe(PeripheralDevicePubSub.peripheralDeviceCommands, this.core.deviceId)
 		} catch (e) {
 			this._coreParentHandler.logger.error(e)
 		}

--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -23,20 +23,23 @@ import * as crypto from 'crypto'
 import * as cp from 'child_process'
 
 import * as _ from 'underscore'
-import { Observer, stringifyError } from '@sofie-automation/server-core-integration'
+import {
+	Observer,
+	PeripheralDevicePubSubCollectionsNames,
+	stringifyError,
+} from '@sofie-automation/server-core-integration'
 import { Logger } from 'winston'
 import { disableAtemUpload } from './config'
 import Debug from 'debug'
 import { FinishedTrace, sendTrace } from './influxdb'
 
-import { StudioId, TimelineHash } from '@sofie-automation/shared-lib/dist/core/model/Ids'
+import { RundownId, RundownPlaylistId, StudioId, TimelineHash } from '@sofie-automation/shared-lib/dist/core/model/Ids'
 import {
 	deserializeTimelineBlob,
 	RoutedMappings,
 	RoutedTimeline,
 	TimelineObjGeneric,
 } from '@sofie-automation/shared-lib/dist/core/model/Timeline'
-import { DBTimelineDatastoreEntry } from '@sofie-automation/shared-lib/dist/core/model/TimelineDatastore'
 import { PLAYOUT_DEVICE_CONFIG } from './configManifest'
 import { PlayoutGatewayConfig } from './generated/options'
 import {
@@ -97,9 +100,9 @@ export class TSRHandler {
 	tsr!: Conductor
 	// private _config: TSRConfig
 	private _coreHandler!: CoreHandler
-	private _triggerupdateExpectedPlayoutItemsTimeout: any = null
+	private _triggerupdateExpectedPlayoutItemsTimeout: NodeJS.Timeout | null = null
 	private _coreTsrHandlers: { [deviceId: string]: CoreTSRDeviceHandler } = {}
-	private _observers: Array<Observer> = []
+	private _observers: Array<Observer<any>> = []
 	private _cachedStudioId: StudioId | null = null
 
 	private _initialized = false
@@ -250,7 +253,7 @@ export class TSRHandler {
 		}
 		this.logger.debug('Renewing observers')
 
-		const timelineObserver = this._coreHandler.core.observe('studioTimeline')
+		const timelineObserver = this._coreHandler.core.observe(PeripheralDevicePubSubCollectionsNames.studioTimeline)
 		timelineObserver.added = () => {
 			this._triggerupdateTimelineAndMappings('studioTimeline.added', true)
 		}
@@ -262,7 +265,7 @@ export class TSRHandler {
 		}
 		this._observers.push(timelineObserver)
 
-		const mappingsObserver = this._coreHandler.core.observe('studioMappings')
+		const mappingsObserver = this._coreHandler.core.observe(PeripheralDevicePubSubCollectionsNames.studioMappings)
 		mappingsObserver.added = () => {
 			this._triggerupdateTimelineAndMappings('studioMappings.added')
 		}
@@ -274,7 +277,9 @@ export class TSRHandler {
 		}
 		this._observers.push(mappingsObserver)
 
-		const deviceObserver = this._coreHandler.core.observe('peripheralDeviceForDevice')
+		const deviceObserver = this._coreHandler.core.observe(
+			PeripheralDevicePubSubCollectionsNames.peripheralDeviceForDevice
+		)
 		deviceObserver.added = () => {
 			debug('triggerUpdateDevices from deviceObserver added')
 			this._triggerUpdateDevices()
@@ -292,7 +297,9 @@ export class TSRHandler {
 		}
 		this._observers.push(deviceObserver)
 
-		const expectedPlayoutItemsObserver = this._coreHandler.core.observe('expectedPlayoutItems')
+		const expectedPlayoutItemsObserver = this._coreHandler.core.observe(
+			PeripheralDevicePubSubCollectionsNames.expectedPlayoutItems
+		)
 		expectedPlayoutItemsObserver.added = () => {
 			this._triggerupdateExpectedPlayoutItems()
 		}
@@ -304,7 +311,9 @@ export class TSRHandler {
 		}
 		this._observers.push(expectedPlayoutItemsObserver)
 
-		const timelineDatastoreObserver = this._coreHandler.core.observe('timelineDatastore')
+		const timelineDatastoreObserver = this._coreHandler.core.observe(
+			PeripheralDevicePubSubCollectionsNames.timelineDatastore
+		)
 		timelineDatastoreObserver.added = () => {
 			this._triggerUpdateDatastore()
 		}
@@ -339,7 +348,9 @@ export class TSRHandler {
 			return undefined
 		}
 
-		return this._coreHandler.core.getCollection<RoutedTimeline>('studioTimeline').findOne(studioId)
+		return this._coreHandler.core
+			.getCollection(PeripheralDevicePubSubCollectionsNames.studioTimeline)
+			.findOne(studioId)
 	}
 	getMappings(): RoutedMappings | undefined {
 		const studioId = this._getStudioId()
@@ -348,7 +359,9 @@ export class TSRHandler {
 			return undefined
 		}
 		// Note: The studioMappings virtual collection contains a single object that contains all mappings
-		return this._coreHandler.core.getCollection<RoutedMappings>('studioMappings').findOne(studioId)
+		return this._coreHandler.core
+			.getCollection(PeripheralDevicePubSubCollectionsNames.studioMappings)
+			.findOne(studioId)
 	}
 	onSettingsChanged(): void {
 		if (!this._initialized) return
@@ -424,8 +437,9 @@ export class TSRHandler {
 		this.tsr.setTimelineAndMappings(transformedTimeline, unprotectObject(mappingsObject.mappings))
 	}
 	private _getPeripheralDevice(): PeripheralDeviceForDevice {
-		const peripheralDevices =
-			this._coreHandler.core.getCollection<PeripheralDeviceForDevice>('peripheralDeviceForDevice')
+		const peripheralDevices = this._coreHandler.core.getCollection(
+			PeripheralDevicePubSubCollectionsNames.peripheralDeviceForDevice
+		)
 		const doc = peripheralDevices.findOne(this._coreHandler.core.deviceId)
 		if (!doc) throw new Error('Missing PeripheralDevice document!')
 		return doc
@@ -1016,19 +1030,22 @@ export class TSRHandler {
 		}, 200)
 	}
 	private async _updateExpectedPlayoutItems() {
-		const expectedPlayoutItems = this._coreHandler.core.getCollection<any>('expectedPlayoutItems')
+		const expectedPlayoutItems = this._coreHandler.core.getCollection(
+			PeripheralDevicePubSubCollectionsNames.expectedPlayoutItems
+		)
 		const peripheralDevice = this._getPeripheralDevice()
 
 		const expectedItems = expectedPlayoutItems.find({
 			studioId: peripheralDevice.studioId,
 		})
 
-		const rundowns = _.indexBy(
-			this._coreHandler.core.getCollection<any>('rundowns').find({
-				studioId: peripheralDevice.studioId,
-			}),
-			'_id'
-		)
+		const rundownIdToPlaylistId = new Map<RundownId, RundownPlaylistId>()
+		const allRundowns = this._coreHandler.core.getCollection(PeripheralDevicePubSubCollectionsNames.rundowns).find({
+			studioId: peripheralDevice.studioId,
+		})
+		for (const rundown of allRundowns) {
+			rundownIdToPlaylistId.set(rundown._id, rundown.playlistId)
+		}
 
 		await Promise.all(
 			_.map(this.tsr.getDevices(), async (container) => {
@@ -1036,22 +1053,22 @@ export class TSRHandler {
 					return
 				}
 				await container.device.handleExpectedPlayoutItems(
-					_.map(
-						_.filter(
-							expectedItems,
+					expectedItems
+						.filter(
 							(item) => item.deviceSubType === container.deviceType
 							// TODO: implement item.deviceId === container.deviceId
-						),
-						(item): ExpectedPlayoutItem => {
+						)
+						.map((item): ExpectedPlayoutItem => {
 							const itemContent: ExpectedPlayoutItemContent = item.content
 							return {
 								...itemContent,
-								rundownId: item.rundownId,
-								playlistId: item.rundownId && rundowns[item.rundownId]?.playlistId,
+								rundownId: unprotectString(item.rundownId) ?? '',
+								playlistId:
+									(item.rundownId && unprotectString(rundownIdToPlaylistId.get(item.rundownId))) ??
+									'',
 								baseline: item.baseline,
 							}
-						}
-					)
+						})
 				)
 			})
 		)
@@ -1061,7 +1078,9 @@ export class TSRHandler {
 		this._updateDatastore().catch((e) => this.logger.error('Error in _updateDatastore', e))
 	}
 	private async _updateDatastore() {
-		const datastoreCollection = this._coreHandler.core.getCollection<DBTimelineDatastoreEntry>('timelineDatastore')
+		const datastoreCollection = this._coreHandler.core.getCollection(
+			PeripheralDevicePubSubCollectionsNames.timelineDatastore
+		)
 		const peripheralDevice = this._getPeripheralDevice()
 
 		const datastoreObjs = datastoreCollection.find({

--- a/packages/server-core-integration/README.md
+++ b/packages/server-core-integration/README.md
@@ -57,7 +57,7 @@ This library is developed as part of [Sofie Server Core](https://github.com/nrkn
 This library has a self-contained DDP client that can be used independently of the rest of the module.
 
 ```typescript
-import { DDPClient, DDPConnectorOptions } from 'tv-automation-server-integration'
+import { DDPClient, DDPConnectorOptions, PeripheralDevicePubSubCollectionsNames } from 'tv-automation-server-integration'
 
 let options: DDPConnectorOptions = {
 	host: '127.0.0.1',
@@ -72,7 +72,7 @@ ddp.connect((err: any) => {
 		return
 	}
 	let subId = ddp.subscribe('expectedMediaItems')
-	ddp.observe('expectedMediaItems', /* added cb */, /* changed cb */, /* removed cb */)
+	ddp.observe(PeripheralDevicePubSubCollectionsNames.expectedMediaItems, /* added cb */, /* changed cb */, /* removed cb */)
 
 	/* ... then later ... */
 	ddp.unsub(subId)

--- a/packages/server-core-integration/README.md
+++ b/packages/server-core-integration/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/@sofie-automation/server-core-integration)](https://www.npmjs.com/package/@sofie-automation/server-core-integration)
 
-This library is used to connect to the [**Sofie Server Core**](https://github.com/nrkno/tv-automation-server-core) from other Node processes.
+This library is used to connect to the [**Sofie Server Core**](https://github.com/nrkno/sofie-core) from other Node processes.
 
 This is a part of the [**Sofie** TV News Studio Automation System](https://github.com/nrkno/Sofie-TV-automation/).
 
@@ -45,7 +45,7 @@ core
 
 ## Development
 
-This library is developed as part of [Sofie Server Core](https://github.com/nrkno/tv-automation-server-core). See there for more instructions
+This library is developed as part of [Sofie Server Core](https://github.com/nrkno/sofie-core). See there for more instructions
 
 - Build
   - Build, `yarn build`
@@ -57,7 +57,7 @@ This library is developed as part of [Sofie Server Core](https://github.com/nrkn
 This library has a self-contained DDP client that can be used independently of the rest of the module.
 
 ```typescript
-import { DDPClient, DDPConnectorOptions, PeripheralDevicePubSubCollectionsNames } from 'tv-automation-server-integration'
+import { DDPClient, DDPConnectorOptions } from '@sofie-automation/server-integration'
 
 let options: DDPConnectorOptions = {
 	host: '127.0.0.1',
@@ -72,7 +72,7 @@ ddp.connect((err: any) => {
 		return
 	}
 	let subId = ddp.subscribe('expectedMediaItems')
-	ddp.observe(PeripheralDevicePubSubCollectionsNames.expectedMediaItems, /* added cb */, /* changed cb */, /* removed cb */)
+	ddp.observe('expectedMediaItems', /* added cb */, /* changed cb */, /* removed cb */)
 
 	/* ... then later ... */
 	ddp.unsub(subId)

--- a/packages/server-core-integration/examples/client.ts
+++ b/packages/server-core-integration/examples/client.ts
@@ -4,7 +4,7 @@ import {
 	PeripheralDeviceCategory,
 	PeripheralDeviceType,
 } from '@sofie-automation/shared-lib/dist/peripheralDevice/peripheralDeviceAPI'
-import { CoreConnection } from '../src/index'
+import { CoreConnection, PeripheralDevicePubSub, PeripheralDevicePubSubCollectionsNames } from '../src/index'
 
 const core = new CoreConnection({
 	deviceId: protectString('ExampleDevice'),
@@ -39,13 +39,13 @@ core.onFailed((err) => {
 
 const setupSubscription = async () => {
 	console.log('Setup subscription')
-	return core.autoSubscribe('peripheralDeviceForDevice', core.deviceId).then(() => {
+	return core.autoSubscribe(PeripheralDevicePubSub.peripheralDeviceForDevice, core.deviceId).then(() => {
 		console.log('sub OK!')
 	})
 }
 const setupObserver = () => {
 	console.log('Setup observer')
-	const observer = core.observe('peripheralDeviceForDevice')
+	const observer = core.observe(PeripheralDevicePubSubCollectionsNames.peripheralDeviceForDevice)
 	observer.added = (id) => {
 		console.log('added', id)
 	}

--- a/packages/server-core-integration/src/__tests__/index.spec.ts
+++ b/packages/server-core-integration/src/__tests__/index.spec.ts
@@ -5,7 +5,7 @@ import {
 	PeripheralDeviceType,
 	PERIPHERAL_SUBTYPE_PROCESS,
 } from '@sofie-automation/shared-lib/dist/peripheralDevice/peripheralDeviceAPI'
-import { CoreConnection } from '../index'
+import { CoreConnection, PeripheralDevicePubSub, PeripheralDevicePubSubCollectionsNames } from '../index'
 import { DDPConnectorOptions } from '../lib/ddpClient'
 jest.mock('faye-websocket')
 jest.mock('got')
@@ -110,16 +110,16 @@ describe('coreConnection', () => {
 		})
 
 		// Observe data:
-		const observer = core.observe('peripheralDeviceForDevice')
+		const observer = core.observe(PeripheralDevicePubSubCollectionsNames.peripheralDeviceForDevice)
 		observer.added = jest.fn()
 		observer.changed = jest.fn()
 		observer.removed = jest.fn()
 
 		// Subscribe to data:
-		const coll0 = core.getCollection<any>('peripheralDeviceForDevice')
+		const coll0 = core.getCollection(PeripheralDevicePubSubCollectionsNames.peripheralDeviceForDevice)
 		expect(coll0.findOne(id)).toBeFalsy()
-		const subId = await core.autoSubscribe('peripheralDeviceForDevice', id)
-		const coll1 = core.getCollection<any>('peripheralDeviceForDevice')
+		const subId = await core.autoSubscribe(PeripheralDevicePubSub.peripheralDeviceForDevice, id)
+		const coll1 = core.getCollection(PeripheralDevicePubSubCollectionsNames.peripheralDeviceForDevice)
 		expect(coll1.findOne(id)).toMatchObject({
 			_id: id,
 		})
@@ -294,12 +294,12 @@ describe('coreConnection', () => {
 		const observerAdded = jest.fn()
 		const observerChanged = jest.fn()
 		const observerRemoved = jest.fn()
-		const observer = core.observe('peripheralDeviceForDevice')
+		const observer = core.observe(PeripheralDevicePubSubCollectionsNames.peripheralDeviceForDevice)
 		observer.added = observerAdded
 		observer.changed = observerChanged
 		observer.removed = observerRemoved
 
-		await core.autoSubscribe('peripheralDeviceForDevice', defaultDeviceId)
+		await core.autoSubscribe(PeripheralDevicePubSub.peripheralDeviceForDevice, defaultDeviceId)
 
 		expect(observerAdded).toHaveBeenCalledTimes(1)
 

--- a/packages/server-core-integration/src/index.ts
+++ b/packages/server-core-integration/src/index.ts
@@ -18,3 +18,4 @@ export { PeripheralDeviceCommand } from '@sofie-automation/shared-lib/dist/core/
 export { StatusCode } from '@sofie-automation/shared-lib/dist/lib/status'
 export * as PeripheralDeviceAPI from '@sofie-automation/shared-lib/dist/peripheralDevice/peripheralDeviceAPI'
 export { PeripheralDeviceId, StudioId } from '@sofie-automation/shared-lib/dist/core/model/Ids'
+export * from '@sofie-automation/shared-lib/dist/pubsub/peripheralDevice'

--- a/packages/server-core-integration/src/integrationTests/index.spec.ts
+++ b/packages/server-core-integration/src/integrationTests/index.spec.ts
@@ -1,5 +1,4 @@
 jest.dontMock('ddp')
-import { PeripheralDeviceForDevice } from '@sofie-automation/shared-lib/dist/core/model/peripheralDevice'
 import { protectString } from '@sofie-automation/shared-lib/dist/lib/protectedString'
 import { StatusCode } from '@sofie-automation/shared-lib/dist/lib/status'
 import {
@@ -7,7 +6,7 @@ import {
 	PeripheralDeviceCategory,
 	PeripheralDeviceType,
 } from '@sofie-automation/shared-lib/dist/peripheralDevice/peripheralDeviceAPI'
-import { CoreConnection } from '../index'
+import { CoreConnection, PeripheralDevicePubSub, PeripheralDevicePubSubCollectionsNames } from '../index'
 
 process.on('unhandledRejection', (reason) => {
 	console.log('Unhandled Promise rejection!', reason)
@@ -85,17 +84,17 @@ test('Integration: Test connection and basic Core functionality', async () => {
 	})
 
 	// Observe data:
-	const observer = core.observe('peripheralDeviceForDevice')
+	const observer = core.observe(PeripheralDevicePubSubCollectionsNames.peripheralDeviceForDevice)
 	observer.added = jest.fn()
 	observer.changed = jest.fn()
 	observer.removed = jest.fn()
 
 	// Subscribe to data:
-	const coll0 = core.getCollection<PeripheralDeviceForDevice>('peripheralDeviceForDevice')
+	const coll0 = core.getCollection(PeripheralDevicePubSubCollectionsNames.peripheralDeviceForDevice)
 	expect(coll0.findOne(id)).toBeFalsy()
-	const subId = await core.autoSubscribe('peripheralDeviceForDevice', id)
+	const subId = await core.autoSubscribe(PeripheralDevicePubSub.peripheralDeviceForDevice, id)
 
-	const coll1 = core.getCollection<PeripheralDeviceForDevice>('peripheralDeviceForDevice')
+	const coll1 = core.getCollection(PeripheralDevicePubSubCollectionsNames.peripheralDeviceForDevice)
 	expect(coll1.findOne(id)).toMatchObject({
 		_id: id,
 	})
@@ -275,12 +274,12 @@ test('Integration: autoSubscription', async () => {
 	const observerAdded = jest.fn()
 	const observerChanged = jest.fn()
 	const observerRemoved = jest.fn()
-	const observer = core.observe('peripheralDeviceForDevice')
+	const observer = core.observe(PeripheralDevicePubSubCollectionsNames.peripheralDeviceForDevice)
 	observer.added = observerAdded
 	observer.changed = observerChanged
 	observer.removed = observerRemoved
 
-	await core.autoSubscribe('peripheralDeviceForDevice', defaultDeviceId)
+	await core.autoSubscribe(PeripheralDevicePubSub.peripheralDeviceForDevice, defaultDeviceId)
 
 	expect(observerAdded).toHaveBeenCalledTimes(1)
 

--- a/packages/server-core-integration/src/lib/ddpClient.ts
+++ b/packages/server-core-integration/src/lib/ddpClient.ts
@@ -12,6 +12,7 @@ import * as WebSocket from 'faye-websocket'
 import * as EJSON from 'ejson'
 import { EventEmitter } from 'eventemitter3'
 import got from 'got'
+import { ProtectedString } from '@sofie-automation/shared-lib/dist/lib/protectedString'
 
 export interface TLSOpts {
 	// Described in https://nodejs.org/api/tls.html#tls_tls_connect_options_callback
@@ -48,27 +49,22 @@ export interface DDPConnectorOptions {
 /**
  * Observer watching for changes to a collection.
  */
-export interface Observer {
+export interface Observer<Doc extends { _id: ProtectedString<any> | string }> {
 	/** Name of the collection being observed */
 	readonly name: string
 	/** Identifier of this observer */
-	readonly id: string
+	readonly id: Doc['_id']
 	/**
 	 * Callback when a document is added to a collection.
 	 * @callback
 	 * @param id Identifier of the document added
 	 * @param fields The added document
 	 */
-	added: (id: string, fields?: { [attr: string]: unknown }) => void
+	added: (id: Doc['_id'], fields?: Partial<Doc>) => void
 	/** Callback when a document is changed in a collection. */
-	changed: (
-		id: string,
-		oldFields: { [attr: string]: unknown },
-		clearedFields: Array<string>,
-		newFields: { [attr: string]: unknown }
-	) => void
+	changed: (id: Doc['_id'], oldFields: Partial<Doc>, clearedFields: Array<keyof Doc>, newFields: Partial<Doc>) => void
 	/** Callback when a document is removed from a collection. */
-	removed: (id: string, oldValue: { [attr: string]: unknown }) => void
+	removed: (id: Doc['_id'], oldValue: Partial<Doc>) => void
 	/** Request to stop observing the collection */
 	stop: () => void
 }
@@ -398,7 +394,7 @@ export class DDPClient extends EventEmitter<DDPClientEvents> {
 	private callbacks: { [id: string]: (error?: DDPError, result?: unknown) => void } = {}
 	private updatedCallbacks: { [name: string]: () => void } = {}
 	private pendingMethods: { [id: string]: boolean } = {}
-	private observers: { [name: string]: { [_id: string]: Observer } } = {}
+	private observers: { [name: string]: { [_id: string]: Observer<any> } } = {}
 	private reconnectTimeout: NodeJS.Timeout | null = null
 
 	constructor(opts?: DDPConnectorOptions) {
@@ -530,7 +526,7 @@ export class DDPClient extends EventEmitter<DDPClientEvents> {
 			}
 
 			if (this.observers[name]) {
-				Object.values<Observer>(this.observers[name]).forEach((ob) => ob.added(id, data.fields))
+				Object.values<Observer<any>>(this.observers[name]).forEach((ob) => ob.added(id, data.fields))
 			}
 		}
 	}
@@ -549,7 +545,7 @@ export class DDPClient extends EventEmitter<DDPClientEvents> {
 			delete this.collections[name][id]
 
 			if (this.observers[name]) {
-				Object.values<Observer>(this.observers[name]).forEach((ob) => ob.removed(id, oldValue))
+				Object.values<Observer<any>>(this.observers[name]).forEach((ob) => ob.removed(id, oldValue))
 			}
 		}
 	}
@@ -585,7 +581,7 @@ export class DDPClient extends EventEmitter<DDPClientEvents> {
 			}
 
 			if (this.observers[name]) {
-				Object.values<Observer>(this.observers[name]).forEach((ob) =>
+				Object.values<Observer<any>>(this.observers[name]).forEach((ob) =>
 					ob.changed(id, oldFields, clearedFields, newFields)
 				)
 			}
@@ -640,14 +636,14 @@ export class DDPClient extends EventEmitter<DDPClientEvents> {
 		return (this.nextId += 1).toString()
 	}
 
-	private addObserver(observer: Observer): void {
+	private addObserver(observer: Observer<any>): void {
 		if (!this.observers[observer.name]) {
 			this.observers[observer.name] = {}
 		}
 		this.observers[observer.name][observer.id] = observer
 	}
 
-	private removeObserver(observer: Observer): void {
+	private removeObserver(observer: Observer<any>): void {
 		if (!this.observers[observer.name]) {
 			return
 		}
@@ -867,11 +863,11 @@ export class DDPClient extends EventEmitter<DDPClientEvents> {
 	 */
 	observe(
 		collectionName: string,
-		added?: Observer['added'],
-		changed?: Observer['changed'],
-		removed?: Observer['removed']
-	): Observer {
-		const observer: Observer = {
+		added?: Observer<any>['added'],
+		changed?: Observer<any>['changed'],
+		removed?: Observer<any>['removed']
+	): Observer<any> {
+		const observer: Observer<any> = {
 			id: this.getNextId(),
 			name: collectionName,
 			added:

--- a/packages/shared-lib/src/expectedPlayoutItem.ts
+++ b/packages/shared-lib/src/expectedPlayoutItem.ts
@@ -1,0 +1,24 @@
+import { RundownId } from './core/model/Ids'
+import { ProtectedString } from './lib/protectedString'
+import { TSR } from './tsr'
+
+/** @deprecated */
+export interface ExpectedPlayoutItemGeneric {
+	_id: ProtectedString<any> // TODO - type
+
+	/** What type of playout device this item should be handled by */
+	deviceSubType: TSR.DeviceType // subset of PeripheralDeviceAPI.DeviceSubType
+	/** Which playout device this item should be handled by */
+	// deviceId: string // Todo: implement deviceId support (later)
+	/** Content of the expectedPlayoutItem */
+	content: TSR.ExpectedPlayoutItemContent
+}
+
+export interface ExpectedPlayoutItemPeripheralDevice extends ExpectedPlayoutItemGeneric {
+	rundownId?: RundownId
+
+	baseline?: 'rundown' | 'studio'
+}
+
+type ExpectedPlayoutItemContent = TSR.ExpectedPlayoutItemContent
+export { ExpectedPlayoutItemContent }

--- a/packages/shared-lib/src/pubsub/peripheralDevice.ts
+++ b/packages/shared-lib/src/pubsub/peripheralDevice.ts
@@ -1,0 +1,139 @@
+import { PeripheralDeviceForDevice } from '../core/model/peripheralDevice'
+import { RoutedMappings, RoutedTimeline } from '../core/model/Timeline'
+import { DBTimelineDatastoreEntry } from '../core/model/TimelineDatastore'
+import {
+	PackageManagerPlayoutContext,
+	PackageManagerPackageContainers,
+	PackageManagerExpectedPackage,
+} from '../package-manager/publications'
+import { PeripheralDeviceId, RundownId, RundownPlaylistId } from '../core/model/Ids'
+import { PeripheralDeviceCommand } from '../core/model/PeripheralDeviceCommand'
+import { ExpectedPlayoutItemPeripheralDevice } from '../expectedPlayoutItem'
+import { DeviceTriggerMountedAction, PreviewWrappedAdLib } from '../input-gateway/deviceTriggerPreviews'
+
+/**
+ * Ids of possible DDP subscriptions for any PeripheralDevice.
+ */
+export enum PeripheralDevicePubSub {
+	peripheralDeviceCommands = 'peripheralDeviceCommands',
+
+	// For a PeripheralDevice
+	rundownsForDevice = 'rundownsForDevice',
+
+	// custom publications:
+	peripheralDeviceForDevice = 'peripheralDeviceForDevice',
+	mappingsForDevice = 'mappingsForDevice',
+	timelineForDevice = 'timelineForDevice',
+	timelineDatastoreForDevice = 'timelineDatastoreForDevice',
+	expectedPlayoutItemsForDevice = 'expectedPlayoutItemsForDevice',
+
+	mountedTriggersForDevice = 'mountedTriggersForDevice',
+	mountedTriggersForDevicePreview = 'mountedTriggersForDevicePreview',
+
+	packageManagerPlayoutContext = 'packageManagerPlayoutContext',
+	packageManagerPackageContainers = 'packageManagerPackageContainers',
+	packageManagerExpectedPackages = 'packageManagerExpectedPackages',
+}
+
+/**
+ * Type definitions for DDP subscriptions to be used by any PeripheralDevice.
+ */
+export interface PeripheralDevicePubSubTypes {
+	[PeripheralDevicePubSub.peripheralDeviceCommands]: (
+		deviceId: PeripheralDeviceId,
+		token?: string
+	) => PeripheralDevicePubSubCollectionsNames.peripheralDeviceCommands
+
+	// For a PeripheralDevice
+	[PeripheralDevicePubSub.rundownsForDevice]: (
+		deviceId: PeripheralDeviceId,
+		token?: string
+	) => PeripheralDevicePubSubCollectionsNames.rundowns
+
+	// custom publications:
+	[PeripheralDevicePubSub.peripheralDeviceForDevice]: (
+		deviceId: PeripheralDeviceId,
+		token?: string
+	) => PeripheralDevicePubSubCollectionsNames.peripheralDeviceForDevice
+	[PeripheralDevicePubSub.mappingsForDevice]: (
+		deviceId: PeripheralDeviceId,
+		token?: string
+	) => PeripheralDevicePubSubCollectionsNames.studioMappings
+	[PeripheralDevicePubSub.timelineForDevice]: (
+		deviceId: PeripheralDeviceId,
+		token?: string
+	) => PeripheralDevicePubSubCollectionsNames.studioTimeline
+	[PeripheralDevicePubSub.timelineDatastoreForDevice]: (
+		deviceId: PeripheralDeviceId,
+		token?: string
+	) => PeripheralDevicePubSubCollectionsNames.timelineDatastore
+	[PeripheralDevicePubSub.expectedPlayoutItemsForDevice]: (
+		deviceId: PeripheralDeviceId,
+		token?: string
+	) => PeripheralDevicePubSubCollectionsNames.expectedPlayoutItems
+
+	[PeripheralDevicePubSub.mountedTriggersForDevice]: (
+		deviceId: PeripheralDeviceId,
+		deviceIds: string[],
+		token?: string
+	) => PeripheralDevicePubSubCollectionsNames.mountedTriggers
+	[PeripheralDevicePubSub.mountedTriggersForDevicePreview]: (
+		deviceId: PeripheralDeviceId,
+		token?: string
+	) => PeripheralDevicePubSubCollectionsNames.mountedTriggersPreviews
+
+	/** Custom publications for package-manager */
+	[PeripheralDevicePubSub.packageManagerPlayoutContext]: (
+		deviceId: PeripheralDeviceId,
+		token: string | undefined
+	) => PeripheralDevicePubSubCollectionsNames.packageManagerPlayoutContext
+	[PeripheralDevicePubSub.packageManagerPackageContainers]: (
+		deviceId: PeripheralDeviceId,
+		token: string | undefined
+	) => PeripheralDevicePubSubCollectionsNames.packageManagerPackageContainers
+	[PeripheralDevicePubSub.packageManagerExpectedPackages]: (
+		deviceId: PeripheralDeviceId,
+		filterPlayoutDeviceIds: PeripheralDeviceId[] | undefined,
+		token: string | undefined
+	) => PeripheralDevicePubSubCollectionsNames.packageManagerExpectedPackages
+}
+
+export enum PeripheralDevicePubSubCollectionsNames {
+	// Real Mongodb collections:
+	peripheralDeviceCommands = 'peripheralDeviceCommands',
+	rundowns = 'rundowns',
+	expectedPlayoutItems = 'expectedPlayoutItems',
+	timelineDatastore = 'timelineDatastore',
+
+	// Custom collections:
+	peripheralDeviceForDevice = 'peripheralDeviceForDevice',
+	studioMappings = 'studioMappings',
+	studioTimeline = 'studioTimeline',
+
+	mountedTriggersPreviews = 'mountedTriggersPreviews',
+	mountedTriggers = 'mountedTriggers',
+
+	packageManagerPlayoutContext = 'packageManagerPlayoutContext',
+	packageManagerPackageContainers = 'packageManagerPackageContainers',
+	packageManagerExpectedPackages = 'packageManagerExpectedPackages',
+}
+
+export type PeripheralDevicePubSubCollections = {
+	// Real Mongodb collections:
+	[PeripheralDevicePubSubCollectionsNames.peripheralDeviceCommands]: PeripheralDeviceCommand
+	[PeripheralDevicePubSubCollectionsNames.rundowns]: { _id: RundownId; playlistId: RundownPlaylistId }
+	[PeripheralDevicePubSubCollectionsNames.expectedPlayoutItems]: ExpectedPlayoutItemPeripheralDevice
+	[PeripheralDevicePubSubCollectionsNames.timelineDatastore]: DBTimelineDatastoreEntry
+
+	// Custom collections:
+	[PeripheralDevicePubSubCollectionsNames.peripheralDeviceForDevice]: PeripheralDeviceForDevice
+	[PeripheralDevicePubSubCollectionsNames.studioMappings]: RoutedMappings
+	[PeripheralDevicePubSubCollectionsNames.studioTimeline]: RoutedTimeline
+
+	[PeripheralDevicePubSubCollectionsNames.mountedTriggersPreviews]: PreviewWrappedAdLib
+	[PeripheralDevicePubSubCollectionsNames.mountedTriggers]: DeviceTriggerMountedAction
+
+	[PeripheralDevicePubSubCollectionsNames.packageManagerPlayoutContext]: PackageManagerPlayoutContext
+	[PeripheralDevicePubSubCollectionsNames.packageManagerPackageContainers]: PackageManagerPackageContainers
+	[PeripheralDevicePubSubCollectionsNames.packageManagerExpectedPackages]: PackageManagerExpectedPackage
+}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

* **What is the current behavior?** (You can also link to an open issue here)

Subscribing to publications in peripheraldevices is loosely typed, and requires each gateway to know the type of each collection it is accessing.

* **What is the new behavior (if this is a feature change)?**

the `PubSub` enum has been split up to reflect what is available at different levels, and each gateway is able to define what subset it wants to access, resulting in the correct typings being available for publications.  
One portion resides in `shared-lib`, and is available to all peripheral devices (and is the default, unless they specify another set).  
Another portion resides in `corelib`, and contains publications for the Rundown/RundownPlaylist and its contents. This is intended to be used by the live-status gateway.
The final portion resides in the old location, and is intended to be used solely by the Meteor UI. The Meteor UI also has access to the rest of the publication types.

As part of this, some typings had to be adjusted inside LSG to make the compiler happy, resulting in it having some more usage of our id types, and some additional generics to get the publications typed properly.

Additionally, the `observe` method in server-core-integration has been made typed to match the collections. This did not have much impact and has improved type safety

* **Other information**:

I have prototyped the required changes for package-manager and input-gateway, PRs will be raised when this gets merged.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] Automated tests to cover the new functionality and/or guard against regressions have been added
- [ ] The functionality has been tested by NRK
