### PR TITLE
fix: mounted device triggers preview reset rundown issue

### DIFF
--- a/meteor/client/ui/TestTools/DeviceTriggers.tsx
+++ b/meteor/client/ui/TestTools/DeviceTriggers.tsx
@@ -100,15 +100,17 @@ function DeviceTriggersControls({ peripheralDeviceId }: IDatastoreControlsProps)
 								</tr>
 								<tr>
 									<td colSpan={5}>
-										{mountedTriggersPreviews
-											.filter((preview) => preview.actionId === entry.actionId)
-											.map((preview) => (
-												<span key={unprotectString(preview._id)}>
-													{JSON.stringify(preview.label)}: {String(preview.type)} {preview.sourceLayerType}{' '}
-													{preview.sourceLayerName?.name}{' '}
-													{preview.sourceLayerName?.abbreviation ? `(${preview.sourceLayerName.abbreviation})` : null}
-												</span>
-											))}
+										<ul className="mod mhn mvn">
+											{mountedTriggersPreviews
+												.filter((preview) => preview.actionId === entry.actionId)
+												.map((preview) => (
+													<li key={unprotectString(preview._id)}>
+														{JSON.stringify(preview.label)}: {String(preview.type)} {preview.sourceLayerType}{' '}
+														{preview.sourceLayerName?.name}{' '}
+														{preview.sourceLayerName?.abbreviation ? `(${preview.sourceLayerName.abbreviation})` : null}
+													</li>
+												))}
+										</ul>
 									</td>
 								</tr>
 							</Fragment>

--- a/meteor/server/api/deviceTriggers/StudioObserver.ts
+++ b/meteor/server/api/deviceTriggers/StudioObserver.ts
@@ -61,8 +61,11 @@ export class StudioObserver extends EventEmitter {
 	#showStyleOfRundownLiveQuery: Meteor.LiveQueryHandle | undefined
 	#rundownsLiveQuery: Meteor.LiveQueryHandle | undefined
 	activePlaylistId: RundownPlaylistId | undefined
+	newActivePlaylistId: RundownPlaylistId | undefined
 	activationId: RundownPlaylistActivationId | undefined
+	newActivationId: RundownPlaylistActivationId | undefined
 	currentRundownId: RundownId | undefined
+	newCurrentRundownId: RundownId | undefined
 	showStyleBaseId: ShowStyleBaseId | undefined
 
 	#changed: ChangedHandler
@@ -127,9 +130,9 @@ export class StudioObserver extends EventEmitter {
 				this.#showStyleOfRundownLiveQuery?.stop()
 				this.#showStyleOfRundownLiveQuery = undefined
 
-				this.activePlaylistId = activePlaylistId
-				this.activationId = activationId
-				this.currentRundownId = currentRundownId
+				this.newActivePlaylistId = activePlaylistId
+				this.newActivationId = activationId
+				this.newCurrentRundownId = currentRundownId
 
 				this.#showStyleOfRundownLiveQuery = this.setupShowStyleOfRundownObserver(currentRundownId)
 			}
@@ -170,20 +173,31 @@ export class StudioObserver extends EventEmitter {
 			) => {
 				const showStyleBaseId = state?.showStyleBase._id
 
-				if (showStyleBaseId === undefined || !this.activePlaylistId || !this.activationId) {
+				if (showStyleBaseId === undefined || !this.newActivePlaylistId || !this.newActivationId) {
+					this.activePlaylistId = undefined
+					this.activationId = undefined
 					this.#rundownsLiveQuery?.stop()
 					this.#rundownsLiveQuery = undefined
 					this.showStyleBaseId = showStyleBaseId
 					return
 				}
 
-				if (showStyleBaseId === this.showStyleBaseId) return
+				if (
+					showStyleBaseId === this.showStyleBaseId &&
+					this.newActivationId === this.activationId &&
+					this.newActivePlaylistId === this.activePlaylistId &&
+					this.newCurrentRundownId === this.currentRundownId
+				)
+					return
 
 				this.#rundownsLiveQuery?.stop()
 				this.#rundownsLiveQuery = undefined
 
+				this.activePlaylistId = this.newActivePlaylistId
 				const activePlaylistId = this.activePlaylistId
+				this.activationId = this.newActivationId
 				const activationId = this.activationId
+				this.currentRundownId = this.newCurrentRundownId
 				this.showStyleBaseId = showStyleBaseId
 
 				let cleanupChanges: (() => void) | undefined = undefined

--- a/meteor/server/api/deviceTriggers/StudioObserver.ts
+++ b/meteor/server/api/deviceTriggers/StudioObserver.ts
@@ -56,17 +56,20 @@ const showStyleBaseFieldSpecifier = literal<MongoFieldSpecifierOnesStrict<Pick<D
 	hotkeyLegend: 1,
 })
 
+interface StudioObserverProps {
+	activePlaylistId: RundownPlaylistId
+	activationId: RundownPlaylistActivationId
+	currentRundownId: RundownId
+}
+
 export class StudioObserver extends EventEmitter {
 	#playlistInStudioLiveQuery: Meteor.LiveQueryHandle
 	#showStyleOfRundownLiveQuery: Meteor.LiveQueryHandle | undefined
 	#rundownsLiveQuery: Meteor.LiveQueryHandle | undefined
-	activePlaylistId: RundownPlaylistId | undefined
-	newActivePlaylistId: RundownPlaylistId | undefined
-	activationId: RundownPlaylistActivationId | undefined
-	newActivationId: RundownPlaylistActivationId | undefined
-	currentRundownId: RundownId | undefined
-	newCurrentRundownId: RundownId | undefined
 	showStyleBaseId: ShowStyleBaseId | undefined
+
+	currentProps: StudioObserverProps | undefined = undefined
+	nextProps: StudioObserverProps | undefined = undefined
 
 	#changed: ChangedHandler
 
@@ -114,25 +117,25 @@ export class StudioObserver extends EventEmitter {
 
 				if (!activePlaylistId || !activationId || !currentRundownId) {
 					this.#showStyleOfRundownLiveQuery?.stop()
-					this.activePlaylistId = undefined
-					this.activationId = undefined
-					this.currentRundownId = undefined
+					this.currentProps = undefined
 					return
 				}
 
 				if (
-					currentRundownId === this.currentRundownId &&
-					activePlaylistId === this.activePlaylistId &&
-					activationId === this.activationId
+					currentRundownId === this.currentProps?.currentRundownId &&
+					activePlaylistId === this.currentProps?.activePlaylistId &&
+					activationId === this.currentProps?.activationId
 				)
 					return
 
 				this.#showStyleOfRundownLiveQuery?.stop()
 				this.#showStyleOfRundownLiveQuery = undefined
 
-				this.newActivePlaylistId = activePlaylistId
-				this.newActivationId = activationId
-				this.newCurrentRundownId = currentRundownId
+				this.nextProps = {
+					activePlaylistId,
+					activationId,
+					currentRundownId,
+				}
 
 				this.#showStyleOfRundownLiveQuery = this.setupShowStyleOfRundownObserver(currentRundownId)
 			}
@@ -173,9 +176,12 @@ export class StudioObserver extends EventEmitter {
 			) => {
 				const showStyleBaseId = state?.showStyleBase._id
 
-				if (showStyleBaseId === undefined || !this.newActivePlaylistId || !this.newActivationId) {
-					this.activePlaylistId = undefined
-					this.activationId = undefined
+				if (
+					showStyleBaseId === undefined ||
+					!this.nextProps?.activePlaylistId ||
+					!this.nextProps?.activationId
+				) {
+					this.currentProps = undefined
 					this.#rundownsLiveQuery?.stop()
 					this.#rundownsLiveQuery = undefined
 					this.showStyleBaseId = showStyleBaseId
@@ -184,20 +190,20 @@ export class StudioObserver extends EventEmitter {
 
 				if (
 					showStyleBaseId === this.showStyleBaseId &&
-					this.newActivationId === this.activationId &&
-					this.newActivePlaylistId === this.activePlaylistId &&
-					this.newCurrentRundownId === this.currentRundownId
+					this.nextProps?.activationId === this.currentProps?.activationId &&
+					this.nextProps?.activePlaylistId === this.currentProps?.activePlaylistId &&
+					this.nextProps?.currentRundownId === this.currentProps?.currentRundownId
 				)
 					return
 
 				this.#rundownsLiveQuery?.stop()
 				this.#rundownsLiveQuery = undefined
 
-				this.activePlaylistId = this.newActivePlaylistId
-				const activePlaylistId = this.activePlaylistId
-				this.activationId = this.newActivationId
-				const activationId = this.activationId
-				this.currentRundownId = this.newCurrentRundownId
+				this.currentProps = this.nextProps
+				this.nextProps = undefined
+
+				const { activationId, activePlaylistId } = this.currentProps
+
 				this.showStyleBaseId = showStyleBaseId
 
 				let cleanupChanges: (() => void) | undefined = undefined


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

When a Rundown is reset, the `deviceTriggersPreview` publication becomes empty.

* **What is the new behavior (if this is a feature change)?**

The `deviceTriggersPreview` is correctly refreshed after a rundown reset.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] Automated tests to cover the new functionality and/or guard against regressions have been added
- [ ] The functionality has been tested by NRK
