### PR TITLE
feat: document publications and remove mongo queries from parameters SOFIE-1183

### DIFF
--- a/meteor/client/lib/triggers/TriggersHandler.tsx
+++ b/meteor/client/lib/triggers/TriggersHandler.tsx
@@ -88,13 +88,10 @@ function useSubscriptions(
 				$in: rundownIds,
 			},
 		}),
+		useSubscription(CorelibPubSub.rundownBaselineAdLibActions, rundownIds),
+		useSubscription(CorelibPubSub.rundownBaselineAdLibPieces, rundownIds),
 		useSubscription(MeteorPubSub.uiShowStyleBase, showStyleBaseId),
 	]
-
-	for (const rundownId of rundownIds) {
-		allReady.push(useSubscription(CorelibPubSub.rundownBaselineAdLibPieces, rundownId))
-		allReady.push(useSubscription(CorelibPubSub.rundownBaselineAdLibActions, rundownId))
-	}
 
 	return !allReady.some((state) => state === false)
 }

--- a/meteor/client/lib/triggers/TriggersHandler.tsx
+++ b/meteor/client/lib/triggers/TriggersHandler.tsx
@@ -74,7 +74,7 @@ function useSubscriptions(
 ) {
 	const allReady = [
 		useSubscription(CorelibPubSub.rundownPlaylists, [rundownPlaylistId], null),
-		useSubscription(CorelibPubSub.rundowns, [rundownPlaylistId], null),
+		useSubscription(CorelibPubSub.rundownsInPlaylists, [rundownPlaylistId]),
 
 		useSubscription(CorelibPubSub.adLibActions, rundownIds),
 		useSubscription(CorelibPubSub.adLibPieces, rundownIds),

--- a/meteor/client/lib/triggers/TriggersHandler.tsx
+++ b/meteor/client/lib/triggers/TriggersHandler.tsx
@@ -78,16 +78,8 @@ function useSubscriptions(
 		}),
 		useSubscription(CorelibPubSub.rundowns, [rundownPlaylistId], null),
 
-		useSubscription(CorelibPubSub.adLibActions, {
-			rundownId: {
-				$in: rundownIds,
-			},
-		}),
-		useSubscription(CorelibPubSub.adLibPieces, {
-			rundownId: {
-				$in: rundownIds,
-			},
-		}),
+		useSubscription(CorelibPubSub.adLibActions, rundownIds),
+		useSubscription(CorelibPubSub.adLibPieces, rundownIds),
 		useSubscription(CorelibPubSub.rundownBaselineAdLibActions, rundownIds),
 		useSubscription(CorelibPubSub.rundownBaselineAdLibPieces, rundownIds),
 		useSubscription(MeteorPubSub.uiShowStyleBase, showStyleBaseId),

--- a/meteor/client/lib/triggers/TriggersHandler.tsx
+++ b/meteor/client/lib/triggers/TriggersHandler.tsx
@@ -73,9 +73,7 @@ function useSubscriptions(
 	showStyleBaseId: ShowStyleBaseId
 ) {
 	const allReady = [
-		useSubscription(CorelibPubSub.rundownPlaylists, {
-			_id: rundownPlaylistId,
-		}),
+		useSubscription(CorelibPubSub.rundownPlaylists, [rundownPlaylistId], null),
 		useSubscription(CorelibPubSub.rundowns, [rundownPlaylistId], null),
 
 		useSubscription(CorelibPubSub.adLibActions, rundownIds),

--- a/meteor/client/lib/triggers/TriggersHandler.tsx
+++ b/meteor/client/lib/triggers/TriggersHandler.tsx
@@ -88,18 +88,13 @@ function useSubscriptions(
 				$in: rundownIds,
 			},
 		}),
-		useSubscription(CorelibPubSub.rundownBaselineAdLibActions, {
-			rundownId: {
-				$in: rundownIds,
-			},
-		}),
-		useSubscription(CorelibPubSub.rundownBaselineAdLibPieces, {
-			rundownId: {
-				$in: rundownIds,
-			},
-		}),
 		useSubscription(MeteorPubSub.uiShowStyleBase, showStyleBaseId),
 	]
+
+	for (const rundownId of rundownIds) {
+		allReady.push(useSubscription(CorelibPubSub.rundownBaselineAdLibPieces, rundownId))
+		allReady.push(useSubscription(CorelibPubSub.rundownBaselineAdLibActions, rundownId))
+	}
 
 	return !allReady.some((state) => state === false)
 }

--- a/meteor/client/ui/Account/OrganizationPage.tsx
+++ b/meteor/client/ui/Account/OrganizationPage.tsx
@@ -53,7 +53,7 @@ export const OrganizationPage = translateWithTracker(() => {
 		componentDidMount(): void {
 			this.autorun(() => {
 				if (this.props.organization) {
-					this.subscribe(MeteorPubSub.usersInOrganization, { organizationId: this.props.organization._id })
+					this.subscribe(MeteorPubSub.usersInOrganization, this.props.organization._id)
 				}
 			})
 		}

--- a/meteor/client/ui/ActiveRundownView.tsx
+++ b/meteor/client/ui/ActiveRundownView.tsx
@@ -16,7 +16,7 @@ export function ActiveRundownView({ studioId }: { studioId: StudioId }): JSX.Ele
 	const { path } = useRouteMatch()
 
 	const studioReady = useSubscription(MeteorPubSub.uiStudio, studioId)
-	const playlistReady = useSubscription(MeteorPubSub.activeRundownPlaylistForStudio, studioId)
+	const playlistReady = useSubscription(MeteorPubSub.rundownPlaylistForStudio, studioId, true)
 
 	const subsReady = studioReady && playlistReady
 

--- a/meteor/client/ui/ActiveRundownView.tsx
+++ b/meteor/client/ui/ActiveRundownView.tsx
@@ -9,7 +9,6 @@ import { UIStudios } from './Collections'
 import { StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { RundownPlaylists } from '../collections'
 import { useTranslation } from 'react-i18next'
-import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 export function ActiveRundownView({ studioId }: { studioId: StudioId }): JSX.Element | null {
 	const { t } = useTranslation()
@@ -17,10 +16,7 @@ export function ActiveRundownView({ studioId }: { studioId: StudioId }): JSX.Ele
 	const { path } = useRouteMatch()
 
 	const studioReady = useSubscription(MeteorPubSub.uiStudio, studioId)
-	const playlistReady = useSubscription(CorelibPubSub.rundownPlaylists, {
-		activationId: { $exists: true },
-		studioId,
-	})
+	const playlistReady = useSubscription(MeteorPubSub.activeRundownPlaylistForStudio, studioId)
 
 	const subsReady = studioReady && playlistReady
 

--- a/meteor/client/ui/ClipTrimPanel/ClipTrimPanel.tsx
+++ b/meteor/client/ui/ClipTrimPanel/ClipTrimPanel.tsx
@@ -86,7 +86,7 @@ export function ClipTrimPanel({
 }: IProps): JSX.Element {
 	const { t } = useTranslation()
 
-	useSubscription(CorelibPubSub.pieces, { _id: pieceId, startRundownId: rundownId })
+	useSubscription(CorelibPubSub.pieces, [rundownId], null) // TODO: This should filter by pieceId, but that requires a different publication and this panel isnt used
 
 	const piece = useTracker(() => Pieces.findOne(pieceId), [pieceId])
 

--- a/meteor/client/ui/ClockView/CameraScreen/index.tsx
+++ b/meteor/client/ui/ClockView/CameraScreen/index.tsx
@@ -96,11 +96,7 @@ export function CameraScreen({ playlist, studioId }: IProps): JSX.Element | null
 	const showStyleBaseIds = useMemo(() => rundowns.map((rundown) => rundown.showStyleBaseId), [rundowns])
 
 	const rundownsReady = useSubscription(CorelibPubSub.rundowns, playlistIds, null)
-	useSubscription(CorelibPubSub.segments, {
-		rundownId: {
-			$in: rundownIds,
-		},
-	})
+	useSubscription(CorelibPubSub.segments, rundownIds, false)
 
 	const studioReady = useSubscription(MeteorPubSub.uiStudio, studioId)
 	useSubscription(CorelibPubSub.partInstances, rundownIds, playlist?.activationId)

--- a/meteor/client/ui/ClockView/CameraScreen/index.tsx
+++ b/meteor/client/ui/ClockView/CameraScreen/index.tsx
@@ -99,7 +99,7 @@ export function CameraScreen({ playlist, studioId }: IProps): JSX.Element | null
 	useSubscription(CorelibPubSub.segments, rundownIds, false)
 
 	const studioReady = useSubscription(MeteorPubSub.uiStudio, studioId)
-	useSubscription(CorelibPubSub.partInstances, rundownIds, playlist?.activationId)
+	useSubscription(CorelibPubSub.partInstances, rundownIds, playlist?.activationId ?? null)
 
 	useSubscription(CorelibPubSub.parts, rundownIds)
 

--- a/meteor/client/ui/ClockView/CameraScreen/index.tsx
+++ b/meteor/client/ui/ClockView/CameraScreen/index.tsx
@@ -107,11 +107,7 @@ export function CameraScreen({ playlist, studioId }: IProps): JSX.Element | null
 
 	useSubscription(CorelibPubSub.parts, rundownIds)
 
-	useSubscription(CorelibPubSub.pieceInstancesSimple, {
-		rundownId: {
-			$in: rundownIds,
-		},
-	})
+	useSubscription(CorelibPubSub.pieceInstancesSimple, rundownIds, null)
 
 	const piecesReady = useSubscription(CorelibPubSub.pieces, {
 		startRundownId: {

--- a/meteor/client/ui/ClockView/CameraScreen/index.tsx
+++ b/meteor/client/ui/ClockView/CameraScreen/index.tsx
@@ -95,13 +95,13 @@ export function CameraScreen({ playlist, studioId }: IProps): JSX.Element | null
 	const rundownIds = useMemo(() => rundowns.map((rundown) => rundown._id), [rundowns])
 	const showStyleBaseIds = useMemo(() => rundowns.map((rundown) => rundown.showStyleBaseId), [rundowns])
 
-	const rundownsReady = useSubscription(CorelibPubSub.rundowns, playlistIds, null)
-	useSubscription(CorelibPubSub.segments, rundownIds, false)
+	const rundownsReady = useSubscription(CorelibPubSub.rundownsInPlaylists, playlistIds)
+	useSubscription(CorelibPubSub.segments, rundownIds, {})
 
 	const studioReady = useSubscription(MeteorPubSub.uiStudio, studioId)
 	useSubscription(CorelibPubSub.partInstances, rundownIds, playlist?.activationId ?? null)
 
-	useSubscription(CorelibPubSub.parts, rundownIds)
+	useSubscription(CorelibPubSub.parts, rundownIds, null)
 
 	useSubscription(CorelibPubSub.pieceInstancesSimple, rundownIds, null)
 

--- a/meteor/client/ui/ClockView/CameraScreen/index.tsx
+++ b/meteor/client/ui/ClockView/CameraScreen/index.tsx
@@ -105,11 +105,7 @@ export function CameraScreen({ playlist, studioId }: IProps): JSX.Element | null
 
 	useSubscription(CorelibPubSub.pieceInstancesSimple, rundownIds, null)
 
-	const piecesReady = useSubscription(CorelibPubSub.pieces, {
-		startRundownId: {
-			$in: rundownIds,
-		},
-	})
+	const piecesReady = useSubscription(CorelibPubSub.pieces, rundownIds, null)
 
 	const [piecesReadyOnce, setPiecesReadyOnce] = useState(false)
 	useEffect(() => {

--- a/meteor/client/ui/ClockView/ClockView.tsx
+++ b/meteor/client/ui/ClockView/ClockView.tsx
@@ -14,7 +14,7 @@ import { CameraScreen } from './CameraScreen'
 import { MeteorPubSub } from '../../../lib/api/pubsub'
 
 export function ClockView({ studioId }: { studioId: StudioId }): JSX.Element {
-	useSubscription(MeteorPubSub.activeRundownPlaylistForStudio, studioId)
+	useSubscription(MeteorPubSub.rundownPlaylistForStudio, studioId, true)
 
 	const playlist = useTracker(
 		() =>

--- a/meteor/client/ui/ClockView/ClockView.tsx
+++ b/meteor/client/ui/ClockView/ClockView.tsx
@@ -11,13 +11,10 @@ import { OverlayScreenSaver } from './OverlayScreenSaver'
 import { RundownPlaylists } from '../../collections'
 import { StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { CameraScreen } from './CameraScreen'
-import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
+import { MeteorPubSub } from '../../../lib/api/pubsub'
 
 export function ClockView({ studioId }: { studioId: StudioId }): JSX.Element {
-	useSubscription(CorelibPubSub.rundownPlaylists, {
-		activationId: { $exists: true },
-		studioId,
-	})
+	useSubscription(MeteorPubSub.activeRundownPlaylistForStudio, studioId)
 
 	const playlist = useTracker(
 		() =>

--- a/meteor/client/ui/ClockView/OverlayScreenSaver.tsx
+++ b/meteor/client/ui/ClockView/OverlayScreenSaver.tsx
@@ -6,7 +6,6 @@ import { findNextPlaylist } from '../StudioScreenSaver/StudioScreenSaver'
 // @ts-expect-error No types available
 import Velocity from 'velocity-animate'
 import { StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
-import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 export function OverlayScreenSaver({ studioId }: { studioId: StudioId }): JSX.Element {
 	const studioNameRef = useRef<HTMLDivElement>(null)
@@ -19,7 +18,7 @@ export function OverlayScreenSaver({ studioId }: { studioId: StudioId }): JSX.El
 	})
 
 	useSubscription(MeteorPubSub.uiStudio, studioId)
-	useSubscription(CorelibPubSub.rundownPlaylists, { studioId: studioId, activationId: { $exists: false } })
+	useSubscription(MeteorPubSub.rundownPlaylistForStudio, studioId, false)
 
 	const data = useTracker(() => findNextPlaylist({ studioId }), [studioId])
 

--- a/meteor/client/ui/ClockView/PresenterScreen.tsx
+++ b/meteor/client/ui/ClockView/PresenterScreen.tsx
@@ -329,9 +329,7 @@ export class PresenterScreenBase extends MeteorReactComponent<
 					const showStyleBaseIds = rundowns.map((r) => r.showStyleBaseId)
 					const showStyleVariantIds = rundowns.map((r) => r.showStyleVariantId)
 
-					this.subscribe(CorelibPubSub.segments, {
-						rundownId: { $in: rundownIds },
-					})
+					this.subscribe(CorelibPubSub.segments, rundownIds, false)
 					this.subscribe(CorelibPubSub.parts, rundownIds)
 					this.subscribe(CorelibPubSub.partInstances, rundownIds, playlist.activationId)
 

--- a/meteor/client/ui/ClockView/PresenterScreen.tsx
+++ b/meteor/client/ui/ClockView/PresenterScreen.tsx
@@ -338,11 +338,7 @@ export class PresenterScreenBase extends MeteorReactComponent<
 					}
 
 					this.subscribe(CorelibPubSub.showStyleVariants, showStyleVariantIds)
-					this.subscribe(MeteorPubSub.rundownLayouts, {
-						showStyleBaseId: {
-							$in: showStyleBaseIds,
-						},
-					})
+					this.subscribe(MeteorPubSub.rundownLayouts, showStyleBaseIds)
 
 					this.autorun(() => {
 						const playlistR = RundownPlaylists.findOne(this.props.playlistId, {

--- a/meteor/client/ui/ClockView/PresenterScreen.tsx
+++ b/meteor/client/ui/ClockView/PresenterScreen.tsx
@@ -357,16 +357,20 @@ export class PresenterScreenBase extends MeteorReactComponent<
 							const { nextPartInstance, currentPartInstance } =
 								RundownPlaylistCollectionUtil.getSelectedPartInstances(playlistR)
 							if (currentPartInstance) {
-								this.subscribe(CorelibPubSub.pieceInstances, {
-									rundownId: currentPartInstance.rundownId,
-									partInstanceId: currentPartInstance._id,
-								})
+								this.subscribe(
+									CorelibPubSub.pieceInstances,
+									[currentPartInstance.rundownId],
+									[currentPartInstance._id],
+									false
+								)
 							}
 							if (nextPartInstance) {
-								this.subscribe(CorelibPubSub.pieceInstances, {
-									rundownId: nextPartInstance.rundownId,
-									partInstanceId: nextPartInstance._id,
-								})
+								this.subscribe(
+									CorelibPubSub.pieceInstances,
+									[nextPartInstance.rundownId],
+									[nextPartInstance._id],
+									false
+								)
 							}
 						}
 					})

--- a/meteor/client/ui/ClockView/PresenterScreen.tsx
+++ b/meteor/client/ui/ClockView/PresenterScreen.tsx
@@ -337,11 +337,7 @@ export class PresenterScreenBase extends MeteorReactComponent<
 						this.subscribe(MeteorPubSub.uiShowStyleBase, rundown.showStyleBaseId)
 					}
 
-					this.subscribe(CorelibPubSub.showStyleVariants, {
-						_id: {
-							$in: showStyleVariantIds,
-						},
-					})
+					this.subscribe(CorelibPubSub.showStyleVariants, showStyleVariantIds)
 					this.subscribe(MeteorPubSub.rundownLayouts, {
 						showStyleBaseId: {
 							$in: showStyleBaseIds,

--- a/meteor/client/ui/ClockView/PresenterScreen.tsx
+++ b/meteor/client/ui/ClockView/PresenterScreen.tsx
@@ -331,7 +331,7 @@ export class PresenterScreenBase extends MeteorReactComponent<
 
 					this.subscribe(CorelibPubSub.segments, rundownIds, false)
 					this.subscribe(CorelibPubSub.parts, rundownIds)
-					this.subscribe(CorelibPubSub.partInstances, rundownIds, playlist.activationId)
+					this.subscribe(CorelibPubSub.partInstances, rundownIds, playlist.activationId ?? null)
 
 					for (const rundown of rundowns) {
 						this.subscribe(MeteorPubSub.uiShowStyleBase, rundown.showStyleBaseId)

--- a/meteor/client/ui/ClockView/PresenterScreen.tsx
+++ b/meteor/client/ui/ClockView/PresenterScreen.tsx
@@ -315,7 +315,7 @@ export class PresenterScreenBase extends MeteorReactComponent<
 				},
 			}) as Pick<DBRundownPlaylist, '_id' | 'activationId'> | undefined
 			if (playlist) {
-				this.subscribe(CorelibPubSub.rundowns, [playlist._id], null)
+				this.subscribe(CorelibPubSub.rundownsInPlaylists, [playlist._id])
 
 				this.autorun(() => {
 					const rundowns = RundownPlaylistCollectionUtil.getRundownsUnordered(playlist, undefined, {
@@ -329,15 +329,15 @@ export class PresenterScreenBase extends MeteorReactComponent<
 					const showStyleBaseIds = rundowns.map((r) => r.showStyleBaseId)
 					const showStyleVariantIds = rundowns.map((r) => r.showStyleVariantId)
 
-					this.subscribe(CorelibPubSub.segments, rundownIds, false)
-					this.subscribe(CorelibPubSub.parts, rundownIds)
+					this.subscribe(CorelibPubSub.segments, rundownIds, {})
+					this.subscribe(CorelibPubSub.parts, rundownIds, null)
 					this.subscribe(CorelibPubSub.partInstances, rundownIds, playlist.activationId ?? null)
 
 					for (const rundown of rundowns) {
 						this.subscribe(MeteorPubSub.uiShowStyleBase, rundown.showStyleBaseId)
 					}
 
-					this.subscribe(CorelibPubSub.showStyleVariants, showStyleVariantIds)
+					this.subscribe(CorelibPubSub.showStyleVariants, null, showStyleVariantIds)
 					this.subscribe(MeteorPubSub.rundownLayouts, showStyleBaseIds)
 
 					this.autorun(() => {
@@ -357,16 +357,11 @@ export class PresenterScreenBase extends MeteorReactComponent<
 									CorelibPubSub.pieceInstances,
 									[currentPartInstance.rundownId],
 									[currentPartInstance._id],
-									false
+									{}
 								)
 							}
 							if (nextPartInstance) {
-								this.subscribe(
-									CorelibPubSub.pieceInstances,
-									[nextPartInstance.rundownId],
-									[nextPartInstance._id],
-									false
-								)
+								this.subscribe(CorelibPubSub.pieceInstances, [nextPartInstance.rundownId], [nextPartInstance._id], {})
 							}
 						}
 					})

--- a/meteor/client/ui/MediaStatus/MediaStatus.tsx
+++ b/meteor/client/ui/MediaStatus/MediaStatus.tsx
@@ -302,16 +302,11 @@ function useMediaStatusSubscriptions(
 			$in: rundownIds,
 		},
 	})
-	readyStatus[counter++] = useSubscription(CorelibPubSub.rundownBaselineAdLibActions, {
-		rundownId: {
-			$in: rundownIds,
-		},
-	})
-	readyStatus[counter++] = useSubscription(CorelibPubSub.rundownBaselineAdLibPieces, {
-		rundownId: {
-			$in: rundownIds,
-		},
-	})
+	for (const rundownId of rundownIds) {
+		readyStatus[counter++] = useSubscription(CorelibPubSub.rundownBaselineAdLibActions, rundownId)
+		readyStatus[counter++] = useSubscription(CorelibPubSub.rundownBaselineAdLibPieces, rundownId)
+	}
+
 	const uiPieceContentStatusesSubArguments = useMemo(
 		() => playlistIds.map((playlistIds) => [playlistIds] as [RundownPlaylistId]),
 		[playlistIds]

--- a/meteor/client/ui/MediaStatus/MediaStatus.tsx
+++ b/meteor/client/ui/MediaStatus/MediaStatus.tsx
@@ -274,14 +274,7 @@ function useMediaStatusSubscriptions(
 		},
 	})
 	readyStatus[counter++] = useSubscription(CorelibPubSub.parts, rundownIds)
-	readyStatus[counter++] = useSubscription(CorelibPubSub.partInstancesSimple, {
-		rundownId: {
-			$in: rundownIds,
-		},
-		reset: {
-			$ne: true,
-		},
-	})
+	readyStatus[counter++] = useSubscription(CorelibPubSub.partInstancesSimple, rundownIds, null)
 	readyStatus[counter++] = useSubscription(CorelibPubSub.pieceInstancesSimple, rundownIds, null)
 	readyStatus[counter++] = useSubscription(CorelibPubSub.pieces, {
 		startRundownId: {

--- a/meteor/client/ui/MediaStatus/MediaStatus.tsx
+++ b/meteor/client/ui/MediaStatus/MediaStatus.tsx
@@ -258,14 +258,14 @@ function useMediaStatusSubscriptions(
 	const readyStatus: boolean[] = []
 	let counter = 0
 	readyStatus[counter++] = useSubscription(CorelibPubSub.rundownPlaylists, playlistIds, null)
-	readyStatus[counter++] = useSubscription(CorelibPubSub.rundowns, playlistIds, null)
+	readyStatus[counter++] = useSubscription(CorelibPubSub.rundownsInPlaylists, playlistIds)
 	const uiShowStyleBaseSubArguments = useMemo(
 		() => showStyleBaseIds.map((showStyleBaseId) => [showStyleBaseId] as [ShowStyleBaseId]),
 		[showStyleBaseIds]
 	)
 	readyStatus[counter++] = useSubscriptions(MeteorPubSub.uiShowStyleBase, uiShowStyleBaseSubArguments)
-	readyStatus[counter++] = useSubscription(CorelibPubSub.segments, rundownIds, false)
-	readyStatus[counter++] = useSubscription(CorelibPubSub.parts, rundownIds)
+	readyStatus[counter++] = useSubscription(CorelibPubSub.segments, rundownIds, {})
+	readyStatus[counter++] = useSubscription(CorelibPubSub.parts, rundownIds, null)
 	readyStatus[counter++] = useSubscription(CorelibPubSub.partInstancesSimple, rundownIds, null)
 	readyStatus[counter++] = useSubscription(CorelibPubSub.pieceInstancesSimple, rundownIds, null)
 	readyStatus[counter++] = useSubscription(CorelibPubSub.pieces, rundownIds, null)

--- a/meteor/client/ui/MediaStatus/MediaStatus.tsx
+++ b/meteor/client/ui/MediaStatus/MediaStatus.tsx
@@ -257,11 +257,7 @@ function useMediaStatusSubscriptions(
 ): boolean {
 	const readyStatus: boolean[] = []
 	let counter = 0
-	readyStatus[counter++] = useSubscription(CorelibPubSub.rundownPlaylists, {
-		_id: {
-			$in: playlistIds,
-		},
-	})
+	readyStatus[counter++] = useSubscription(CorelibPubSub.rundownPlaylists, playlistIds, null)
 	readyStatus[counter++] = useSubscription(CorelibPubSub.rundowns, playlistIds, null)
 	const uiShowStyleBaseSubArguments = useMemo(
 		() => showStyleBaseIds.map((showStyleBaseId) => [showStyleBaseId] as [ShowStyleBaseId]),

--- a/meteor/client/ui/MediaStatus/MediaStatus.tsx
+++ b/meteor/client/ui/MediaStatus/MediaStatus.tsx
@@ -302,10 +302,8 @@ function useMediaStatusSubscriptions(
 			$in: rundownIds,
 		},
 	})
-	for (const rundownId of rundownIds) {
-		readyStatus[counter++] = useSubscription(CorelibPubSub.rundownBaselineAdLibActions, rundownId)
-		readyStatus[counter++] = useSubscription(CorelibPubSub.rundownBaselineAdLibPieces, rundownId)
-	}
+	readyStatus[counter++] = useSubscription(CorelibPubSub.rundownBaselineAdLibActions, rundownIds)
+	readyStatus[counter++] = useSubscription(CorelibPubSub.rundownBaselineAdLibPieces, rundownIds)
 
 	const uiPieceContentStatusesSubArguments = useMemo(
 		() => playlistIds.map((playlistIds) => [playlistIds] as [RundownPlaylistId]),

--- a/meteor/client/ui/MediaStatus/MediaStatus.tsx
+++ b/meteor/client/ui/MediaStatus/MediaStatus.tsx
@@ -268,11 +268,7 @@ function useMediaStatusSubscriptions(
 		[showStyleBaseIds]
 	)
 	readyStatus[counter++] = useSubscriptions(MeteorPubSub.uiShowStyleBase, uiShowStyleBaseSubArguments)
-	readyStatus[counter++] = useSubscription(CorelibPubSub.segments, {
-		rundownId: {
-			$in: rundownIds,
-		},
-	})
+	readyStatus[counter++] = useSubscription(CorelibPubSub.segments, rundownIds, false)
 	readyStatus[counter++] = useSubscription(CorelibPubSub.parts, rundownIds)
 	readyStatus[counter++] = useSubscription(CorelibPubSub.partInstancesSimple, rundownIds, null)
 	readyStatus[counter++] = useSubscription(CorelibPubSub.pieceInstancesSimple, rundownIds, null)

--- a/meteor/client/ui/MediaStatus/MediaStatus.tsx
+++ b/meteor/client/ui/MediaStatus/MediaStatus.tsx
@@ -292,16 +292,8 @@ function useMediaStatusSubscriptions(
 			$in: rundownIds,
 		},
 	})
-	readyStatus[counter++] = useSubscription(CorelibPubSub.adLibActions, {
-		rundownId: {
-			$in: rundownIds,
-		},
-	})
-	readyStatus[counter++] = useSubscription(CorelibPubSub.adLibPieces, {
-		rundownId: {
-			$in: rundownIds,
-		},
-	})
+	readyStatus[counter++] = useSubscription(CorelibPubSub.adLibActions, rundownIds)
+	readyStatus[counter++] = useSubscription(CorelibPubSub.adLibPieces, rundownIds)
 	readyStatus[counter++] = useSubscription(CorelibPubSub.rundownBaselineAdLibActions, rundownIds)
 	readyStatus[counter++] = useSubscription(CorelibPubSub.rundownBaselineAdLibPieces, rundownIds)
 

--- a/meteor/client/ui/MediaStatus/MediaStatus.tsx
+++ b/meteor/client/ui/MediaStatus/MediaStatus.tsx
@@ -282,11 +282,7 @@ function useMediaStatusSubscriptions(
 			$ne: true,
 		},
 	})
-	readyStatus[counter++] = useSubscription(CorelibPubSub.pieceInstancesSimple, {
-		rundownId: {
-			$in: rundownIds,
-		},
-	})
+	readyStatus[counter++] = useSubscription(CorelibPubSub.pieceInstancesSimple, rundownIds, null)
 	readyStatus[counter++] = useSubscription(CorelibPubSub.pieces, {
 		startRundownId: {
 			$in: rundownIds,

--- a/meteor/client/ui/MediaStatus/MediaStatus.tsx
+++ b/meteor/client/ui/MediaStatus/MediaStatus.tsx
@@ -272,11 +272,7 @@ function useMediaStatusSubscriptions(
 	readyStatus[counter++] = useSubscription(CorelibPubSub.parts, rundownIds)
 	readyStatus[counter++] = useSubscription(CorelibPubSub.partInstancesSimple, rundownIds, null)
 	readyStatus[counter++] = useSubscription(CorelibPubSub.pieceInstancesSimple, rundownIds, null)
-	readyStatus[counter++] = useSubscription(CorelibPubSub.pieces, {
-		startRundownId: {
-			$in: rundownIds,
-		},
-	})
+	readyStatus[counter++] = useSubscription(CorelibPubSub.pieces, rundownIds, null)
 	readyStatus[counter++] = useSubscription(CorelibPubSub.adLibActions, rundownIds)
 	readyStatus[counter++] = useSubscription(CorelibPubSub.adLibPieces, rundownIds)
 	readyStatus[counter++] = useSubscription(CorelibPubSub.rundownBaselineAdLibActions, rundownIds)

--- a/meteor/client/ui/PieceIcons/PieceCountdown.tsx
+++ b/meteor/client/ui/PieceIcons/PieceCountdown.tsx
@@ -42,10 +42,7 @@ export function PieceCountdownContainer(props: IPropsHeader): JSX.Element | null
 		}
 	)
 
-	useSubscription(CorelibPubSub.pieceInstancesSimple, {
-		rundownId: { $in: props.rundownIds },
-		playlistActivationId: props.playlistActivationId,
-	})
+	useSubscription(CorelibPubSub.pieceInstancesSimple, props.rundownIds, props.playlistActivationId ?? null)
 
 	useSubscription(MeteorPubSub.uiShowStyleBase, props.showStyleBaseId)
 

--- a/meteor/client/ui/PieceIcons/PieceIcon.tsx
+++ b/meteor/client/ui/PieceIcons/PieceIcon.tsx
@@ -130,10 +130,7 @@ export function PieceIconContainer(props: IPropsHeader): JSX.Element | null {
 		}
 	)
 
-	useSubscription(CorelibPubSub.pieceInstancesSimple, {
-		rundownId: { $in: props.rundownIds },
-		playlistActivationId: props.playlistActivationId,
-	})
+	useSubscription(CorelibPubSub.pieceInstancesSimple, props.rundownIds, props.playlistActivationId ?? null)
 
 	useSubscription(MeteorPubSub.uiShowStyleBase, props.showStyleBaseId)
 

--- a/meteor/client/ui/PieceIcons/PieceName.tsx
+++ b/meteor/client/ui/PieceIcons/PieceName.tsx
@@ -55,10 +55,7 @@ export function PieceNameContainer(props: INamePropsHeader): JSX.Element | null 
 		}
 	)
 
-	useSubscription(CorelibPubSub.pieceInstancesSimple, {
-		rundownId: { $in: props.rundownIds },
-		playlistActivationId: props.playlistActivationId,
-	})
+	useSubscription(CorelibPubSub.pieceInstancesSimple, props.rundownIds, props.playlistActivationId ?? null)
 
 	useSubscription(MeteorPubSub.uiShowStyleBase, props.showStyleBaseId)
 

--- a/meteor/client/ui/Prompter/PrompterView.tsx
+++ b/meteor/client/ui/Prompter/PrompterView.tsx
@@ -607,9 +607,7 @@ export const Prompter = translateWithTracker<PropsWithChildren<IPrompterProps>, 
 				}) as Pick<DBRundownPlaylist, '_id' | 'activationId'> | undefined
 				if (playlist) {
 					const rundownIDs = RundownPlaylistCollectionUtil.getRundownUnorderedIDs(playlist)
-					this.subscribe(CorelibPubSub.segments, {
-						rundownId: { $in: rundownIDs },
-					})
+					this.subscribe(CorelibPubSub.segments, rundownIDs, false)
 					this.subscribe(CorelibPubSub.parts, rundownIDs)
 					this.subscribe(CorelibPubSub.partInstances, rundownIDs, playlist.activationId)
 					this.subscribe(CorelibPubSub.pieces, {

--- a/meteor/client/ui/Prompter/PrompterView.tsx
+++ b/meteor/client/ui/Prompter/PrompterView.tsx
@@ -206,10 +206,7 @@ export class PrompterViewInner extends MeteorReactComponent<Translated<IProps & 
 		if (this.props.studioId) {
 			this.subscribe(MeteorPubSub.uiStudio, this.props.studioId)
 
-			this.subscribe(CorelibPubSub.rundownPlaylists, {
-				activationId: { $exists: true },
-				studioId: this.props.studioId,
-			})
+			this.subscribe(MeteorPubSub.activeRundownPlaylistForStudio, this.props.studioId)
 		}
 
 		this.autorun(() => {

--- a/meteor/client/ui/Prompter/PrompterView.tsx
+++ b/meteor/client/ui/Prompter/PrompterView.tsx
@@ -609,7 +609,7 @@ export const Prompter = translateWithTracker<PropsWithChildren<IPrompterProps>, 
 					const rundownIDs = RundownPlaylistCollectionUtil.getRundownUnorderedIDs(playlist)
 					this.subscribe(CorelibPubSub.segments, rundownIDs, false)
 					this.subscribe(CorelibPubSub.parts, rundownIDs)
-					this.subscribe(CorelibPubSub.partInstances, rundownIDs, playlist.activationId)
+					this.subscribe(CorelibPubSub.partInstances, rundownIDs, playlist.activationId ?? null)
 					this.subscribe(CorelibPubSub.pieces, rundownIDs, null)
 					this.subscribe(CorelibPubSub.pieceInstancesSimple, rundownIDs, null)
 				}

--- a/meteor/client/ui/Prompter/PrompterView.tsx
+++ b/meteor/client/ui/Prompter/PrompterView.tsx
@@ -222,7 +222,7 @@ export class PrompterViewInner extends MeteorReactComponent<Translated<IProps & 
 				}
 			) as Pick<DBRundownPlaylist, '_id'> | undefined
 			if (playlist?._id) {
-				this.subscribe(CorelibPubSub.rundowns, [playlist._id], null)
+				this.subscribe(CorelibPubSub.rundownsInPlaylists, [playlist._id])
 			}
 		})
 
@@ -596,7 +596,7 @@ export const Prompter = translateWithTracker<PropsWithChildren<IPrompterProps>, 
 		}
 
 		componentDidMount(): void {
-			this.subscribe(CorelibPubSub.rundowns, [this.props.rundownPlaylistId], null)
+			this.subscribe(CorelibPubSub.rundownsInPlaylists, [this.props.rundownPlaylistId])
 
 			this.autorun(() => {
 				const playlist = RundownPlaylists.findOne(this.props.rundownPlaylistId, {
@@ -607,8 +607,8 @@ export const Prompter = translateWithTracker<PropsWithChildren<IPrompterProps>, 
 				}) as Pick<DBRundownPlaylist, '_id' | 'activationId'> | undefined
 				if (playlist) {
 					const rundownIDs = RundownPlaylistCollectionUtil.getRundownUnorderedIDs(playlist)
-					this.subscribe(CorelibPubSub.segments, rundownIDs, false)
-					this.subscribe(CorelibPubSub.parts, rundownIDs)
+					this.subscribe(CorelibPubSub.segments, rundownIDs, {})
+					this.subscribe(CorelibPubSub.parts, rundownIDs, null)
 					this.subscribe(CorelibPubSub.partInstances, rundownIDs, playlist.activationId ?? null)
 					this.subscribe(CorelibPubSub.pieces, rundownIDs, null)
 					this.subscribe(CorelibPubSub.pieceInstancesSimple, rundownIDs, null)

--- a/meteor/client/ui/Prompter/PrompterView.tsx
+++ b/meteor/client/ui/Prompter/PrompterView.tsx
@@ -615,10 +615,8 @@ export const Prompter = translateWithTracker<PropsWithChildren<IPrompterProps>, 
 					this.subscribe(CorelibPubSub.pieces, {
 						startRundownId: { $in: rundownIDs },
 					})
-					this.subscribe(CorelibPubSub.pieceInstancesSimple, {
-						rundownId: { $in: rundownIDs },
-						reset: { $ne: true },
-					})
+
+					this.subscribe(CorelibPubSub.pieceInstancesSimple, rundownIDs, null)
 				}
 			})
 

--- a/meteor/client/ui/Prompter/PrompterView.tsx
+++ b/meteor/client/ui/Prompter/PrompterView.tsx
@@ -206,7 +206,7 @@ export class PrompterViewInner extends MeteorReactComponent<Translated<IProps & 
 		if (this.props.studioId) {
 			this.subscribe(MeteorPubSub.uiStudio, this.props.studioId)
 
-			this.subscribe(MeteorPubSub.activeRundownPlaylistForStudio, this.props.studioId)
+			this.subscribe(MeteorPubSub.rundownPlaylistForStudio, this.props.studioId, true)
 		}
 
 		this.autorun(() => {

--- a/meteor/client/ui/Prompter/PrompterView.tsx
+++ b/meteor/client/ui/Prompter/PrompterView.tsx
@@ -610,10 +610,7 @@ export const Prompter = translateWithTracker<PropsWithChildren<IPrompterProps>, 
 					this.subscribe(CorelibPubSub.segments, rundownIDs, false)
 					this.subscribe(CorelibPubSub.parts, rundownIDs)
 					this.subscribe(CorelibPubSub.partInstances, rundownIDs, playlist.activationId)
-					this.subscribe(CorelibPubSub.pieces, {
-						startRundownId: { $in: rundownIDs },
-					})
-
+					this.subscribe(CorelibPubSub.pieces, rundownIDs, null)
 					this.subscribe(CorelibPubSub.pieceInstancesSimple, rundownIDs, null)
 				}
 			})

--- a/meteor/client/ui/RundownList.tsx
+++ b/meteor/client/ui/RundownList.tsx
@@ -64,10 +64,10 @@ export function RundownList(): JSX.Element {
 		useSubscription(MeteorPubSub.uiStudio, null),
 		useSubscription(MeteorPubSub.rundownLayouts, null),
 
-		useSubscription(CorelibPubSub.rundowns, playlistIds, null),
+		useSubscription(CorelibPubSub.rundownsInPlaylists, playlistIds),
 
 		useSubscription(CorelibPubSub.showStyleBases, showStyleBaseIds),
-		useSubscription(CorelibPubSub.showStyleVariants, showStyleVariantIds),
+		useSubscription(CorelibPubSub.showStyleVariants, null, showStyleVariantIds),
 	].reduce((prev, current) => prev && current, true)
 
 	const [subsReady, setSubsReady] = useState(false)

--- a/meteor/client/ui/RundownList.tsx
+++ b/meteor/client/ui/RundownList.tsx
@@ -62,7 +62,7 @@ export function RundownList(): JSX.Element {
 	const baseSubsReady = [
 		useSubscription(CorelibPubSub.rundownPlaylists, null, null),
 		useSubscription(MeteorPubSub.uiStudio, null),
-		useSubscription(MeteorPubSub.rundownLayouts, {}),
+		useSubscription(MeteorPubSub.rundownLayouts, null),
 
 		useSubscription(CorelibPubSub.rundowns, playlistIds, null),
 

--- a/meteor/client/ui/RundownList.tsx
+++ b/meteor/client/ui/RundownList.tsx
@@ -60,7 +60,7 @@ export function RundownList(): JSX.Element {
 	)
 
 	const baseSubsReady = [
-		useSubscription(CorelibPubSub.rundownPlaylists, {}),
+		useSubscription(CorelibPubSub.rundownPlaylists, null, null),
 		useSubscription(MeteorPubSub.uiStudio, null),
 		useSubscription(MeteorPubSub.rundownLayouts, {}),
 

--- a/meteor/client/ui/RundownList.tsx
+++ b/meteor/client/ui/RundownList.tsx
@@ -67,10 +67,7 @@ export function RundownList(): JSX.Element {
 		useSubscription(CorelibPubSub.rundowns, playlistIds, null),
 
 		useSubscription(CorelibPubSub.showStyleBases, showStyleBaseIds),
-
-		useSubscription(CorelibPubSub.showStyleVariants, {
-			_id: { $in: showStyleVariantIds },
-		}),
+		useSubscription(CorelibPubSub.showStyleVariants, showStyleVariantIds),
 	].reduce((prev, current) => prev && current, true)
 
 	const [subsReady, setSubsReady] = useState(false)

--- a/meteor/client/ui/RundownList.tsx
+++ b/meteor/client/ui/RundownList.tsx
@@ -66,9 +66,7 @@ export function RundownList(): JSX.Element {
 
 		useSubscription(CorelibPubSub.rundowns, playlistIds, null),
 
-		useSubscription(CorelibPubSub.showStyleBases, {
-			_id: { $in: showStyleBaseIds },
-		}),
+		useSubscription(CorelibPubSub.showStyleBases, showStyleBaseIds),
 
 		useSubscription(CorelibPubSub.showStyleVariants, {
 			_id: { $in: showStyleVariantIds },

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1666,9 +1666,6 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 								playlist.previousPartInfo?.partInstanceId,
 							].filter((p): p is PartInstanceId => p !== null),
 						},
-						reset: {
-							$ne: true,
-						},
 					})
 					const { previousPartInstance, currentPartInstance } =
 						RundownPlaylistCollectionUtil.getSelectedPartInstances(playlist)

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1635,17 +1635,9 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 						$in: rundownIDs,
 					},
 				})
-				this.subscribe(CorelibPubSub.adLibPieces, {
-					rundownId: {
-						$in: rundownIDs,
-					},
-				})
+				this.subscribe(CorelibPubSub.adLibPieces, rundownIDs)
 				this.subscribe(CorelibPubSub.rundownBaselineAdLibPieces, rundownIDs)
-				this.subscribe(CorelibPubSub.adLibActions, {
-					rundownId: {
-						$in: rundownIDs,
-					},
-				})
+				this.subscribe(CorelibPubSub.adLibActions, rundownIDs)
 				this.subscribe(CorelibPubSub.rundownBaselineAdLibActions, rundownIDs)
 				this.subscribe(CorelibPubSub.parts, rundownIDs)
 				this.subscribe(CorelibPubSub.partInstances, rundownIDs, playlist.activationId)

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1648,18 +1648,16 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 					// Use meteorSubscribe so that this subscription doesn't mess with this.subscriptionsReady()
 					// it's run in this.autorun, so the subscription will be stopped along with the autorun,
 					// so we don't have to manually clean up after ourselves.
-					meteorSubscribe(CorelibPubSub.pieceInstances, {
-						rundownId: {
-							$in: rundownIds,
-						},
-						partInstanceId: {
-							$in: [
-								playlist.currentPartInfo?.partInstanceId,
-								playlist.nextPartInfo?.partInstanceId,
-								playlist.previousPartInfo?.partInstanceId,
-							].filter((p): p is PartInstanceId => p !== null),
-						},
-					})
+					meteorSubscribe(
+						CorelibPubSub.pieceInstances,
+						rundownIds,
+						[
+							playlist.currentPartInfo?.partInstanceId,
+							playlist.nextPartInfo?.partInstanceId,
+							playlist.previousPartInfo?.partInstanceId,
+						].filter((p): p is PartInstanceId => p !== null),
+						false
+					)
 					const { previousPartInstance, currentPartInstance } =
 						RundownPlaylistCollectionUtil.getSelectedPartInstances(playlist)
 

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1580,7 +1580,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 			const playlistId = this.props.rundownPlaylistId
 
 			this.subscribe(CorelibPubSub.rundownPlaylists, [playlistId], null)
-			this.subscribe(CorelibPubSub.rundowns, [playlistId], null)
+			this.subscribe(CorelibPubSub.rundownsInPlaylists, [playlistId])
 			this.autorun(() => {
 				const playlist = RundownPlaylists.findOne(playlistId, {
 					fields: {
@@ -1619,6 +1619,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 
 				this.subscribe(
 					CorelibPubSub.showStyleVariants,
+					null,
 					rundowns.map((i) => i.showStyleVariantId)
 				)
 				this.subscribe(
@@ -1626,12 +1627,12 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 					rundowns.map((i) => i.showStyleBaseId)
 				)
 				const rundownIDs = rundowns.map((i) => i._id)
-				this.subscribe(CorelibPubSub.segments, rundownIDs, false)
+				this.subscribe(CorelibPubSub.segments, rundownIDs, {})
 				this.subscribe(CorelibPubSub.adLibPieces, rundownIDs)
 				this.subscribe(CorelibPubSub.rundownBaselineAdLibPieces, rundownIDs)
 				this.subscribe(CorelibPubSub.adLibActions, rundownIDs)
 				this.subscribe(CorelibPubSub.rundownBaselineAdLibActions, rundownIDs)
-				this.subscribe(CorelibPubSub.parts, rundownIDs)
+				this.subscribe(CorelibPubSub.parts, rundownIDs, null)
 				this.subscribe(CorelibPubSub.partInstances, rundownIDs, playlist.activationId ?? null)
 			})
 			this.autorun(() => {
@@ -1655,7 +1656,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 							playlist.nextPartInfo?.partInstanceId,
 							playlist.previousPartInfo?.partInstanceId,
 						].filter((p): p is PartInstanceId => p !== null),
-						false
+						{}
 					)
 					const { previousPartInstance, currentPartInstance } =
 						RundownPlaylistCollectionUtil.getSelectedPartInstances(playlist)

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1630,11 +1630,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 					},
 				})
 				const rundownIDs = rundowns.map((i) => i._id)
-				this.subscribe(CorelibPubSub.segments, {
-					rundownId: {
-						$in: rundownIDs,
-					},
-				})
+				this.subscribe(CorelibPubSub.segments, rundownIDs, false)
 				this.subscribe(CorelibPubSub.adLibPieces, rundownIDs)
 				this.subscribe(CorelibPubSub.rundownBaselineAdLibPieces, rundownIDs)
 				this.subscribe(CorelibPubSub.adLibActions, rundownIDs)

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1632,7 +1632,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 				this.subscribe(CorelibPubSub.adLibActions, rundownIDs)
 				this.subscribe(CorelibPubSub.rundownBaselineAdLibActions, rundownIDs)
 				this.subscribe(CorelibPubSub.parts, rundownIDs)
-				this.subscribe(CorelibPubSub.partInstances, rundownIDs, playlist.activationId)
+				this.subscribe(CorelibPubSub.partInstances, rundownIDs, playlist.activationId ?? null)
 			})
 			this.autorun(() => {
 				const playlist = RundownPlaylists.findOne(playlistId, {

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1579,9 +1579,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 		componentDidMount(): void {
 			const playlistId = this.props.rundownPlaylistId
 
-			this.subscribe(CorelibPubSub.rundownPlaylists, {
-				_id: playlistId,
-			})
+			this.subscribe(CorelibPubSub.rundownPlaylists, [playlistId], null)
 			this.subscribe(CorelibPubSub.rundowns, [playlistId], null)
 			this.autorun(() => {
 				const playlist = RundownPlaylists.findOne(playlistId, {

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1621,11 +1621,10 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 					CorelibPubSub.showStyleVariants,
 					rundowns.map((i) => i.showStyleVariantId)
 				)
-				this.subscribe(MeteorPubSub.rundownLayouts, {
-					showStyleBaseId: {
-						$in: rundowns.map((i) => i.showStyleBaseId),
-					},
-				})
+				this.subscribe(
+					MeteorPubSub.rundownLayouts,
+					rundowns.map((i) => i.showStyleBaseId)
+				)
 				const rundownIDs = rundowns.map((i) => i._id)
 				this.subscribe(CorelibPubSub.segments, rundownIDs, false)
 				this.subscribe(CorelibPubSub.adLibPieces, rundownIDs)

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1671,16 +1671,18 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 						RundownPlaylistCollectionUtil.getSelectedPartInstances(playlist)
 
 					if (previousPartInstance) {
-						meteorSubscribe(CorelibPubSub.partInstancesForSegmentPlayout, {
-							rundownId: previousPartInstance.rundownId,
-							segmentPlayoutId: previousPartInstance.segmentPlayoutId,
-						})
+						meteorSubscribe(
+							CorelibPubSub.partInstancesForSegmentPlayout,
+							previousPartInstance.rundownId,
+							previousPartInstance.segmentPlayoutId
+						)
 					}
 					if (currentPartInstance) {
-						meteorSubscribe(CorelibPubSub.partInstancesForSegmentPlayout, {
-							rundownId: currentPartInstance.rundownId,
-							segmentPlayoutId: currentPartInstance.segmentPlayoutId,
-						})
+						meteorSubscribe(
+							CorelibPubSub.partInstancesForSegmentPlayout,
+							currentPartInstance.rundownId,
+							currentPartInstance.segmentPlayoutId
+						)
 					}
 				}
 			})

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1617,9 +1617,6 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 
 				for (const rundown of rundowns) {
 					this.subscribe(MeteorPubSub.uiShowStyleBase, rundown.showStyleBaseId)
-
-					this.subscribe(CorelibPubSub.rundownBaselineAdLibPieces, rundown._id)
-					this.subscribe(CorelibPubSub.rundownBaselineAdLibActions, rundown._id)
 				}
 
 				this.subscribe(CorelibPubSub.showStyleVariants, {
@@ -1643,11 +1640,13 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 						$in: rundownIDs,
 					},
 				})
+				this.subscribe(CorelibPubSub.rundownBaselineAdLibPieces, rundownIDs)
 				this.subscribe(CorelibPubSub.adLibActions, {
 					rundownId: {
 						$in: rundownIDs,
 					},
 				})
+				this.subscribe(CorelibPubSub.rundownBaselineAdLibActions, rundownIDs)
 				this.subscribe(CorelibPubSub.parts, rundownIDs)
 				this.subscribe(CorelibPubSub.partInstances, rundownIDs, playlist.activationId)
 			})

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1617,6 +1617,9 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 
 				for (const rundown of rundowns) {
 					this.subscribe(MeteorPubSub.uiShowStyleBase, rundown.showStyleBaseId)
+
+					this.subscribe(CorelibPubSub.rundownBaselineAdLibPieces, rundown._id)
+					this.subscribe(CorelibPubSub.rundownBaselineAdLibActions, rundown._id)
 				}
 
 				this.subscribe(CorelibPubSub.showStyleVariants, {
@@ -1640,17 +1643,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 						$in: rundownIDs,
 					},
 				})
-				this.subscribe(CorelibPubSub.rundownBaselineAdLibPieces, {
-					rundownId: {
-						$in: rundownIDs,
-					},
-				})
 				this.subscribe(CorelibPubSub.adLibActions, {
-					rundownId: {
-						$in: rundownIDs,
-					},
-				})
-				this.subscribe(CorelibPubSub.rundownBaselineAdLibActions, {
 					rundownId: {
 						$in: rundownIDs,
 					},

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1619,11 +1619,10 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 					this.subscribe(MeteorPubSub.uiShowStyleBase, rundown.showStyleBaseId)
 				}
 
-				this.subscribe(CorelibPubSub.showStyleVariants, {
-					_id: {
-						$in: rundowns.map((i) => i.showStyleVariantId),
-					},
-				})
+				this.subscribe(
+					CorelibPubSub.showStyleVariants,
+					rundowns.map((i) => i.showStyleVariantId)
+				)
 				this.subscribe(MeteorPubSub.rundownLayouts, {
 					showStyleBaseId: {
 						$in: rundowns.map((i) => i.showStyleBaseId),

--- a/meteor/client/ui/RundownView/RundownNotifier.tsx
+++ b/meteor/client/ui/RundownView/RundownNotifier.tsx
@@ -293,7 +293,7 @@ class RundownViewNotifier extends WithManagedTracker {
 			| ReactiveVar<Pick<PeripheralDevice, '_id' | 'name' | 'ignore' | 'status' | 'connected' | 'parentDeviceId'>[]>
 			| undefined
 		if (studioId) {
-			meteorSubscribe(CorelibPubSub.peripheralDevicesAndSubDevices, { studioId: studioId })
+			meteorSubscribe(CorelibPubSub.peripheralDevicesAndSubDevices, studioId)
 			reactivePeripheralDevices = reactiveData.getRPeripheralDevices(studioId, {
 				fields: {
 					name: 1,

--- a/meteor/client/ui/RundownView/RundownSystemStatus.tsx
+++ b/meteor/client/ui/RundownView/RundownSystemStatus.tsx
@@ -180,9 +180,7 @@ export const RundownSystemStatus = translateWithTracker(
 		}
 
 		componentDidMount(): void {
-			this.subscribe(CorelibPubSub.peripheralDevicesAndSubDevices, {
-				studioId: this.props.studio._id,
-			})
+			this.subscribe(CorelibPubSub.peripheralDevicesAndSubDevices, this.props.studio._id)
 		}
 
 		componentWillUnmount(): void {

--- a/meteor/client/ui/SegmentList/LinePartPieceIndicator/LinePartAdLibIndicator.tsx
+++ b/meteor/client/ui/SegmentList/LinePartPieceIndicator/LinePartAdLibIndicator.tsx
@@ -10,7 +10,7 @@ import { translateMessage } from '@sofie-automation/corelib/dist/TranslatableMes
 import StudioContext from '../../RundownView/StudioContext'
 import { AdLibActions, AdLibPieces } from '../../../collections'
 import RundownViewEventBus, { RundownViewEvents } from '../../../../lib/api/triggers/RundownViewEventBus'
-import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
+import { MeteorPubSub } from '../../../../lib/api/pubsub'
 
 interface IProps {
 	sourceLayers: ISourceLayerExtended[]
@@ -24,19 +24,8 @@ export const LinePartAdLibIndicator: React.FC<IProps> = function LinePartAdLibIn
 	const sourceLayerIds = useMemo(() => sourceLayers.map((sourceLayer) => sourceLayer._id), [sourceLayers])
 	const label = useMemo(() => sourceLayers[0]?.name ?? '', [sourceLayers])
 
-	useSubscription(CorelibPubSub.adLibPieces, {
-		partId,
-		sourceLayerId: {
-			$in: sourceLayerIds,
-		},
-	})
-
-	useSubscription(CorelibPubSub.adLibActions, {
-		partId,
-		'display.sourceLayerId': {
-			$in: sourceLayerIds,
-		},
-	})
+	useSubscription(MeteorPubSub.adLibPiecesForPart, partId, sourceLayerIds)
+	useSubscription(MeteorPubSub.adLibActionsForPart, partId, sourceLayerIds)
 
 	const adLibPieces = useTracker(
 		() =>

--- a/meteor/client/ui/SegmentList/SegmentListContainer.tsx
+++ b/meteor/client/ui/SegmentList/SegmentListContainer.tsx
@@ -62,12 +62,7 @@ export const SegmentListContainer = withResolvedSegment<IProps>(function Segment
 		[segmentId]
 	)
 
-	useSubscription(CorelibPubSub.pieceInstances, {
-		rundownId: rundownId,
-		partInstanceId: {
-			$in: partInstanceIds,
-		},
-	})
+	useSubscription(CorelibPubSub.pieceInstances, [rundownId], partInstanceIds ?? [], false)
 
 	useTracker(() => {
 		const segment = Segments.findOne(segmentId, {

--- a/meteor/client/ui/SegmentList/SegmentListContainer.tsx
+++ b/meteor/client/ui/SegmentList/SegmentListContainer.tsx
@@ -73,9 +73,6 @@ export const SegmentListContainer = withResolvedSegment<IProps>(function Segment
 		partInstanceId: {
 			$in: partInstanceIds,
 		},
-		reset: {
-			$ne: true,
-		},
 	})
 
 	useTracker(() => {

--- a/meteor/client/ui/SegmentList/SegmentListContainer.tsx
+++ b/meteor/client/ui/SegmentList/SegmentListContainer.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef } from 'react'
-import { PieceLifespan } from '@sofie-automation/blueprints-integration'
 import { meteorSubscribe } from '../../../lib/api/pubsub'
 import { useSubscription, useTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
 import {
@@ -42,12 +41,7 @@ export const SegmentListContainer = withResolvedSegment<IProps>(function Segment
 		[segmentId]
 	)
 
-	useSubscription(CorelibPubSub.pieces, {
-		startRundownId: rundownId,
-		startPartId: {
-			$in: partIds,
-		},
-	})
+	useSubscription(CorelibPubSub.pieces, [rundownId], partIds ?? [])
 
 	const partInstanceIds = useTracker(
 		() =>
@@ -83,28 +77,12 @@ export const SegmentListContainer = withResolvedSegment<IProps>(function Segment
 			},
 		})
 		segment &&
-			meteorSubscribe(CorelibPubSub.pieces, {
-				invalid: {
-					$ne: true,
-				},
-				$or: [
-					// same rundown, and previous segment
-					{
-						startRundownId: rundownId,
-						startSegmentId: { $in: Array.from(segmentsIdsBefore.values()) },
-						lifespan: {
-							$in: [PieceLifespan.OutOnRundownEnd, PieceLifespan.OutOnRundownChange, PieceLifespan.OutOnShowStyleEnd],
-						},
-					},
-					// Previous rundown
-					{
-						startRundownId: { $in: Array.from(rundownIdsBefore.values()) },
-						lifespan: {
-							$in: [PieceLifespan.OutOnShowStyleEnd],
-						},
-					},
-				],
-			})
+			meteorSubscribe(
+				CorelibPubSub.piecesInfiniteStartingBefore,
+				rundownId,
+				Array.from(segmentsIdsBefore.values()),
+				Array.from(rundownIdsBefore.values())
+			)
 	}, [segmentId, rundownId, segmentsIdsBefore.values(), rundownIdsBefore.values()])
 
 	const isLiveSegment = useTracker(

--- a/meteor/client/ui/SegmentList/SegmentListContainer.tsx
+++ b/meteor/client/ui/SegmentList/SegmentListContainer.tsx
@@ -62,7 +62,7 @@ export const SegmentListContainer = withResolvedSegment<IProps>(function Segment
 		[segmentId]
 	)
 
-	useSubscription(CorelibPubSub.pieceInstances, [rundownId], partInstanceIds ?? [], false)
+	useSubscription(CorelibPubSub.pieceInstances, [rundownId], partInstanceIds ?? [], {})
 
 	useTracker(() => {
 		const segment = Segments.findOne(segmentId, {

--- a/meteor/client/ui/SegmentScratchpad/SegmentScratchpadContainer.tsx
+++ b/meteor/client/ui/SegmentScratchpad/SegmentScratchpadContainer.tsx
@@ -66,12 +66,7 @@ export const SegmentScratchpadContainer = withResolvedSegment<IProps>(function S
 		[segmentId]
 	)
 
-	const pieceInstancesReady = useSubscription(CorelibPubSub.pieceInstances, {
-		rundownId: rundownId,
-		partInstanceId: {
-			$in: partInstanceIds,
-		},
-	})
+	const pieceInstancesReady = useSubscription(CorelibPubSub.pieceInstances, [rundownId], partInstanceIds ?? [], false)
 
 	useTracker(() => {
 		const segment = Segments.findOne(segmentId, {

--- a/meteor/client/ui/SegmentScratchpad/SegmentScratchpadContainer.tsx
+++ b/meteor/client/ui/SegmentScratchpad/SegmentScratchpadContainer.tsx
@@ -77,9 +77,6 @@ export const SegmentScratchpadContainer = withResolvedSegment<IProps>(function S
 		partInstanceId: {
 			$in: partInstanceIds,
 		},
-		reset: {
-			$ne: true,
-		},
 	})
 
 	useTracker(() => {

--- a/meteor/client/ui/SegmentScratchpad/SegmentScratchpadContainer.tsx
+++ b/meteor/client/ui/SegmentScratchpad/SegmentScratchpadContainer.tsx
@@ -66,7 +66,7 @@ export const SegmentScratchpadContainer = withResolvedSegment<IProps>(function S
 		[segmentId]
 	)
 
-	const pieceInstancesReady = useSubscription(CorelibPubSub.pieceInstances, [rundownId], partInstanceIds ?? [], false)
+	const pieceInstancesReady = useSubscription(CorelibPubSub.pieceInstances, [rundownId], partInstanceIds ?? [], {})
 
 	useTracker(() => {
 		const segment = Segments.findOne(segmentId, {

--- a/meteor/client/ui/SegmentStoryboard/SegmentStoryboardContainer.tsx
+++ b/meteor/client/ui/SegmentStoryboard/SegmentStoryboardContainer.tsx
@@ -66,7 +66,7 @@ export const SegmentStoryboardContainer = withResolvedSegment<IProps>(function S
 		[segmentId]
 	)
 
-	const pieceInstancesReady = useSubscription(CorelibPubSub.pieceInstances, [rundownId], partInstanceIds ?? [], false)
+	const pieceInstancesReady = useSubscription(CorelibPubSub.pieceInstances, [rundownId], partInstanceIds ?? [], {})
 
 	useTracker(() => {
 		const segment = Segments.findOne(segmentId, {

--- a/meteor/client/ui/SegmentStoryboard/SegmentStoryboardContainer.tsx
+++ b/meteor/client/ui/SegmentStoryboard/SegmentStoryboardContainer.tsx
@@ -77,9 +77,6 @@ export const SegmentStoryboardContainer = withResolvedSegment<IProps>(function S
 		partInstanceId: {
 			$in: partInstanceIds,
 		},
-		reset: {
-			$ne: true,
-		},
 	})
 
 	useTracker(() => {

--- a/meteor/client/ui/SegmentStoryboard/SegmentStoryboardContainer.tsx
+++ b/meteor/client/ui/SegmentStoryboard/SegmentStoryboardContainer.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
-import { PieceLifespan } from '@sofie-automation/blueprints-integration'
 import { meteorSubscribe } from '../../../lib/api/pubsub'
 import { useSubscription, useTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
 import {
@@ -46,12 +45,7 @@ export const SegmentStoryboardContainer = withResolvedSegment<IProps>(function S
 		[segmentId]
 	)
 
-	const piecesReady = useSubscription(CorelibPubSub.pieces, {
-		startRundownId: rundownId,
-		startPartId: {
-			$in: partIds,
-		},
-	})
+	const piecesReady = useSubscription(CorelibPubSub.pieces, [rundownId], partIds ?? [])
 
 	const partInstanceIds = useTracker(
 		() =>
@@ -87,28 +81,12 @@ export const SegmentStoryboardContainer = withResolvedSegment<IProps>(function S
 			},
 		})
 		segment &&
-			meteorSubscribe(CorelibPubSub.pieces, {
-				invalid: {
-					$ne: true,
-				},
-				$or: [
-					// same rundown, and previous segment
-					{
-						startRundownId: rundownId,
-						startSegmentId: { $in: Array.from(segmentsIdsBefore.values()) },
-						lifespan: {
-							$in: [PieceLifespan.OutOnRundownEnd, PieceLifespan.OutOnRundownChange, PieceLifespan.OutOnShowStyleEnd],
-						},
-					},
-					// Previous rundown
-					{
-						startRundownId: { $in: Array.from(rundownIdsBefore.values()) },
-						lifespan: {
-							$in: [PieceLifespan.OutOnShowStyleEnd],
-						},
-					},
-				],
-			})
+			meteorSubscribe(
+				CorelibPubSub.piecesInfiniteStartingBefore,
+				rundownId,
+				Array.from(segmentsIdsBefore.values()),
+				Array.from(rundownIdsBefore.values())
+			)
 	}, [segmentId, rundownId, segmentsIdsBefore.values(), rundownIdsBefore.values()])
 
 	const isLiveSegment = useTracker(

--- a/meteor/client/ui/SegmentStoryboard/SegmentStoryboardContainer.tsx
+++ b/meteor/client/ui/SegmentStoryboard/SegmentStoryboardContainer.tsx
@@ -66,12 +66,7 @@ export const SegmentStoryboardContainer = withResolvedSegment<IProps>(function S
 		[segmentId]
 	)
 
-	const pieceInstancesReady = useSubscription(CorelibPubSub.pieceInstances, {
-		rundownId: rundownId,
-		partInstanceId: {
-			$in: partInstanceIds,
-		},
-	})
+	const pieceInstancesReady = useSubscription(CorelibPubSub.pieceInstances, [rundownId], partInstanceIds ?? [], false)
 
 	useTracker(() => {
 		const segment = Segments.findOne(segmentId, {

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import * as PropTypes from 'prop-types'
 import * as _ from 'underscore'
-import { PieceLifespan } from '@sofie-automation/blueprints-integration'
 import { SegmentTimeline, SegmentTimelineClass } from './SegmentTimeline'
 import { computeSegmentDisplayDuration, RundownTiming, TimingEvent } from '../RundownView/RundownTiming/RundownTiming'
 import { UIStateStorage } from '../../lib/UIStateStorage'
@@ -146,12 +145,7 @@ export const SegmentTimelineContainer = withResolvedSegment(
 					}
 				).map((part) => part._id)
 
-				this.subscribe(CorelibPubSub.pieces, {
-					startRundownId: this.props.rundownId,
-					startPartId: {
-						$in: partIds,
-					},
-				})
+				this.subscribe(CorelibPubSub.pieces, [this.props.rundownId], partIds ?? [])
 			})
 			this.autorun(() => {
 				const partInstanceIds = PartInstances.find(
@@ -179,32 +173,12 @@ export const SegmentTimelineContainer = withResolvedSegment(
 					},
 				})
 				segment &&
-					this.subscribe(CorelibPubSub.pieces, {
-						invalid: {
-							$ne: true,
-						},
-						$or: [
-							// same rundown, and previous segment
-							{
-								startRundownId: this.props.rundownId,
-								startSegmentId: { $in: Array.from(this.props.segmentsIdsBefore.values()) },
-								lifespan: {
-									$in: [
-										PieceLifespan.OutOnRundownEnd,
-										PieceLifespan.OutOnRundownChange,
-										PieceLifespan.OutOnShowStyleEnd,
-									],
-								},
-							},
-							// Previous rundown
-							{
-								startRundownId: { $in: Array.from(this.props.rundownIdsBefore.values()) },
-								lifespan: {
-									$in: [PieceLifespan.OutOnShowStyleEnd],
-								},
-							},
-						],
-					})
+					this.subscribe(
+						CorelibPubSub.piecesInfiniteStartingBefore,
+						this.props.rundownId,
+						Array.from(this.props.segmentsIdsBefore.values()),
+						Array.from(this.props.rundownIdsBefore.values())
+					)
 			})
 			SpeechSynthesiser.init()
 

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -402,7 +402,7 @@ export const SegmentTimelineContainer = withResolvedSegment(
 					CorelibPubSub.pieceInstances,
 					[this.props.rundownId],
 					partInstanceIds,
-					false
+					{}
 				)
 				this.partInstanceSubPartInstanceIds = partInstanceIds
 			})

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -429,9 +429,6 @@ export const SegmentTimelineContainer = withResolvedSegment(
 					partInstanceId: {
 						$in: partInstanceIds,
 					},
-					reset: {
-						$ne: true,
-					},
 				})
 				this.partInstanceSubPartInstanceIds = partInstanceIds
 			})

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -398,12 +398,12 @@ export const SegmentTimelineContainer = withResolvedSegment(
 					this.partInstanceSub.stop()
 				}
 				// we handle this subscription manually
-				this.partInstanceSub = meteorSubscribe(CorelibPubSub.pieceInstances, {
-					rundownId: this.props.rundownId,
-					partInstanceId: {
-						$in: partInstanceIds,
-					},
-				})
+				this.partInstanceSub = meteorSubscribe(
+					CorelibPubSub.pieceInstances,
+					[this.props.rundownId],
+					partInstanceIds,
+					false
+				)
 				this.partInstanceSubPartInstanceIds = partInstanceIds
 			})
 		}

--- a/meteor/client/ui/Settings.tsx
+++ b/meteor/client/ui/Settings.tsx
@@ -24,7 +24,7 @@ export function Settings(): JSX.Element | null {
 	const history = useHistory()
 
 	useSubscription(CorelibPubSub.peripheralDevices, null)
-	useSubscription(CorelibPubSub.studios, {})
+	useSubscription(CorelibPubSub.studios, null)
 	useSubscription(CorelibPubSub.showStyleBases, null)
 	useSubscription(CorelibPubSub.showStyleVariants, null)
 	useSubscription(CorelibPubSub.blueprints, {})

--- a/meteor/client/ui/Settings.tsx
+++ b/meteor/client/ui/Settings.tsx
@@ -27,7 +27,7 @@ export function Settings(): JSX.Element | null {
 	useSubscription(CorelibPubSub.studios, null)
 	useSubscription(CorelibPubSub.showStyleBases, null)
 	useSubscription(CorelibPubSub.showStyleVariants, null)
-	useSubscription(CorelibPubSub.blueprints, {})
+	useSubscription(CorelibPubSub.blueprints, null)
 
 	useEffect(() => {
 		if (MeteorSettings.enableUserAccounts && user) {

--- a/meteor/client/ui/Settings.tsx
+++ b/meteor/client/ui/Settings.tsx
@@ -25,7 +25,7 @@ export function Settings(): JSX.Element | null {
 
 	useSubscription(CorelibPubSub.peripheralDevices, {})
 	useSubscription(CorelibPubSub.studios, {})
-	useSubscription(CorelibPubSub.showStyleBases, {})
+	useSubscription(CorelibPubSub.showStyleBases, null)
 	useSubscription(CorelibPubSub.showStyleVariants, {})
 	useSubscription(CorelibPubSub.blueprints, {})
 

--- a/meteor/client/ui/Settings.tsx
+++ b/meteor/client/ui/Settings.tsx
@@ -26,7 +26,7 @@ export function Settings(): JSX.Element | null {
 	useSubscription(CorelibPubSub.peripheralDevices, {})
 	useSubscription(CorelibPubSub.studios, {})
 	useSubscription(CorelibPubSub.showStyleBases, null)
-	useSubscription(CorelibPubSub.showStyleVariants, {})
+	useSubscription(CorelibPubSub.showStyleVariants, null)
 	useSubscription(CorelibPubSub.blueprints, {})
 
 	useEffect(() => {

--- a/meteor/client/ui/Settings.tsx
+++ b/meteor/client/ui/Settings.tsx
@@ -26,7 +26,7 @@ export function Settings(): JSX.Element | null {
 	useSubscription(CorelibPubSub.peripheralDevices, null)
 	useSubscription(CorelibPubSub.studios, null)
 	useSubscription(CorelibPubSub.showStyleBases, null)
-	useSubscription(CorelibPubSub.showStyleVariants, null)
+	useSubscription(CorelibPubSub.showStyleVariants, null, null)
 	useSubscription(CorelibPubSub.blueprints, null)
 
 	useEffect(() => {

--- a/meteor/client/ui/Settings.tsx
+++ b/meteor/client/ui/Settings.tsx
@@ -23,7 +23,7 @@ export function Settings(): JSX.Element | null {
 
 	const history = useHistory()
 
-	useSubscription(CorelibPubSub.peripheralDevices, {})
+	useSubscription(CorelibPubSub.peripheralDevices, null)
 	useSubscription(CorelibPubSub.studios, {})
 	useSubscription(CorelibPubSub.showStyleBases, null)
 	useSubscription(CorelibPubSub.showStyleVariants, null)

--- a/meteor/client/ui/Settings/RundownLayoutEditor.tsx
+++ b/meteor/client/ui/Settings/RundownLayoutEditor.tsx
@@ -83,7 +83,7 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 		componentDidMount(): void {
 			super.componentDidMount && super.componentDidMount()
 
-			this.subscribe(MeteorPubSub.rundownLayouts, {})
+			this.subscribe(MeteorPubSub.rundownLayouts, null)
 		}
 
 		onAddLayout = () => {

--- a/meteor/client/ui/Settings/SettingsMenu.tsx
+++ b/meteor/client/ui/Settings/SettingsMenu.tsx
@@ -43,7 +43,7 @@ export const SettingsMenu = translateWithTracker<ISettingsMenuProps, ISettingsMe
 		meteorSubscribe(CorelibPubSub.showStyleBases, null)
 		meteorSubscribe(CorelibPubSub.showStyleVariants, null)
 		meteorSubscribe(CorelibPubSub.blueprints, {})
-		meteorSubscribe(CorelibPubSub.peripheralDevices, {})
+		meteorSubscribe(CorelibPubSub.peripheralDevices, null)
 
 		return {
 			studios: Studios.find({}).fetch(),

--- a/meteor/client/ui/Settings/SettingsMenu.tsx
+++ b/meteor/client/ui/Settings/SettingsMenu.tsx
@@ -41,7 +41,7 @@ export const SettingsMenu = translateWithTracker<ISettingsMenuProps, ISettingsMe
 
 		meteorSubscribe(CorelibPubSub.studios, {})
 		meteorSubscribe(CorelibPubSub.showStyleBases, null)
-		meteorSubscribe(CorelibPubSub.showStyleVariants, {})
+		meteorSubscribe(CorelibPubSub.showStyleVariants, null)
 		meteorSubscribe(CorelibPubSub.blueprints, {})
 		meteorSubscribe(CorelibPubSub.peripheralDevices, {})
 

--- a/meteor/client/ui/Settings/SettingsMenu.tsx
+++ b/meteor/client/ui/Settings/SettingsMenu.tsx
@@ -41,7 +41,7 @@ export const SettingsMenu = translateWithTracker<ISettingsMenuProps, ISettingsMe
 
 		meteorSubscribe(CorelibPubSub.studios, null)
 		meteorSubscribe(CorelibPubSub.showStyleBases, null)
-		meteorSubscribe(CorelibPubSub.showStyleVariants, null)
+		meteorSubscribe(CorelibPubSub.showStyleVariants, null, null)
 		meteorSubscribe(CorelibPubSub.blueprints, null)
 		meteorSubscribe(CorelibPubSub.peripheralDevices, null)
 

--- a/meteor/client/ui/Settings/SettingsMenu.tsx
+++ b/meteor/client/ui/Settings/SettingsMenu.tsx
@@ -39,7 +39,7 @@ export const SettingsMenu = translateWithTracker<ISettingsMenuProps, ISettingsMe
 	(_props: ISettingsMenuProps) => {
 		// TODO: add organizationId:
 
-		meteorSubscribe(CorelibPubSub.studios, {})
+		meteorSubscribe(CorelibPubSub.studios, null)
 		meteorSubscribe(CorelibPubSub.showStyleBases, null)
 		meteorSubscribe(CorelibPubSub.showStyleVariants, null)
 		meteorSubscribe(CorelibPubSub.blueprints, {})

--- a/meteor/client/ui/Settings/SettingsMenu.tsx
+++ b/meteor/client/ui/Settings/SettingsMenu.tsx
@@ -42,7 +42,7 @@ export const SettingsMenu = translateWithTracker<ISettingsMenuProps, ISettingsMe
 		meteorSubscribe(CorelibPubSub.studios, null)
 		meteorSubscribe(CorelibPubSub.showStyleBases, null)
 		meteorSubscribe(CorelibPubSub.showStyleVariants, null)
-		meteorSubscribe(CorelibPubSub.blueprints, {})
+		meteorSubscribe(CorelibPubSub.blueprints, null)
 		meteorSubscribe(CorelibPubSub.peripheralDevices, null)
 
 		return {

--- a/meteor/client/ui/Settings/SettingsMenu.tsx
+++ b/meteor/client/ui/Settings/SettingsMenu.tsx
@@ -40,7 +40,7 @@ export const SettingsMenu = translateWithTracker<ISettingsMenuProps, ISettingsMe
 		// TODO: add organizationId:
 
 		meteorSubscribe(CorelibPubSub.studios, {})
-		meteorSubscribe(CorelibPubSub.showStyleBases, {})
+		meteorSubscribe(CorelibPubSub.showStyleBases, null)
 		meteorSubscribe(CorelibPubSub.showStyleVariants, {})
 		meteorSubscribe(CorelibPubSub.blueprints, {})
 		meteorSubscribe(CorelibPubSub.peripheralDevices, {})

--- a/meteor/client/ui/Settings/SnapshotsView.tsx
+++ b/meteor/client/ui/Settings/SnapshotsView.tsx
@@ -3,7 +3,7 @@ import { Translated, translateWithTracker } from '../../lib/ReactMeteorData/reac
 import { doModalDialog } from '../../lib/ModalDialog'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { SnapshotItem } from '../../../lib/collections/Snapshots'
-import { getCurrentTime, unprotectString } from '../../../lib/lib'
+import { unprotectString } from '../../../lib/lib'
 import * as _ from 'underscore'
 import { logger } from '../../../lib/logging'
 import { EditAttribute } from '../../lib/EditAttribute'
@@ -60,11 +60,7 @@ export default translateWithTracker<IProps, IState, ITrackedProps>(() => {
 			}
 		}
 		componentDidMount(): void {
-			this.subscribe(MeteorPubSub.snapshots, {
-				created: {
-					$gt: getCurrentTime() - 30 * 24 * 3600 * 1000, // last 30 days
-				},
-			})
+			this.subscribe(MeteorPubSub.snapshots)
 			this.subscribe(CorelibPubSub.studios, null)
 		}
 

--- a/meteor/client/ui/Settings/SnapshotsView.tsx
+++ b/meteor/client/ui/Settings/SnapshotsView.tsx
@@ -65,7 +65,7 @@ export default translateWithTracker<IProps, IState, ITrackedProps>(() => {
 					$gt: getCurrentTime() - 30 * 24 * 3600 * 1000, // last 30 days
 				},
 			})
-			this.subscribe(CorelibPubSub.studios, {})
+			this.subscribe(CorelibPubSub.studios, null)
 		}
 
 		onUploadFile(e: React.ChangeEvent<HTMLInputElement>) {

--- a/meteor/client/ui/Settings/components/triggeredActions/TriggeredActionsEditor.tsx
+++ b/meteor/client/ui/Settings/components/triggeredActions/TriggeredActionsEditor.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect, useContext, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSubscription, useTracker } from '../../../../lib/ReactMeteorData/ReactMeteorData'
 import { MeteorPubSub } from '../../../../../lib/api/pubsub'
-import { TriggeredActionsObj } from '../../../../../lib/collections/TriggeredActions'
 import { faCaretDown, faCaretRight, faDownload, faPlus, faUpload } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { TriggeredActionEntry, TRIGGERED_ACTION_ENTRY_DRAG_TYPE } from './TriggeredActionEntry'
@@ -24,8 +23,6 @@ import { catchError, fetchFrom } from '../../../../lib/lib'
 import { NotificationCenter, Notification, NoticeLevel } from '../../../../../lib/notifications/notifications'
 import { Meteor } from 'meteor/meteor'
 import { doModalDialog } from '../../../../lib/ModalDialog'
-import { MongoQuery } from '@sofie-automation/corelib/dist/mongo'
-import _ from 'underscore'
 import { PartId, RundownId, ShowStyleBaseId, TriggeredActionId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { PartInstances, Parts, RundownPlaylists, Rundowns, TriggeredActions } from '../../../../collections'
 import { applyAndValidateOverrides } from '@sofie-automation/corelib/dist/settings/objectWithOverrides'
@@ -78,20 +75,8 @@ export const TriggeredActionsEditor: React.FC<IProps> = function TriggeredAction
 	})
 
 	const { showStyleBaseId, sourceLayers, outputLayers } = props
-	const showStyleBaseSelector: MongoQuery<TriggeredActionsObj> = {
-		$or: _.compact([
-			{
-				showStyleBaseId: null,
-			},
-			showStyleBaseId !== null
-				? {
-						showStyleBaseId: showStyleBaseId,
-				  }
-				: undefined,
-		]),
-	}
 
-	useSubscription(MeteorPubSub.triggeredActions, showStyleBaseSelector)
+	useSubscription(MeteorPubSub.triggeredActions, showStyleBaseId ? [showStyleBaseId] : null)
 	useSubscription(CorelibPubSub.rundowns, null, showStyleBaseId ? [showStyleBaseId] : [])
 
 	useEffect(() => {

--- a/meteor/client/ui/Settings/components/triggeredActions/TriggeredActionsEditor.tsx
+++ b/meteor/client/ui/Settings/components/triggeredActions/TriggeredActionsEditor.tsx
@@ -77,7 +77,7 @@ export const TriggeredActionsEditor: React.FC<IProps> = function TriggeredAction
 	const { showStyleBaseId, sourceLayers, outputLayers } = props
 
 	useSubscription(MeteorPubSub.triggeredActions, showStyleBaseId ? [showStyleBaseId] : null)
-	useSubscription(CorelibPubSub.rundowns, null, showStyleBaseId ? [showStyleBaseId] : [])
+	useSubscription(CorelibPubSub.rundownsWithShowStyleBases, showStyleBaseId ? [showStyleBaseId] : [])
 
 	useEffect(() => {
 		const debounce = setTimeout(() => {
@@ -192,7 +192,7 @@ export const TriggeredActionsEditor: React.FC<IProps> = function TriggeredAction
 	)
 
 	useSubscription(CorelibPubSub.partInstances, rundown ? [rundown._id] : [], rundownPlaylist?.activationId ?? null)
-	useSubscription(CorelibPubSub.parts, rundown ? [rundown._id] : [])
+	useSubscription(CorelibPubSub.parts, rundown ? [rundown._id] : [], null)
 
 	const previewContext = useTracker(
 		() => {

--- a/meteor/client/ui/Settings/components/triggeredActions/TriggeredActionsEditor.tsx
+++ b/meteor/client/ui/Settings/components/triggeredActions/TriggeredActionsEditor.tsx
@@ -167,7 +167,7 @@ export const TriggeredActionsEditor: React.FC<IProps> = function TriggeredAction
 		[showStyleBaseId, parsedTriggerFilter]
 	)
 
-	useSubscription(CorelibPubSub.rundownPlaylists, {})
+	useSubscription(CorelibPubSub.rundownPlaylists, null, null)
 
 	const rundown = useTracker(() => {
 		const activePlaylists = RundownPlaylists.find(

--- a/meteor/client/ui/Settings/components/triggeredActions/TriggeredActionsEditor.tsx
+++ b/meteor/client/ui/Settings/components/triggeredActions/TriggeredActionsEditor.tsx
@@ -191,7 +191,7 @@ export const TriggeredActionsEditor: React.FC<IProps> = function TriggeredAction
 		null
 	)
 
-	useSubscription(CorelibPubSub.partInstances, rundown ? [rundown._id] : [], rundownPlaylist?.activationId)
+	useSubscription(CorelibPubSub.partInstances, rundown ? [rundown._id] : [], rundownPlaylist?.activationId ?? null)
 	useSubscription(CorelibPubSub.parts, rundown ? [rundown._id] : [])
 
 	const previewContext = useTracker(

--- a/meteor/client/ui/Shelf/BucketPanel.tsx
+++ b/meteor/client/ui/Shelf/BucketPanel.tsx
@@ -397,20 +397,18 @@ export const BucketPanel = translateWithTracker<Translated<IBucketPanelProps>, I
 							])
 						const showStyleBases = showStyles.map((showStyle) => showStyle[0])
 						const showStyleVariants = showStyles.map((showStyle) => showStyle[1])
-						this.subscribe(CorelibPubSub.bucketAdLibPieces, {
-							bucketId: this.props.bucket._id,
-							studioId: this.props.playlist.studioId,
-							showStyleVariantId: {
-								$in: [null, ...showStyleVariants], // null = valid for all variants
-							},
-						})
-						this.subscribe(CorelibPubSub.bucketAdLibActions, {
-							bucketId: this.props.bucket._id,
-							studioId: this.props.playlist.studioId,
-							showStyleVariantId: {
-								$in: [null, ...showStyleVariants], // null = valid for all variants
-							},
-						})
+						this.subscribe(
+							CorelibPubSub.bucketAdLibPieces,
+							this.props.playlist.studioId,
+							this.props.bucket._id,
+							showStyleVariants
+						)
+						this.subscribe(
+							CorelibPubSub.bucketAdLibActions,
+							this.props.playlist.studioId,
+							this.props.bucket._id,
+							showStyleVariants
+						)
 						for (const showStyleBaseId of _.uniq(showStyleBases)) {
 							this.subscribe(MeteorPubSub.uiShowStyleBase, showStyleBaseId)
 						}

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -167,7 +167,9 @@ export class DashboardPanelInner extends MeteorReactComponent<
 		this.autorun(() => {
 			const unorderedRundownIds = RundownPlaylistCollectionUtil.getRundownUnorderedIDs(this.props.playlist)
 			if (unorderedRundownIds.length > 0) {
-				this.subscribe(CorelibPubSub.pieceInstances, unorderedRundownIds, null, true)
+				this.subscribe(CorelibPubSub.pieceInstances, unorderedRundownIds, null, {
+					onlyPlayingAdlibsOrWithTags: true,
+				})
 			}
 		})
 	}

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -167,44 +167,7 @@ export class DashboardPanelInner extends MeteorReactComponent<
 		this.autorun(() => {
 			const unorderedRundownIds = RundownPlaylistCollectionUtil.getRundownUnorderedIDs(this.props.playlist)
 			if (unorderedRundownIds.length > 0) {
-				this.subscribe(CorelibPubSub.pieceInstances, {
-					rundownId: {
-						$in: unorderedRundownIds,
-					},
-					plannedStartedPlayback: {
-						$exists: true,
-					},
-					$and: [
-						{
-							$or: [
-								{
-									adLibSourceId: {
-										$exists: true,
-									},
-								},
-								{
-									'piece.tags': {
-										$exists: true,
-									},
-								},
-							],
-						},
-						{
-							$or: [
-								{
-									plannedStoppedPlayback: {
-										$eq: 0,
-									},
-								},
-								{
-									plannedStoppedPlayback: {
-										$exists: false,
-									},
-								},
-							],
-						},
-					],
-				})
+				this.subscribe(CorelibPubSub.pieceInstances, unorderedRundownIds, null, true)
 			}
 		})
 	}

--- a/meteor/client/ui/Status.tsx
+++ b/meteor/client/ui/Status.tsx
@@ -83,7 +83,7 @@ class Status extends MeteorReactComponent<Translated<IStatusProps>> {
 		this.subscribe(CorelibPubSub.peripheralDevices, null)
 		this.subscribe(MeteorPubSub.uiStudio, null)
 		this.subscribe(CorelibPubSub.showStyleBases, null)
-		this.subscribe(CorelibPubSub.showStyleVariants, null)
+		this.subscribe(CorelibPubSub.showStyleVariants, null, null)
 	}
 	render(): JSX.Element {
 		// const { t } = this.props

--- a/meteor/client/ui/Status.tsx
+++ b/meteor/client/ui/Status.tsx
@@ -83,7 +83,7 @@ class Status extends MeteorReactComponent<Translated<IStatusProps>> {
 		this.subscribe(CorelibPubSub.peripheralDevices, {})
 		this.subscribe(MeteorPubSub.uiStudio, null)
 		this.subscribe(CorelibPubSub.showStyleBases, null)
-		this.subscribe(CorelibPubSub.showStyleVariants, {})
+		this.subscribe(CorelibPubSub.showStyleVariants, null)
 	}
 	render(): JSX.Element {
 		// const { t } = this.props

--- a/meteor/client/ui/Status.tsx
+++ b/meteor/client/ui/Status.tsx
@@ -82,7 +82,7 @@ class Status extends MeteorReactComponent<Translated<IStatusProps>> {
 
 		this.subscribe(CorelibPubSub.peripheralDevices, {})
 		this.subscribe(MeteorPubSub.uiStudio, null)
-		this.subscribe(CorelibPubSub.showStyleBases, {})
+		this.subscribe(CorelibPubSub.showStyleBases, null)
 		this.subscribe(CorelibPubSub.showStyleVariants, {})
 	}
 	render(): JSX.Element {

--- a/meteor/client/ui/Status.tsx
+++ b/meteor/client/ui/Status.tsx
@@ -80,7 +80,7 @@ class Status extends MeteorReactComponent<Translated<IStatusProps>> {
 	componentDidMount(): void {
 		// Subscribe to data:
 
-		this.subscribe(CorelibPubSub.peripheralDevices, {})
+		this.subscribe(CorelibPubSub.peripheralDevices, null)
 		this.subscribe(MeteorPubSub.uiStudio, null)
 		this.subscribe(CorelibPubSub.showStyleBases, null)
 		this.subscribe(CorelibPubSub.showStyleVariants, null)

--- a/meteor/client/ui/Status/Evaluations.tsx
+++ b/meteor/client/ui/Status/Evaluations.tsx
@@ -63,12 +63,7 @@ const EvaluationView = translateWithTracker<IEvaluationProps, IEvaluationState, 
 				if (this._sub) {
 					this._sub.stop()
 				}
-				this._sub = meteorSubscribe(MeteorPubSub.evaluations, {
-					timestamp: {
-						$gte: this.state.dateFrom,
-						$lt: this.state.dateTo,
-					},
-				})
+				this._sub = meteorSubscribe(MeteorPubSub.evaluations, this.state.dateFrom, this.state.dateTo)
 			}
 		}
 		componentWillUnmount(): void {

--- a/meteor/client/ui/Status/MediaManager.tsx
+++ b/meteor/client/ui/Status/MediaManager.tsx
@@ -378,8 +378,8 @@ export const MediaManagerStatus = translateWithTracker<IMediaManagerStatusProps,
 
 		componentDidMount(): void {
 			// Subscribe to data:
-			this.subscribe(MeteorPubSub.mediaWorkFlows, {}) // TODO: add some limit
-			this.subscribe(MeteorPubSub.mediaWorkFlowSteps, {})
+			this.subscribe(MeteorPubSub.mediaWorkFlows) // TODO: add some limit
+			this.subscribe(MeteorPubSub.mediaWorkFlowSteps)
 		}
 
 		toggleExpanded = (workFlowId: MediaWorkFlowId) => {

--- a/meteor/client/ui/Status/SystemStatus.tsx
+++ b/meteor/client/ui/Status/SystemStatus.tsx
@@ -546,7 +546,7 @@ export default translateWithTracker<ISystemStatusProps, ISystemStatusState, ISys
 			this.refreshDebugStatesInterval = setInterval(this.refreshDebugStates, 1000)
 
 			// Subscribe to data:
-			this.subscribe(CorelibPubSub.peripheralDevices, {})
+			this.subscribe(CorelibPubSub.peripheralDevices, null)
 		}
 
 		componentWillUnmount(): void {

--- a/meteor/client/ui/Status/UserActivity.tsx
+++ b/meteor/client/ui/Status/UserActivity.tsx
@@ -149,12 +149,7 @@ function UserActivity(): JSX.Element {
 	const [dateFrom, setDateFrom] = useState<Time>(moment().startOf('day').valueOf())
 	const [dateTo, setDateTo] = useState<Time>(moment().add(1, 'days').startOf('day').valueOf())
 
-	useSubscription(MeteorPubSub.userActionsLog, {
-		timestamp: {
-			$gte: dateFrom,
-			$lt: dateTo,
-		},
-	})
+	useSubscription(MeteorPubSub.userActionsLog, dateFrom, dateTo)
 
 	const log = useTracker(
 		() =>

--- a/meteor/client/ui/Status/media-status/index.tsx
+++ b/meteor/client/ui/Status/media-status/index.tsx
@@ -35,7 +35,7 @@ export function MediaStatus(): JSX.Element | null {
 		setSortBy(sortBy)
 	}
 
-	useSubscription(CorelibPubSub.rundownPlaylists, {})
+	useSubscription(CorelibPubSub.rundownPlaylists, null, null)
 
 	const { t } = useTranslation()
 

--- a/meteor/client/ui/Status/package-status/index.tsx
+++ b/meteor/client/ui/Status/package-status/index.tsx
@@ -34,15 +34,9 @@ export const ExpectedPackagesStatus: React.FC<{}> = function ExpectedPackagesSta
 
 	const allSubsReady: boolean =
 		[
-			useSubscription(CorelibPubSub.expectedPackageWorkStatuses, {
-				studioId: { $in: studioIds },
-			}),
-			useSubscription(CorelibPubSub.expectedPackages, {
-				studioId: { $in: studioIds },
-			}),
-			useSubscription(CorelibPubSub.packageContainerStatuses, {
-				studioId: { $in: studioIds },
-			}),
+			useSubscription(CorelibPubSub.expectedPackageWorkStatuses, studioIds ?? []),
+			useSubscription(CorelibPubSub.expectedPackages, studioIds ?? []),
+			useSubscription(CorelibPubSub.packageContainerStatuses, studioIds ?? []),
 			studioIds && studioIds.length > 0,
 		].reduce((memo, value) => memo && value, true) || false
 

--- a/meteor/client/ui/Status/package-status/index.tsx
+++ b/meteor/client/ui/Status/package-status/index.tsx
@@ -50,9 +50,7 @@ export const ExpectedPackagesStatus: React.FC<{}> = function ExpectedPackagesSta
 		expectedPackageWorkStatuses.forEach((epws) => devices.add(epws.deviceId))
 		return Array.from(devices)
 	}, [packageContainerStatuses, expectedPackageWorkStatuses])
-	const peripheralDeviceSubReady = useSubscription(CorelibPubSub.peripheralDevices, {
-		_id: { $in: deviceIds },
-	})
+	const peripheralDeviceSubReady = useSubscription(CorelibPubSub.peripheralDevices, deviceIds)
 	const peripheralDevices = useTracker(() => PeripheralDevices.find().fetch(), [], [])
 	const peripheralDevicesMap = normalizeArrayToMap(peripheralDevices, '_id')
 

--- a/meteor/client/ui/StudioScreenSaver/StudioScreenSaver.tsx
+++ b/meteor/client/ui/StudioScreenSaver/StudioScreenSaver.tsx
@@ -126,9 +126,7 @@ export const StudioScreenSaver = translateWithTracker(findNextPlaylist)(
 
 		componentDidMount(): void {
 			this.subscribe(MeteorPubSub.uiStudio, this.props.studioId)
-			this.subscribe(CorelibPubSub.rundownPlaylists, {
-				studioId: this.props.studioId,
-			})
+			this.subscribe(CorelibPubSub.rundownPlaylists, [], [this.props.studioId])
 
 			if (this.props.ownBackground) {
 				document.body.classList.add('dark', 'xdark')

--- a/meteor/client/ui/TestTools/DeviceTriggers.tsx
+++ b/meteor/client/ui/TestTools/DeviceTriggers.tsx
@@ -130,7 +130,7 @@ function DeviceTriggersControls({ peripheralDeviceId }: IDatastoreControlsProps)
 }
 
 const DeviceTriggersDeviceSelect: React.FC = function DeviceTriggersDeviceSelect() {
-	useSubscription(CorelibPubSub.peripheralDevices, {})
+	useSubscription(CorelibPubSub.peripheralDevices, null)
 	const devices = useTracker(() => PeripheralDevices.find().fetch(), [])
 
 	if (!devices) return null

--- a/meteor/client/ui/TestTools/index.tsx
+++ b/meteor/client/ui/TestTools/index.tsx
@@ -64,7 +64,7 @@ class Status extends MeteorReactComponent<Translated<IStatusProps>> {
 		// Subscribe to data:
 
 		this.subscribe(MeteorPubSub.uiStudio, null)
-		this.subscribe(CorelibPubSub.showStyleBases, {})
+		this.subscribe(CorelibPubSub.showStyleBases, null)
 		this.subscribe(CorelibPubSub.showStyleVariants, {})
 	}
 	render(): JSX.Element {

--- a/meteor/client/ui/TestTools/index.tsx
+++ b/meteor/client/ui/TestTools/index.tsx
@@ -65,7 +65,7 @@ class Status extends MeteorReactComponent<Translated<IStatusProps>> {
 
 		this.subscribe(MeteorPubSub.uiStudio, null)
 		this.subscribe(CorelibPubSub.showStyleBases, null)
-		this.subscribe(CorelibPubSub.showStyleVariants, null)
+		this.subscribe(CorelibPubSub.showStyleVariants, null, null)
 	}
 	render(): JSX.Element {
 		return (

--- a/meteor/client/ui/TestTools/index.tsx
+++ b/meteor/client/ui/TestTools/index.tsx
@@ -65,7 +65,7 @@ class Status extends MeteorReactComponent<Translated<IStatusProps>> {
 
 		this.subscribe(MeteorPubSub.uiStudio, null)
 		this.subscribe(CorelibPubSub.showStyleBases, null)
-		this.subscribe(CorelibPubSub.showStyleVariants, {})
+		this.subscribe(CorelibPubSub.showStyleVariants, null)
 	}
 	render(): JSX.Element {
 		return (

--- a/meteor/client/ui/i18n.ts
+++ b/meteor/client/ui/i18n.ts
@@ -103,7 +103,7 @@ class I18nContainer extends WithManagedTracker {
 			})
 			.catch(catchError('i18nInstance.init'))
 
-		this.subscribe(MeteorPubSub.translationsBundles, {})
+		this.subscribe(MeteorPubSub.translationsBundles)
 		this.autorun(() => {
 			const bundlesInfo = TranslationsBundles.find().fetch() as Omit<TranslationsBundle, 'data'>[]
 

--- a/meteor/lib/api/pubsub.ts
+++ b/meteor/lib/api/pubsub.ts
@@ -114,7 +114,8 @@ export interface MeteorPubSubTypes {
 	/** @deprecated */
 	[MeteorPubSub.mediaWorkFlowSteps]: (token?: string) => CollectionName.MediaWorkFlowSteps
 	[MeteorPubSub.rundownLayouts]: (
-		selector: MongoQuery<RundownLayoutBase>,
+		/** ShowStyleBaseIds to fetch for, or null to fetch all */
+		showStyleBaseIds: ShowStyleBaseId[] | null,
 		token?: string
 	) => CollectionName.RundownLayouts
 	[MeteorPubSub.loggedInUser]: (token?: string) => CollectionName.Users

--- a/meteor/lib/api/pubsub.ts
+++ b/meteor/lib/api/pubsub.ts
@@ -43,7 +43,7 @@ export enum MeteorPubSub {
 	coreSystem = 'coreSystem',
 	evaluations = 'evaluations',
 
-	activeRundownPlaylistForStudio = 'activeRundownPlaylistForStudio',
+	rundownPlaylistForStudio = 'rundownPlaylistForStudio',
 	adLibActionsForPart = 'adLibActionsForPart',
 	adLibPiecesForPart = 'adLibPiecesForPart',
 
@@ -96,7 +96,7 @@ export interface MeteorPubSubTypes {
 	[MeteorPubSub.coreSystem]: (token?: string) => CollectionName.CoreSystem
 	[MeteorPubSub.evaluations]: (selector: MongoQuery<Evaluation>, token?: string) => CollectionName.Evaluations
 
-	[MeteorPubSub.activeRundownPlaylistForStudio]: (studioId: StudioId) => CollectionName.RundownPlaylists
+	[MeteorPubSub.rundownPlaylistForStudio]: (studioId: StudioId, isActive: boolean) => CollectionName.RundownPlaylists
 	[MeteorPubSub.adLibActionsForPart]: (partId: PartId, sourceLayerIds: string[]) => CollectionName.AdLibActions
 	[MeteorPubSub.adLibPiecesForPart]: (partId: PartId, sourceLayerIds: string[]) => CollectionName.AdLibPieces
 

--- a/meteor/lib/api/pubsub.ts
+++ b/meteor/lib/api/pubsub.ts
@@ -124,7 +124,7 @@ export interface MeteorPubSubTypes {
 		token?: string
 	) => CollectionName.RundownLayouts
 	[MeteorPubSub.loggedInUser]: (token?: string) => CollectionName.Users
-	[MeteorPubSub.usersInOrganization]: (selector: MongoQuery<DBUser>, token?: string) => CollectionName.Users
+	[MeteorPubSub.usersInOrganization]: (organizationId: OrganizationId, token?: string) => CollectionName.Users
 	[MeteorPubSub.organization]: (organizationId: OrganizationId | null, token?: string) => CollectionName.Organizations
 	[MeteorPubSub.buckets]: (studioId: StudioId, bucketId: BucketId | null, token?: string) => CollectionName.Buckets
 	[MeteorPubSub.translationsBundles]: (

--- a/meteor/lib/api/pubsub.ts
+++ b/meteor/lib/api/pubsub.ts
@@ -39,40 +39,124 @@ import { CollectionName } from '@sofie-automation/corelib/dist/dataModel/Collect
  * Ids of possible DDP subscriptions
  */
 export enum MeteorPubSub {
+	/**
+	 * Fetch the CoreSystem document
+	 */
 	coreSystem = 'coreSystem',
+	/**
+	 * Fetch all User Evaluations for the specified time range
+	 */
 	evaluations = 'evaluations',
 
+	/**
+	 * Fetch RundownPlaylists for the specified Studio, limited to either active or inactive playlists
+	 */
 	rundownPlaylistForStudio = 'rundownPlaylistForStudio',
+	/**
+	 * Fetch all the AdlibActions for specified PartId, limited to the specified sourceLayerIds
+	 */
 	adLibActionsForPart = 'adLibActionsForPart',
+	/**
+	 * Fetch all the AdlibPieces for specified PartId, limited to the specified sourceLayerIds
+	 */
 	adLibPiecesForPart = 'adLibPiecesForPart',
 
+	/**
+	 * Fetch either all TriggeredActions or limited to the specified ShowStyleBases
+	 */
 	triggeredActions = 'triggeredActions',
+	/**
+	 * Fetch all the Snapshots in the system
+	 */
 	snapshots = 'snapshots',
+	/**
+	 * Fetch all User Action Log entries for the specified time range
+	 */
 	userActionsLog = 'userActionsLog',
-	/** @deprecated */
+	/**
+	 * Fetch all MediaManager workflows in the system
+	 * @deprecated
+	 */
 	mediaWorkFlows = 'mediaWorkFlows',
-	/** @deprecated */
+	/**
+	 * Fetch all MediaManager workflow steps in the system
+	 * @deprecated
+	 */
 	mediaWorkFlowSteps = 'mediaWorkFlowSteps',
+	/**
+	 * Fetch either all RundownLayouts or limited to the specified ShowStyleBases
+	 */
 	rundownLayouts = 'rundownLayouts',
+	/**
+	 * Fetch information about the current logged in user, if any
+	 */
 	loggedInUser = 'loggedInUser',
+	/**
+	 * Fetch information about all users for a given organization
+	 */
 	usersInOrganization = 'usersInOrganization',
+	/**
+	 * Fetch information about a specified organization.
+	 * If null is provided, nothing will be returned
+	 */
 	organization = 'organization',
+	/**
+	 * Fetch either all buckets for the given Studio, or the Bucket specified.
+	 */
 	buckets = 'buckets',
+	/**
+	 * Fetch all translation bundles
+	 */
 	translationsBundles = 'translationsBundles',
 
 	// custom publications:
+
+	/**
+	 * Fetch the simplified timeline mappings for a given studio
+	 */
 	mappingsForStudio = 'mappingsForStudio',
+	/**
+	 * Fetch the simplified timeline for a given studio
+	 */
 	timelineForStudio = 'timelineForStudio',
 
+	/**
+	 * Fetch the simplified playout UI view of the specified ShowStyleBase
+	 */
 	uiShowStyleBase = 'uiShowStyleBase',
+	/**
+	 * Fetch the simplified playout UI view of the specified Studio.
+	 * If the id is null, nothing will be returned
+	 */
 	uiStudio = 'uiStudio',
+	/**
+	 * Fetch the simplified playout UI view of the TriggeredActions in the specified ShowStyleBase.
+	 * If the id is null, nothing will be returned
+	 */
 	uiTriggeredActions = 'uiTriggeredActions',
 
+	/**
+	 * Fetch the calculated trigger previews for the given Studio
+	 */
 	deviceTriggersPreview = 'deviceTriggersPreview',
 
+	/**
+	 * Fetch the Segment and Part notes in the given RundownPlaylist
+	 * If the id is null, nothing will be returned
+	 */
 	uiSegmentPartNotes = 'uiSegmentPartNotes',
+	/**
+	 * Fetch the Pieces content-status in the given RundownPlaylist
+	 * If the id is null, nothing will be returned
+	 */
 	uiPieceContentStatuses = 'uiPieceContentStatuses',
+	/**
+	 * Fetch the Pieces content-status in the given Bucket
+	 */
 	uiBucketContentStatuses = 'uiBucketContentStatuses',
+	/**
+	 * Fetch the Upgrade Statuses of all Blueprints in the system
+	 */
 	uiBlueprintUpgradeStatuses = 'uiBlueprintUpgradeStatuses',
 }
 

--- a/meteor/lib/api/pubsub.ts
+++ b/meteor/lib/api/pubsub.ts
@@ -101,7 +101,8 @@ export interface MeteorPubSubTypes {
 	[MeteorPubSub.adLibPiecesForPart]: (partId: PartId, sourceLayerIds: string[]) => CollectionName.AdLibPieces
 
 	[MeteorPubSub.triggeredActions]: (
-		selector: MongoQuery<DBTriggeredActions>,
+		/** ShowStyleBaseIds to fetch for, or null to just fetch global */
+		showStyleBaseIds: ShowStyleBaseId[] | null,
 		token?: string
 	) => CollectionName.TriggeredActions
 	[MeteorPubSub.snapshots]: (selector: MongoQuery<SnapshotItem>, token?: string) => CollectionName.Snapshots

--- a/meteor/lib/api/pubsub.ts
+++ b/meteor/lib/api/pubsub.ts
@@ -36,7 +36,7 @@ import { CorelibPubSub, CorelibPubSubCollections, CorelibPubSubTypes } from '@so
 import { CollectionName } from '@sofie-automation/corelib/dist/dataModel/Collections'
 
 /**
- * Ids of possible DDP subscriptions
+ * Ids of possible DDP subscriptions for the UI only
  */
 export enum MeteorPubSub {
 	/**

--- a/meteor/lib/api/pubsub.ts
+++ b/meteor/lib/api/pubsub.ts
@@ -1,6 +1,7 @@
 import {
 	BucketId,
 	OrganizationId,
+	PartId,
 	RundownPlaylistId,
 	ShowStyleBaseId,
 	StudioId,
@@ -42,6 +43,10 @@ export enum MeteorPubSub {
 	coreSystem = 'coreSystem',
 	evaluations = 'evaluations',
 	expectedPlayoutItems = 'expectedPlayoutItems',
+
+	activeRundownPlaylistForStudio = 'activeRundownPlaylistForStudio',
+	adLibActionsForPart = 'adLibActionsForPart',
+	adLibPiecesForPart = 'adLibPiecesForPart',
 
 	triggeredActions = 'triggeredActions',
 	snapshots = 'snapshots',
@@ -95,6 +100,10 @@ export interface MeteorPubSubTypes {
 		selector: MongoQuery<ExpectedPlayoutItem>,
 		token?: string
 	) => CollectionName.ExpectedPlayoutItems
+
+	[MeteorPubSub.activeRundownPlaylistForStudio]: (studioId: StudioId) => CollectionName.RundownPlaylists
+	[MeteorPubSub.adLibActionsForPart]: (partId: PartId, sourceLayerIds: string[]) => CollectionName.AdLibActions
+	[MeteorPubSub.adLibPiecesForPart]: (partId: PartId, sourceLayerIds: string[]) => CollectionName.AdLibPieces
 
 	[MeteorPubSub.triggeredActions]: (
 		selector: MongoQuery<DBTriggeredActions>,

--- a/meteor/lib/api/pubsub.ts
+++ b/meteor/lib/api/pubsub.ts
@@ -42,7 +42,6 @@ import { CollectionName } from '@sofie-automation/corelib/dist/dataModel/Collect
 export enum MeteorPubSub {
 	coreSystem = 'coreSystem',
 	evaluations = 'evaluations',
-	expectedPlayoutItems = 'expectedPlayoutItems',
 
 	activeRundownPlaylistForStudio = 'activeRundownPlaylistForStudio',
 	adLibActionsForPart = 'adLibActionsForPart',
@@ -96,10 +95,6 @@ export type AllPubSubTypes = CorelibPubSubTypes & PeripheralDevicePubSubTypes & 
 export interface MeteorPubSubTypes {
 	[MeteorPubSub.coreSystem]: (token?: string) => CollectionName.CoreSystem
 	[MeteorPubSub.evaluations]: (selector: MongoQuery<Evaluation>, token?: string) => CollectionName.Evaluations
-	[MeteorPubSub.expectedPlayoutItems]: (
-		selector: MongoQuery<ExpectedPlayoutItem>,
-		token?: string
-	) => CollectionName.ExpectedPlayoutItems
 
 	[MeteorPubSub.activeRundownPlaylistForStudio]: (studioId: StudioId) => CollectionName.RundownPlaylists
 	[MeteorPubSub.adLibActionsForPart]: (partId: PartId, sourceLayerIds: string[]) => CollectionName.AdLibActions

--- a/meteor/lib/api/pubsub.ts
+++ b/meteor/lib/api/pubsub.ts
@@ -123,10 +123,7 @@ export interface MeteorPubSubTypes {
 	[MeteorPubSub.usersInOrganization]: (organizationId: OrganizationId, token?: string) => CollectionName.Users
 	[MeteorPubSub.organization]: (organizationId: OrganizationId | null, token?: string) => CollectionName.Organizations
 	[MeteorPubSub.buckets]: (studioId: StudioId, bucketId: BucketId | null, token?: string) => CollectionName.Buckets
-	[MeteorPubSub.translationsBundles]: (
-		selector: MongoQuery<TranslationsBundle>,
-		token?: string
-	) => CollectionName.TranslationsBundles
+	[MeteorPubSub.translationsBundles]: (token?: string) => CollectionName.TranslationsBundles
 
 	// custom publications:
 

--- a/meteor/lib/api/pubsub.ts
+++ b/meteor/lib/api/pubsub.ts
@@ -110,15 +110,9 @@ export interface MeteorPubSubTypes {
 		token?: string
 	) => CollectionName.UserActionsLog
 	/** @deprecated */
-	[MeteorPubSub.mediaWorkFlows]: (
-		selector: MongoQuery<MediaWorkFlow>,
-		token?: string
-	) => CollectionName.MediaWorkFlows
+	[MeteorPubSub.mediaWorkFlows]: (token?: string) => CollectionName.MediaWorkFlows
 	/** @deprecated */
-	[MeteorPubSub.mediaWorkFlowSteps]: (
-		selector: MongoQuery<MediaWorkFlowStep>,
-		token?: string
-	) => CollectionName.MediaWorkFlowSteps
+	[MeteorPubSub.mediaWorkFlowSteps]: (token?: string) => CollectionName.MediaWorkFlowSteps
 	[MeteorPubSub.rundownLayouts]: (
 		selector: MongoQuery<RundownLayoutBase>,
 		token?: string

--- a/meteor/lib/api/pubsub.ts
+++ b/meteor/lib/api/pubsub.ts
@@ -24,7 +24,6 @@ import { UIBucketContentStatus, UIPieceContentStatus, UISegmentPartNote } from '
 import { UIShowStyleBase } from './showStyles'
 import { UIStudio } from './studios'
 import { UIDeviceTriggerPreview } from '../../server/publications/deviceTriggersPreview'
-import { MongoQuery } from '@sofie-automation/corelib/dist/mongo'
 import { logger } from '../logging'
 import { UIBlueprintUpgradeStatus } from './upgradeStatus'
 import {
@@ -94,7 +93,7 @@ export type AllPubSubTypes = CorelibPubSubTypes & PeripheralDevicePubSubTypes & 
 
 export interface MeteorPubSubTypes {
 	[MeteorPubSub.coreSystem]: (token?: string) => CollectionName.CoreSystem
-	[MeteorPubSub.evaluations]: (selector: MongoQuery<Evaluation>, token?: string) => CollectionName.Evaluations
+	[MeteorPubSub.evaluations]: (dateFrom: number, dateTo: number, token?: string) => CollectionName.Evaluations
 
 	[MeteorPubSub.rundownPlaylistForStudio]: (studioId: StudioId, isActive: boolean) => CollectionName.RundownPlaylists
 	[MeteorPubSub.adLibActionsForPart]: (partId: PartId, sourceLayerIds: string[]) => CollectionName.AdLibActions
@@ -105,11 +104,8 @@ export interface MeteorPubSubTypes {
 		showStyleBaseIds: ShowStyleBaseId[] | null,
 		token?: string
 	) => CollectionName.TriggeredActions
-	[MeteorPubSub.snapshots]: (selector: MongoQuery<SnapshotItem>, token?: string) => CollectionName.Snapshots
-	[MeteorPubSub.userActionsLog]: (
-		selector: MongoQuery<UserActionsLogItem>,
-		token?: string
-	) => CollectionName.UserActionsLog
+	[MeteorPubSub.snapshots]: (token?: string) => CollectionName.Snapshots
+	[MeteorPubSub.userActionsLog]: (dateFrom: number, dateTo: number, token?: string) => CollectionName.UserActionsLog
 	/** @deprecated */
 	[MeteorPubSub.mediaWorkFlows]: (token?: string) => CollectionName.MediaWorkFlows
 	/** @deprecated */

--- a/meteor/server/publications/buckets.ts
+++ b/meteor/server/publications/buckets.ts
@@ -1,17 +1,13 @@
-import { Meteor } from 'meteor/meteor'
 import { FindOptions } from '../../lib/collections/lib'
 import { BucketSecurity } from '../security/buckets'
 import { meteorPublish } from './lib'
 import { MeteorPubSub } from '../../lib/api/pubsub'
 import { Bucket } from '../../lib/collections/Buckets'
-import { BucketAdLib } from '@sofie-automation/corelib/dist/dataModel/BucketAdLibPiece'
-import { BucketAdLibAction } from '@sofie-automation/corelib/dist/dataModel/BucketAdLibAction'
 import { StudioReadAccess } from '../security/studio'
 import { isProtectedString } from '@sofie-automation/corelib/dist/protectedString'
 import { BucketAdLibActions, BucketAdLibs, Buckets } from '../collections'
 import { check, Match } from 'meteor/check'
-import { MongoQuery } from '@sofie-automation/corelib/dist/mongo'
-import { StudioId, BucketId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { StudioId, BucketId, ShowStyleVariantId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 meteorPublish(
@@ -45,15 +41,26 @@ meteorPublish(
 
 meteorPublish(
 	CorelibPubSub.bucketAdLibPieces,
-	async function (selector: MongoQuery<BucketAdLib>, _token: string | undefined) {
-		if (!selector) throw new Meteor.Error(400, 'selector argument missing')
-		const modifier: FindOptions<BucketAdLib> = {
-			fields: {
-				ingestInfo: 0, // This is a large blob, and is not of interest to the UI
-			},
-		}
-		if (isProtectedString(selector.bucketId) && (await BucketSecurity.allowReadAccess(this, selector.bucketId))) {
-			return BucketAdLibs.findWithCursor(selector, modifier)
+	async function (studioId: StudioId, bucketId: BucketId, showStyleVariantIds: ShowStyleVariantId[]) {
+		check(studioId, String)
+		check(bucketId, String)
+		check(showStyleVariantIds, Array)
+
+		if (isProtectedString(bucketId) && (await BucketSecurity.allowReadAccess(this, bucketId))) {
+			return BucketAdLibs.findWithCursor(
+				{
+					studioId: studioId,
+					bucketId: bucketId,
+					showStyleVariantId: {
+						$in: [null, ...showStyleVariantIds], // null = valid for all variants
+					},
+				},
+				{
+					fields: {
+						ingestInfo: 0, // This is a large blob, and is not of interest to the UI
+					},
+				}
+			)
 		}
 		return null
 	}
@@ -61,15 +68,26 @@ meteorPublish(
 
 meteorPublish(
 	CorelibPubSub.bucketAdLibActions,
-	async function (selector: MongoQuery<BucketAdLibAction>, _token: string | undefined) {
-		if (!selector) throw new Meteor.Error(400, 'selector argument missing')
-		const modifier: FindOptions<BucketAdLibAction> = {
-			fields: {
-				ingestInfo: 0, // This is a large blob, and is not of interest to the UI
-			},
-		}
-		if (isProtectedString(selector.bucketId) && (await BucketSecurity.allowReadAccess(this, selector.bucketId))) {
-			return BucketAdLibActions.findWithCursor(selector, modifier)
+	async function (studioId: StudioId, bucketId: BucketId, showStyleVariantIds: ShowStyleVariantId[]) {
+		check(studioId, String)
+		check(bucketId, String)
+		check(showStyleVariantIds, Array)
+
+		if (isProtectedString(bucketId) && (await BucketSecurity.allowReadAccess(this, bucketId))) {
+			return BucketAdLibActions.findWithCursor(
+				{
+					studioId: studioId,
+					bucketId: bucketId,
+					showStyleVariantId: {
+						$in: [null, ...showStyleVariantIds], // null = valid for all variants
+					},
+				},
+				{
+					fields: {
+						ingestInfo: 0, // This is a large blob, and is not of interest to the UI
+					},
+				}
+			)
 		}
 		return null
 	}

--- a/meteor/server/publications/organization.ts
+++ b/meteor/server/publications/organization.ts
@@ -13,6 +13,7 @@ import { MongoQuery } from '@sofie-automation/corelib/dist/mongo'
 import { BlueprintId, OrganizationId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 import { check, Match } from '../../lib/check'
+import { getCurrentTime } from '../../lib/lib'
 
 meteorPublish(
 	MeteorPubSub.organization,
@@ -58,14 +59,27 @@ meteorPublish(CorelibPubSub.blueprints, async function (blueprintIds: BlueprintI
 	}
 	return null
 })
-meteorPublish(MeteorPubSub.evaluations, async function (selector0: MongoQuery<Evaluation>, token: string | undefined) {
+meteorPublish(MeteorPubSub.evaluations, async function (dateFrom: number, dateTo: number, token: string | undefined) {
+	const selector0: MongoQuery<Evaluation> = {
+		timestamp: {
+			$gte: dateFrom,
+			$lt: dateTo,
+		},
+	}
+
 	const { cred, selector } = await AutoFillSelector.organizationId<Evaluation>(this.userId, selector0, token)
 	if (!cred || (await OrganizationReadAccess.organizationContent(selector.organizationId, cred))) {
 		return Evaluations.findWithCursor(selector)
 	}
 	return null
 })
-meteorPublish(MeteorPubSub.snapshots, async function (selector0: MongoQuery<SnapshotItem>, token: string | undefined) {
+meteorPublish(MeteorPubSub.snapshots, async function (token: string | undefined) {
+	const selector0: MongoQuery<SnapshotItem> = {
+		created: {
+			$gt: getCurrentTime() - 30 * 24 * 3600 * 1000, // last 30 days
+		},
+	}
+
 	const { cred, selector } = await AutoFillSelector.organizationId<SnapshotItem>(this.userId, selector0, token)
 	if (!cred || (await OrganizationReadAccess.organizationContent(selector.organizationId, cred))) {
 		return Snapshots.findWithCursor(selector)
@@ -74,7 +88,14 @@ meteorPublish(MeteorPubSub.snapshots, async function (selector0: MongoQuery<Snap
 })
 meteorPublish(
 	MeteorPubSub.userActionsLog,
-	async function (selector0: MongoQuery<UserActionsLogItem>, token: string | undefined) {
+	async function (dateFrom: number, dateTo: number, token: string | undefined) {
+		const selector0: MongoQuery<UserActionsLogItem> = {
+			timestamp: {
+				$gte: dateFrom,
+				$lt: dateTo,
+			},
+		}
+
 		const { cred, selector } = await AutoFillSelector.organizationId<UserActionsLogItem>(
 			this.userId,
 			selector0,

--- a/meteor/server/publications/organization.ts
+++ b/meteor/server/publications/organization.ts
@@ -10,8 +10,9 @@ import { DBOrganization } from '../../lib/collections/Organization'
 import { isProtectedString } from '@sofie-automation/corelib/dist/protectedString'
 import { Blueprints, Evaluations, Organizations, Snapshots, UserActionsLog } from '../collections'
 import { MongoQuery } from '@sofie-automation/corelib/dist/mongo'
-import { OrganizationId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { BlueprintId, OrganizationId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
+import { check, Match } from '../../lib/check'
 
 meteorPublish(
 	MeteorPubSub.organization,
@@ -37,15 +38,23 @@ meteorPublish(
 	}
 )
 
-meteorPublish(CorelibPubSub.blueprints, async function (selector0: MongoQuery<Blueprint>, token: string | undefined) {
-	const { cred, selector } = await AutoFillSelector.organizationId<Blueprint>(this.userId, selector0, token)
-	const modifier: FindOptions<Blueprint> = {
-		fields: {
-			code: 0,
-		},
-	}
+meteorPublish(CorelibPubSub.blueprints, async function (blueprintIds: BlueprintId[] | null, token: string | undefined) {
+	check(blueprintIds, Match.Maybe(Array))
+
+	// If values were provided, they must have values
+	if (blueprintIds && blueprintIds.length === 0) return null
+
+	const { cred, selector } = await AutoFillSelector.organizationId<Blueprint>(this.userId, {}, token)
+
+	// Add the requested filter
+	if (blueprintIds) selector._id = { $in: blueprintIds }
+
 	if (!cred || (await OrganizationReadAccess.organizationContent(selector.organizationId, cred))) {
-		return Blueprints.findWithCursor(selector, modifier)
+		return Blueprints.findWithCursor(selector, {
+			fields: {
+				code: 0,
+			},
+		})
 	}
 	return null
 })

--- a/meteor/server/publications/peripheralDevice.ts
+++ b/meteor/server/publications/peripheralDevice.ts
@@ -104,23 +104,17 @@ meteorPublish(
 		return null
 	}
 )
-meteorPublish(
-	MeteorPubSub.mediaWorkFlows,
-	async function (selector0: MongoQuery<MediaWorkFlow>, token: string | undefined) {
-		const { cred, selector } = await AutoFillSelector.deviceId(this.userId, selector0, token)
-		if (!cred || (await PeripheralDeviceReadAccess.peripheralDeviceContent(selector.deviceId, cred))) {
-			return MediaWorkFlows.findWithCursor(selector)
-		}
-		return null
+meteorPublish(MeteorPubSub.mediaWorkFlows, async function (token: string | undefined) {
+	const { cred, selector } = await AutoFillSelector.deviceId<MediaWorkFlow>(this.userId, {}, token)
+	if (!cred || (await PeripheralDeviceReadAccess.peripheralDeviceContent(selector.deviceId, cred))) {
+		return MediaWorkFlows.findWithCursor(selector)
 	}
-)
-meteorPublish(
-	MeteorPubSub.mediaWorkFlowSteps,
-	async function (selector0: MongoQuery<MediaWorkFlowStep>, token: string | undefined) {
-		const { cred, selector } = await AutoFillSelector.deviceId(this.userId, selector0, token)
-		if (!cred || (await PeripheralDeviceReadAccess.peripheralDeviceContent(selector.deviceId, cred))) {
-			return MediaWorkFlowSteps.findWithCursor(selector)
-		}
-		return null
+	return null
+})
+meteorPublish(MeteorPubSub.mediaWorkFlowSteps, async function (token: string | undefined) {
+	const { cred, selector } = await AutoFillSelector.deviceId<MediaWorkFlowStep>(this.userId, {}, token)
+	if (!cred || (await PeripheralDeviceReadAccess.peripheralDeviceContent(selector.deviceId, cred))) {
+		return MediaWorkFlowSteps.findWithCursor(selector)
 	}
-)
+	return null
+})

--- a/meteor/server/publications/rundown.ts
+++ b/meteor/server/publications/rundown.ts
@@ -10,12 +10,10 @@ import { DBPart } from '@sofie-automation/corelib/dist/dataModel/Part'
 import { Piece } from '@sofie-automation/corelib/dist/dataModel/Piece'
 import { PieceInstance } from '@sofie-automation/corelib/dist/dataModel/PieceInstance'
 import { PartInstance } from '../../lib/collections/PartInstances'
-import { RundownBaselineAdLibItem } from '@sofie-automation/corelib/dist/dataModel/RundownBaselineAdLibPiece'
 import { NoSecurityReadAccess } from '../security/noSecurity'
 import { OrganizationReadAccess } from '../security/organization'
 import { StudioReadAccess } from '../security/studio'
 import { AdLibAction } from '@sofie-automation/corelib/dist/dataModel/AdlibAction'
-import { RundownBaselineAdLibAction } from '@sofie-automation/corelib/dist/dataModel/RundownBaselineAdLibAction'
 import { check, Match } from 'meteor/check'
 import { FindOptions } from '../../lib/collections/lib'
 import {
@@ -414,18 +412,20 @@ meteorPublish(
 )
 meteorPublish(
 	CorelibPubSub.rundownBaselineAdLibPieces,
-	async function (selector: MongoQuery<RundownBaselineAdLibItem>, token: string | undefined) {
-		if (!selector) throw new Meteor.Error(400, 'selector argument missing')
-		const modifier: FindOptions<RundownBaselineAdLibItem> = {
-			fields: {
-				timelineObjectsString: 0,
-			},
-		}
+	async function (rundownId: RundownId, token: string | undefined) {
+		if (!rundownId) throw new Meteor.Error(400, 'rundownId argument missing')
 		if (
 			NoSecurityReadAccess.any() ||
-			(await RundownReadAccess.rundownContent(selector.rundownId, { userId: this.userId, token }))
+			(await RundownReadAccess.rundownContent(rundownId, { userId: this.userId, token }))
 		) {
-			return RundownBaselineAdLibPieces.findWithCursor(selector, modifier)
+			return RundownBaselineAdLibPieces.findWithCursor(
+				{ rundownId },
+				{
+					fields: {
+						timelineObjectsString: 0,
+					},
+				}
+			)
 		}
 		return null
 	}
@@ -448,16 +448,13 @@ meteorPublish(
 )
 meteorPublish(
 	CorelibPubSub.rundownBaselineAdLibActions,
-	async function (selector: MongoQuery<RundownBaselineAdLibAction>, token: string | undefined) {
-		if (!selector) throw new Meteor.Error(400, 'selector argument missing')
-		const modifier: FindOptions<RundownBaselineAdLibAction> = {
-			fields: {},
-		}
+	async function (rundownId: RundownId, token: string | undefined) {
+		if (!rundownId) throw new Meteor.Error(400, 'rundownId argument missing')
 		if (
 			NoSecurityReadAccess.any() ||
-			(await RundownReadAccess.rundownContent(selector.rundownId, { userId: this.userId, token }))
+			(await RundownReadAccess.rundownContent(rundownId, { userId: this.userId, token }))
 		) {
-			return RundownBaselineAdLibActions.findWithCursor(selector, modifier)
+			return RundownBaselineAdLibActions.findWithCursor({ rundownId })
 		}
 		return null
 	}

--- a/meteor/server/publications/rundown.ts
+++ b/meteor/server/publications/rundown.ts
@@ -1,5 +1,4 @@
 import { Meteor } from 'meteor/meteor'
-import * as _ from 'underscore'
 import { meteorPublish, AutoFillSelector } from './lib'
 import { MeteorPubSub } from '../../lib/api/pubsub'
 import { MongoFieldSpecifierZeroes, MongoQuery } from '@sofie-automation/corelib/dist/mongo'
@@ -18,7 +17,6 @@ import { FindOptions } from '../../lib/collections/lib'
 import {
 	AdLibActions,
 	AdLibPieces,
-	ExpectedMediaItems,
 	ExpectedPlayoutItems,
 	IngestDataCache,
 	PartInstances,
@@ -42,8 +40,6 @@ import {
 	RundownPlaylistId,
 	ShowStyleBaseId,
 } from '@sofie-automation/corelib/dist/dataModel/Ids'
-import { ExpectedMediaItem } from '@sofie-automation/corelib/dist/dataModel/ExpectedMediaItem'
-import { ExpectedPlayoutItem } from '@sofie-automation/corelib/dist/dataModel/ExpectedPlayoutItem'
 import { DBPartInstance } from '@sofie-automation/corelib/dist/dataModel/PartInstance'
 import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 import { PeripheralDevicePubSub } from '@sofie-automation/shared-lib/dist/pubsub/peripheralDevice'
@@ -366,46 +362,6 @@ meteorPublish(
 					plannedStoppedPlayback: 0,
 				}),
 			})
-		}
-		return null
-	}
-)
-meteorPublish(
-	CorelibPubSub.expectedMediaItems,
-	async function (selector: MongoQuery<ExpectedMediaItem>, token: string | undefined) {
-		const allowed =
-			NoSecurityReadAccess.any() ||
-			(await RundownReadAccess.expectedMediaItems(selector, { userId: this.userId, token }))
-		if (!allowed) {
-			return null
-		} else if (allowed === true) {
-			return ExpectedMediaItems.findWithCursor(selector)
-		} else if (typeof allowed === 'object') {
-			return ExpectedMediaItems.findWithCursor(
-				_.extend(selector, {
-					studioId: allowed.studioId,
-				})
-			)
-		}
-		return null
-	}
-)
-meteorPublish(
-	MeteorPubSub.expectedPlayoutItems,
-	async function (selector: MongoQuery<ExpectedPlayoutItem>, token: string | undefined) {
-		const allowed =
-			NoSecurityReadAccess.any() ||
-			(await RundownReadAccess.expectedPlayoutItems(selector, { userId: this.userId, token }))
-		if (!allowed) {
-			return null
-		} else if (allowed === true) {
-			return ExpectedPlayoutItems.findWithCursor(selector)
-		} else if (typeof allowed === 'object') {
-			return ExpectedPlayoutItems.findWithCursor(
-				_.extend(selector, {
-					studioId: allowed.studioId,
-				})
-			)
 		}
 		return null
 	}

--- a/meteor/server/publications/rundown.ts
+++ b/meteor/server/publications/rundown.ts
@@ -177,7 +177,7 @@ meteorPublish(
 	CorelibPubSub.partInstances,
 	async function (
 		rundownIds: RundownId[],
-		playlistActivationId: RundownPlaylistActivationId | undefined,
+		playlistActivationId: RundownPlaylistActivationId | null,
 		token: string | undefined
 	) {
 		check(rundownIds, Array)
@@ -194,9 +194,9 @@ meteorPublish(
 
 		const selector: MongoQuery<DBPartInstance> = {
 			rundownId: { $in: rundownIds },
-			playlistActivationId: playlistActivationId,
 			reset: { $ne: true },
 		}
+		if (playlistActivationId) selector.playlistActivationId = playlistActivationId
 
 		if (
 			NoSecurityReadAccess.any() ||

--- a/meteor/server/publications/rundownPlaylist.ts
+++ b/meteor/server/publications/rundownPlaylist.ts
@@ -6,23 +6,33 @@ import { NoSecurityReadAccess } from '../security/noSecurity'
 import { isProtectedString } from '@sofie-automation/corelib/dist/protectedString'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { RundownPlaylists } from '../collections'
-import { MongoQuery } from '@sofie-automation/corelib/dist/mongo'
 import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 import { MeteorPubSub } from '../../lib/api/pubsub'
-import { StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { RundownPlaylistId, StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { resolveCredentials } from '../security/lib/credentials'
+import { check, Match } from '../../lib/check'
+import { MongoQuery } from '@sofie-automation/corelib/dist/mongo'
 
 meteorPublish(
 	CorelibPubSub.rundownPlaylists,
-	async function (selector0: MongoQuery<DBRundownPlaylist>, token: string | undefined) {
-		const { cred, selector } = await AutoFillSelector.organizationId<DBRundownPlaylist>(
-			this.userId,
-			selector0,
-			token
-		)
-		const modifier = {
-			fields: {},
-		}
+	async function (
+		rundownPlaylistIds: RundownPlaylistId[] | null,
+		studioIds: StudioId[] | null,
+		token: string | undefined
+	) {
+		check(rundownPlaylistIds, Match.Maybe(Array))
+		check(studioIds, Match.Maybe(Array))
+
+		// If values were provided, they must have values
+		if (rundownPlaylistIds && rundownPlaylistIds.length === 0) return null
+		if (studioIds && studioIds.length === 0) return null
+
+		const { cred, selector } = await AutoFillSelector.organizationId<DBRundownPlaylist>(this.userId, {}, token)
+
+		// Add the requested filter
+		if (rundownPlaylistIds) selector._id = { $in: rundownPlaylistIds }
+		if (studioIds) selector.studioId = { $in: studioIds }
+
 		if (
 			!cred ||
 			NoSecurityReadAccess.any() ||
@@ -31,13 +41,13 @@ meteorPublish(
 			(selector.studioId && (await StudioReadAccess.studioContent(selector.studioId, cred))) ||
 			(isProtectedString(selector._id) && (await RundownPlaylistReadAccess.rundownPlaylist(selector._id, cred)))
 		) {
-			return RundownPlaylists.findWithCursor(selector, modifier)
+			return RundownPlaylists.findWithCursor(selector)
 		}
 		return null
 	}
 )
 
-meteorPublish(MeteorPubSub.activeRundownPlaylistForStudio, async function (studioId: StudioId) {
+meteorPublish(MeteorPubSub.rundownPlaylistForStudio, async function (studioId: StudioId, isActive: boolean) {
 	if (!NoSecurityReadAccess.any()) {
 		const cred = await resolveCredentials({ userId: this.userId })
 		if (!cred) return null
@@ -45,14 +55,15 @@ meteorPublish(MeteorPubSub.activeRundownPlaylistForStudio, async function (studi
 		if (!(await StudioReadAccess.studioContent(studioId, cred))) return null
 	}
 
-	return RundownPlaylists.findWithCursor(
-		{ studioId },
-		{
-			// Ensure the result is 'stable' and only produces one (there should only ever be one)
-			sort: {
-				_id: 1,
-			},
-			limit: 1,
-		}
-	)
+	const selector: MongoQuery<DBRundownPlaylist> = {
+		studioId,
+	}
+
+	if (isActive) {
+		selector.activationId = { $exists: true }
+	} else {
+		selector.activationId = { $exists: false }
+	}
+
+	return RundownPlaylists.findWithCursor(selector)
 })

--- a/meteor/server/publications/showStyle.ts
+++ b/meteor/server/publications/showStyle.ts
@@ -41,15 +41,22 @@ meteorPublish(
 
 meteorPublish(
 	CorelibPubSub.showStyleVariants,
-	async function (showStyleVariantIds: ShowStyleVariantId[] | null, token: string | undefined) {
+	async function (
+		showStyleBaseIds: ShowStyleBaseId[] | null,
+		showStyleVariantIds: ShowStyleVariantId[] | null,
+		token: string | undefined
+	) {
+		check(showStyleBaseIds, Match.Maybe(Array))
 		check(showStyleVariantIds, Match.Maybe(Array))
 
 		// If values were provided, they must have values
+		if (showStyleBaseIds && showStyleBaseIds.length === 0) return null
 		if (showStyleVariantIds && showStyleVariantIds.length === 0) return null
 
 		const { cred, selector } = await AutoFillSelector.showStyleBaseId<DBShowStyleVariant>(this.userId, {}, token)
 
 		// Add the requested filter
+		if (showStyleBaseIds) selector.showStyleBaseId = { $in: showStyleBaseIds }
 		if (showStyleVariantIds) selector._id = { $in: showStyleVariantIds }
 
 		if (

--- a/meteor/server/publications/showStyle.ts
+++ b/meteor/server/publications/showStyle.ts
@@ -86,7 +86,23 @@ meteorPublish(
 
 meteorPublish(
 	MeteorPubSub.triggeredActions,
-	async function (selector0: MongoQuery<DBTriggeredActions>, token: string | undefined) {
+	async function (showStyleBaseIds: ShowStyleBaseId[] | null, token: string | undefined) {
+		check(showStyleBaseIds, Match.Maybe(Array))
+
+		const selector0: MongoQuery<DBTriggeredActions> =
+			showStyleBaseIds && showStyleBaseIds.length > 0
+				? {
+						$or: [
+							{
+								showStyleBaseId: null,
+							},
+							{
+								showStyleBaseId: { $in: showStyleBaseIds },
+							},
+						],
+				  }
+				: { showStyleBaseId: null }
+
 		const { cred, selector } = await AutoFillSelector.showStyleBaseId(this.userId, selector0, token)
 
 		if (

--- a/meteor/server/publications/timeline.ts
+++ b/meteor/server/publications/timeline.ts
@@ -30,7 +30,6 @@ import { PeripheralDeviceId, StudioId } from '@sofie-automation/corelib/dist/dat
 import { DBTimelineDatastoreEntry } from '@sofie-automation/corelib/dist/dataModel/TimelineDatastore'
 import { PeripheralDevices, Studios, Timeline, TimelineDatastore } from '../collections'
 import { check } from 'meteor/check'
-import { MongoQuery } from '@sofie-automation/corelib/dist/mongo'
 import { ResultingMappingRoutes, StudioLight } from '@sofie-automation/corelib/dist/dataModel/Studio'
 import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 import {
@@ -38,19 +37,6 @@ import {
 	PeripheralDevicePubSubCollectionsNames,
 } from '@sofie-automation/shared-lib/dist/pubsub/peripheralDevice'
 
-meteorPublish(
-	CorelibPubSub.timeline,
-	async function (selector: MongoQuery<TimelineComplete>, token: string | undefined) {
-		if (!selector) throw new Meteor.Error(400, 'selector argument missing')
-		const modifier: FindOptions<TimelineComplete> = {
-			fields: {},
-		}
-		if (await StudioReadAccess.studioContent(selector._id, { userId: this.userId, token })) {
-			return Timeline.findWithCursor(selector, modifier)
-		}
-		return null
-	}
-)
 meteorPublish(CorelibPubSub.timelineDatastore, async function (studioId: StudioId, token: string | undefined) {
 	if (!studioId) throw new Meteor.Error(400, 'selector argument missing')
 	const modifier: FindOptions<DBTimelineDatastoreEntry> = {

--- a/meteor/server/publications/translationsBundles.ts
+++ b/meteor/server/publications/translationsBundles.ts
@@ -1,5 +1,3 @@
-import { Meteor } from 'meteor/meteor'
-
 import { TranslationsBundlesSecurity } from '../security/translationsBundles'
 import { meteorPublish } from './lib'
 import { MeteorPubSub } from '../../lib/api/pubsub'
@@ -7,19 +5,16 @@ import { TranslationsBundles } from '../collections'
 import { MongoQuery } from '@sofie-automation/corelib/dist/mongo'
 import { TranslationsBundle } from '../../lib/collections/TranslationsBundles'
 
-meteorPublish(
-	MeteorPubSub.translationsBundles,
-	async (selector: MongoQuery<TranslationsBundle>, token: string | undefined) => {
-		if (!selector) throw new Meteor.Error(400, 'selector argument missing')
+meteorPublish(MeteorPubSub.translationsBundles, async (token: string | undefined) => {
+	const selector: MongoQuery<TranslationsBundle> = {}
 
-		if (TranslationsBundlesSecurity.allowReadAccess(selector, token, this)) {
-			return TranslationsBundles.findWithCursor(selector, {
-				fields: {
-					data: 0,
-				},
-			})
-		}
-
-		return null
+	if (TranslationsBundlesSecurity.allowReadAccess(selector, token, this)) {
+		return TranslationsBundles.findWithCursor(selector, {
+			fields: {
+				data: 0,
+			},
+		})
 	}
-)
+
+	return null
+})

--- a/meteor/server/security/buckets.ts
+++ b/meteor/server/security/buckets.ts
@@ -8,7 +8,6 @@ import { BucketAdLib } from '@sofie-automation/corelib/dist/dataModel/BucketAdLi
 import { BucketAdLibAction } from '@sofie-automation/corelib/dist/dataModel/BucketAdLibAction'
 import { AdLibActionId, BucketId, PieceId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { BucketAdLibActions, BucketAdLibs, Buckets } from '../collections'
-import { Settings } from '../../lib/Settings'
 
 export namespace BucketSecurity {
 	export interface BucketContentAccess extends StudioContentAccess {
@@ -27,8 +26,6 @@ export namespace BucketSecurity {
 		bucketId: BucketId
 	): Promise<boolean> {
 		check(bucketId, String)
-
-		if (!Settings.enableUserAccounts) return true
 
 		const bucket = await Buckets.findOneAsync(bucketId)
 		if (!bucket) throw new Meteor.Error(404, `Bucket "${bucketId}" not found!`)

--- a/meteor/server/security/buckets.ts
+++ b/meteor/server/security/buckets.ts
@@ -8,6 +8,7 @@ import { BucketAdLib } from '@sofie-automation/corelib/dist/dataModel/BucketAdLi
 import { BucketAdLibAction } from '@sofie-automation/corelib/dist/dataModel/BucketAdLibAction'
 import { AdLibActionId, BucketId, PieceId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { BucketAdLibActions, BucketAdLibs, Buckets } from '../collections'
+import { Settings } from '../../lib/Settings'
 
 export namespace BucketSecurity {
 	export interface BucketContentAccess extends StudioContentAccess {
@@ -26,6 +27,8 @@ export namespace BucketSecurity {
 		bucketId: BucketId
 	): Promise<boolean> {
 		check(bucketId, String)
+
+		if (!Settings.enableUserAccounts) return true
 
 		const bucket = await Buckets.findOneAsync(bucketId)
 		if (!bucket) throw new Meteor.Error(404, `Bucket "${bucketId}" not found!`)

--- a/packages/corelib/src/pubsub.ts
+++ b/packages/corelib/src/pubsub.ts
@@ -163,7 +163,7 @@ export interface CorelibPubSubTypes {
 	[CorelibPubSub.parts]: (rundownIds: RundownId[], token?: string) => CollectionName.Parts
 	[CorelibPubSub.partInstances]: (
 		rundownIds: RundownId[],
-		playlistActivationId: RundownPlaylistActivationId | undefined,
+		playlistActivationId: RundownPlaylistActivationId | null,
 		token?: string
 	) => CollectionName.PartInstances
 	[CorelibPubSub.partInstancesSimple]: (

--- a/packages/corelib/src/pubsub.ts
+++ b/packages/corelib/src/pubsub.ts
@@ -57,7 +57,6 @@ export enum CorelibPubSub {
 	pieceInstances = 'pieceInstances',
 	pieceInstancesSimple = 'pieceInstancesSimple',
 
-	timeline = 'timeline',
 	timelineDatastore = 'timelineDatastore',
 
 	expectedPackages = 'expectedPackages',
@@ -161,7 +160,6 @@ export interface CorelibPubSubTypes {
 		studioIds: StudioId[] | null,
 		token?: string
 	) => CollectionName.Studios
-	[CorelibPubSub.timeline]: (selector: MongoQuery<TimelineComplete>, token?: string) => CollectionName.Timelines
 	[CorelibPubSub.timelineDatastore]: (studioId: StudioId, token?: string) => CollectionName.TimelineDatastore
 	[CorelibPubSub.bucketAdLibPieces]: (
 		selector: MongoQuery<BucketAdLib>,

--- a/packages/corelib/src/pubsub.ts
+++ b/packages/corelib/src/pubsub.ts
@@ -32,7 +32,7 @@ import {
 	ShowStyleBaseId,
 	StudioId,
 } from '@sofie-automation/shared-lib/dist/core/model/Ids'
-import { RundownPlaylistActivationId, SegmentPlayoutId } from './dataModel/Ids'
+import { RundownPlaylistActivationId, SegmentPlayoutId, ShowStyleVariantId } from './dataModel/Ids'
 
 /**
  * Ids of possible DDP subscriptions for any the UI and gateways accessing the Rundown & RundownPlaylist model.
@@ -150,7 +150,8 @@ export interface CorelibPubSubTypes {
 		token?: string
 	) => CollectionName.ShowStyleBases
 	[CorelibPubSub.showStyleVariants]: (
-		selector: MongoQuery<DBShowStyleVariant>,
+		/** ShowStyleVariantId to fetch for, or null to fetch all */
+		showStyleVariantIds: ShowStyleVariantId[] | null,
 		token?: string
 	) => CollectionName.ShowStyleVariants
 	[CorelibPubSub.studios]: (selector: MongoQuery<DBStudio>, token?: string) => CollectionName.Studios

--- a/packages/corelib/src/pubsub.ts
+++ b/packages/corelib/src/pubsub.ts
@@ -97,15 +97,13 @@ export interface CorelibPubSubTypes {
 		selector: MongoQuery<PeripheralDevice>,
 		token?: string
 	) => CollectionName.PeripheralDevices
-	[CorelibPubSub.peripheralDevicesAndSubDevices]: (
-		selector: MongoQuery<PeripheralDevice>
-	) => CollectionName.PeripheralDevices
+	[CorelibPubSub.peripheralDevicesAndSubDevices]: (studioId: StudioId) => CollectionName.PeripheralDevices
 	[CorelibPubSub.rundownBaselineAdLibPieces]: (
-		selector: MongoQuery<RundownBaselineAdLibItem>,
+		rundownId: RundownId,
 		token?: string
 	) => CollectionName.RundownBaselineAdLibPieces
 	[CorelibPubSub.rundownBaselineAdLibActions]: (
-		selector: MongoQuery<RundownBaselineAdLibAction>,
+		rundownId: RundownId,
 		token?: string
 	) => CollectionName.RundownBaselineAdLibActions
 	[CorelibPubSub.ingestDataCache]: (

--- a/packages/corelib/src/pubsub.ts
+++ b/packages/corelib/src/pubsub.ts
@@ -99,11 +99,11 @@ export interface CorelibPubSubTypes {
 	) => CollectionName.PeripheralDevices
 	[CorelibPubSub.peripheralDevicesAndSubDevices]: (studioId: StudioId) => CollectionName.PeripheralDevices
 	[CorelibPubSub.rundownBaselineAdLibPieces]: (
-		rundownId: RundownId,
+		rundownIds: RundownId[],
 		token?: string
 	) => CollectionName.RundownBaselineAdLibPieces
 	[CorelibPubSub.rundownBaselineAdLibActions]: (
-		rundownId: RundownId,
+		rundownIds: RundownId[],
 		token?: string
 	) => CollectionName.RundownBaselineAdLibActions
 	[CorelibPubSub.ingestDataCache]: (

--- a/packages/corelib/src/pubsub.ts
+++ b/packages/corelib/src/pubsub.ts
@@ -32,7 +32,7 @@ import {
 	ShowStyleBaseId,
 	StudioId,
 } from '@sofie-automation/shared-lib/dist/core/model/Ids'
-import { RundownPlaylistActivationId } from './dataModel/Ids'
+import { RundownPlaylistActivationId, SegmentPlayoutId } from './dataModel/Ids'
 
 /**
  * Ids of possible DDP subscriptions for any the UI and gateways accessing the Rundown & RundownPlaylist model.
@@ -134,11 +134,13 @@ export interface CorelibPubSubTypes {
 		token?: string
 	) => CollectionName.PartInstances
 	[CorelibPubSub.partInstancesSimple]: (
-		selector: MongoQuery<DBPartInstance>,
+		rundownIds: RundownId[],
+		playlistActivationId: RundownPlaylistActivationId | null,
 		token?: string
 	) => CollectionName.PartInstances
 	[CorelibPubSub.partInstancesForSegmentPlayout]: (
-		selector: MongoQuery<DBPartInstance>,
+		rundownId: RundownId,
+		segmentPlayoutId: SegmentPlayoutId,
 		token?: string
 	) => CollectionName.PartInstances
 	[CorelibPubSub.segments]: (selector: MongoQuery<DBSegment>, token?: string) => CollectionName.Segments

--- a/packages/corelib/src/pubsub.ts
+++ b/packages/corelib/src/pubsub.ts
@@ -27,13 +27,20 @@ import { Piece } from './dataModel/Piece'
 import { PieceInstance } from './dataModel/PieceInstance'
 import { TimelineComplete } from './dataModel/Timeline'
 import {
+	PartId,
 	PeripheralDeviceId,
 	RundownId,
 	RundownPlaylistId,
 	ShowStyleBaseId,
 	StudioId,
 } from '@sofie-automation/shared-lib/dist/core/model/Ids'
-import { BlueprintId, RundownPlaylistActivationId, SegmentPlayoutId, ShowStyleVariantId } from './dataModel/Ids'
+import {
+	BlueprintId,
+	RundownPlaylistActivationId,
+	SegmentId,
+	SegmentPlayoutId,
+	ShowStyleVariantId,
+} from './dataModel/Ids'
 
 /**
  * Ids of possible DDP subscriptions for any the UI and gateways accessing the Rundown & RundownPlaylist model.
@@ -54,6 +61,7 @@ export enum CorelibPubSub {
 	partInstancesSimple = 'partInstancesSimple',
 	partInstancesForSegmentPlayout = 'partInstancesForSegmentPlayout',
 	pieces = 'pieces',
+	piecesInfiniteStartingBefore = 'piecesInfiniteStartingBefore',
 	pieceInstances = 'pieceInstances',
 	pieceInstancesSimple = 'pieceInstancesSimple',
 
@@ -122,7 +130,18 @@ export interface CorelibPubSubTypes {
 	) => CollectionName.Rundowns
 	[CorelibPubSub.adLibActions]: (rundownIds: RundownId[], token?: string) => CollectionName.AdLibActions
 	[CorelibPubSub.adLibPieces]: (rundownIds: RundownId[], token?: string) => CollectionName.AdLibPieces
-	[CorelibPubSub.pieces]: (selector: MongoQuery<Piece>, token?: string) => CollectionName.Pieces
+	[CorelibPubSub.pieces]: (
+		rundownIds: RundownId[],
+		/** PartIds to fetch for, or null to fetch all */
+		partIds: PartId[] | null,
+		token?: string
+	) => CollectionName.Pieces
+	[CorelibPubSub.piecesInfiniteStartingBefore]: (
+		thisRundownId: RundownId,
+		segmentsIdsBefore: SegmentId[],
+		rundownIdsBefore: RundownId[],
+		token?: string
+	) => CollectionName.Pieces
 	[CorelibPubSub.pieceInstances]: (
 		selector: MongoQuery<PieceInstance>,
 		token?: string

--- a/packages/corelib/src/pubsub.ts
+++ b/packages/corelib/src/pubsub.ts
@@ -118,7 +118,10 @@ export interface CorelibPubSubTypes {
 		token?: string
 	) => CollectionName.IngestDataCache
 	[CorelibPubSub.rundownPlaylists]: (
-		selector: MongoQuery<DBRundownPlaylist>,
+		/** RundownPlaylistIds to fetch for, or null to fetch all */
+		rundownPlaylistIds: RundownPlaylistId[] | null,
+		/** StudioIds to fetch for, or null to fetch all */
+		studioIds: StudioId[] | null,
 		token?: string
 	) => CollectionName.RundownPlaylists
 	[CorelibPubSub.rundowns]: (

--- a/packages/corelib/src/pubsub.ts
+++ b/packages/corelib/src/pubsub.ts
@@ -145,7 +145,8 @@ export interface CorelibPubSubTypes {
 	) => CollectionName.PartInstances
 	[CorelibPubSub.segments]: (rundownIds: RundownId[], omitHidden: boolean, token?: string) => CollectionName.Segments
 	[CorelibPubSub.showStyleBases]: (
-		selector: MongoQuery<DBShowStyleBase>,
+		/** ShowStyleBaseIds to fetch for, or null to fetch all */
+		showStyleBaseIds: ShowStyleBaseId[] | null,
 		token?: string
 	) => CollectionName.ShowStyleBases
 	[CorelibPubSub.showStyleVariants]: (

--- a/packages/corelib/src/pubsub.ts
+++ b/packages/corelib/src/pubsub.ts
@@ -156,7 +156,11 @@ export interface CorelibPubSubTypes {
 		showStyleVariantIds: ShowStyleVariantId[] | null,
 		token?: string
 	) => CollectionName.ShowStyleVariants
-	[CorelibPubSub.studios]: (selector: MongoQuery<DBStudio>, token?: string) => CollectionName.Studios
+	[CorelibPubSub.studios]: (
+		/** StudioIds to fetch for, or null to fetch all */
+		studioIds: StudioId[] | null,
+		token?: string
+	) => CollectionName.Studios
 	[CorelibPubSub.timeline]: (selector: MongoQuery<TimelineComplete>, token?: string) => CollectionName.Timelines
 	[CorelibPubSub.timelineDatastore]: (studioId: StudioId, token?: string) => CollectionName.TimelineDatastore
 	[CorelibPubSub.bucketAdLibPieces]: (

--- a/packages/corelib/src/pubsub.ts
+++ b/packages/corelib/src/pubsub.ts
@@ -33,7 +33,7 @@ import {
 	ShowStyleBaseId,
 	StudioId,
 } from '@sofie-automation/shared-lib/dist/core/model/Ids'
-import { RundownPlaylistActivationId, SegmentPlayoutId, ShowStyleVariantId } from './dataModel/Ids'
+import { BlueprintId, RundownPlaylistActivationId, SegmentPlayoutId, ShowStyleVariantId } from './dataModel/Ids'
 
 /**
  * Ids of possible DDP subscriptions for any the UI and gateways accessing the Rundown & RundownPlaylist model.
@@ -81,7 +81,11 @@ export enum CorelibPubSub {
  * Type definitions for DDP subscriptions for any the UI and gateways accessing the Rundown & RundownPlaylist model.
  */
 export interface CorelibPubSubTypes {
-	[CorelibPubSub.blueprints]: (selector: MongoQuery<Blueprint>, token?: string) => CollectionName.Blueprints
+	[CorelibPubSub.blueprints]: (
+		/** BlueprintIds to fetch for, or null to fetch all */
+		blueprintIds: BlueprintId[] | null,
+		token?: string
+	) => CollectionName.Blueprints
 
 	[CorelibPubSub.externalMessageQueue]: (
 		selector: MongoQuery<ExternalMessageQueueObj>,

--- a/packages/corelib/src/pubsub.ts
+++ b/packages/corelib/src/pubsub.ts
@@ -129,7 +129,8 @@ export interface CorelibPubSubTypes {
 		token?: string
 	) => CollectionName.PieceInstances
 	[CorelibPubSub.pieceInstancesSimple]: (
-		selector: MongoQuery<PieceInstance>,
+		rundownIds: RundownId[],
+		playlistActivationId: RundownPlaylistActivationId | null,
 		token?: string
 	) => CollectionName.PieceInstances
 	[CorelibPubSub.parts]: (rundownIds: RundownId[], token?: string) => CollectionName.Parts

--- a/packages/corelib/src/pubsub.ts
+++ b/packages/corelib/src/pubsub.ts
@@ -48,42 +48,139 @@ import {
  * Ids of possible DDP subscriptions for any the UI and gateways accessing the Rundown & RundownPlaylist model.
  */
 export enum CorelibPubSub {
+	/**
+	 * Fetch RundownPlaylists. Either all in the system, limited to certain Studios, or to specific RundownPlaylists by id.
+	 */
 	rundownPlaylists = 'rundownPlaylists',
+	/**
+	 * Fetch Rundowns. Either all in the system, limited to certain ShowStyleBases, or to specific RundownPlaylists by id.
+	 */
 	rundowns = 'rundowns',
+	/**
+	 * Fetch cached ingest data
+	 */
 	ingestDataCache = 'ingestDataCache',
 
+	/**
+	 * Fetch baseline adlib pieces belonging to the specified Rundowns
+	 */
 	rundownBaselineAdLibPieces = 'rundownBaselineAdLibPieces',
+	/**
+	 * Fetch baseline adlib actions belonging to the specified Rundowns
+	 */
 	rundownBaselineAdLibActions = 'rundownBaselineAdLibActions',
+	/**
+	 * Fetch adlib actions belonging to the specified Rundowns
+	 */
 	adLibActions = 'adLibActions',
+	/**
+	 * Fetch adlib pieces belonging to the specified Rundowns
+	 */
 	adLibPieces = 'adLibPieces',
 
+	/**
+	 *  Fetch Segments belonging to the specified Rundowns, optionally omitting ones set as hidden
+	 */
 	segments = 'segments',
+	/**
+	 * Fetch Parts belonging to the specified Rundowns
+	 */
 	parts = 'parts',
+	/**
+	 * Fetch PartInstances in the specified Rundowns. If set, the result will be limited to the supplied RundownPlaylistActivationId.
+	 * Any reset PartInstances will be omitted
+	 */
 	partInstances = 'partInstances',
+	/**
+	 * Fetch PartInstances in the specified Rundowns. If set, the result will be limited to the supplied RundownPlaylistActivationId.
+	 * Any reset PartInstances will be omitted
+	 * This provides a simplified form of the PartInstance, with any timing information omitted to reduce data churn
+	 */
 	partInstancesSimple = 'partInstancesSimple',
+	/**
+	 * Fetch the most recent PartInstance in a Rundown with the SegmentPlayoutId, including reset instances
+	 * This provides a simplified form of the PartInstance, with any timing information omitted to reduce data churn
+	 */
 	partInstancesForSegmentPlayout = 'partInstancesForSegmentPlayout',
+	/**
+	 * Fetch Pieces belonging to the specified Rundowns, optionally limiting the result to the specified Parts
+	 */
 	pieces = 'pieces',
+	/**
+	 * Fetch Pieces which are infinite and start within the specified range of Segments or Rundowns.
+	 */
 	piecesInfiniteStartingBefore = 'piecesInfiniteStartingBefore',
+	/**
+	 * Fetch PieceInstances in the specified Rundowns, optionally limiting the result to the specified PartInstances.
+	 * Optionally only returning PieceInstances which are playing and were sourced from adlibs, or have tags set.
+	 * Any reset PieceInstances will be omitted
+	 */
 	pieceInstances = 'pieceInstances',
+	/**
+	 * Fetch PieceInstances in the specified Rundowns. If set, the result will be limited to the supplied RundownPlaylistActivationId.
+	 * Any reset PieceInstances will be omitted
+	 * This provides a simplified form of the PieceInstance, with any timing information omitted to reduce data churn
+	 */
 	pieceInstancesSimple = 'pieceInstancesSimple',
 
+	/**
+	 * Fetch all Timeline Datastore entries in the specified Studio
+	 */
 	timelineDatastore = 'timelineDatastore',
 
+	/**
+	 * Fetch all Expected Packages in the specified Studios
+	 */
 	expectedPackages = 'expectedPackages',
+	/**
+	 * Fetch all Expected Package statuses in the specified Studios
+	 */
 	expectedPackageWorkStatuses = 'expectedPackageWorkStatuses',
+	/**
+	 * Fetch all Package container statuses in the specified Studios
+	 */
 	packageContainerStatuses = 'packageContainerStatuses',
 
+	/**
+	 * Fetch all bucket adlib pieces for the specified Studio and Bucket.
+	 * The result will be limited to ones valid to the ShowStyleVariants specified, as well as ones marked as valid in any ShowStyleVariant
+	 */
 	bucketAdLibPieces = 'bucketAdLibPieces',
+	/**
+	 * Fetch all bucket adlib action for the specified Studio and Bucket.
+	 * The result will be limited to ones valid to the ShowStyleVariants specified, as well as ones marked as valid in any ShowStyleVariant
+	 */
 	bucketAdLibActions = 'bucketAdLibActions',
 
+	/**
+	 * Fetch all the External Message Queue documents with a raw mongo query
+	 */
 	externalMessageQueue = 'externalMessageQueue',
 
+	/**
+	 * Fetch either all Blueprints, or the ones specified
+	 */
 	blueprints = 'blueprints',
+	/**
+	 * Fetch either all ShowStyleBases, or the ones specified
+	 */
 	showStyleBases = 'showStyleBases',
+	/**
+	 * Fetch either all ShowStyleVariants, or the ones specified
+	 */
 	showStyleVariants = 'showStyleVariants',
+	/**
+	 * Fetch either all Studios, or the ones specified
+	 */
 	studios = 'studios',
 
+	/**
+	 * Fetch either all PeripheralDevices, or the ones specified
+	 */
 	peripheralDevices = 'peripheralDevices',
+	/**
+	 * Fetch all the PeripheralDevices and sub-devices for the specified Studio
+	 */
 	peripheralDevicesAndSubDevices = 'peripheralDevicesAndSubDevices',
 }
 

--- a/packages/corelib/src/pubsub.ts
+++ b/packages/corelib/src/pubsub.ts
@@ -27,6 +27,7 @@ import { Piece } from './dataModel/Piece'
 import { PieceInstance } from './dataModel/PieceInstance'
 import { TimelineComplete } from './dataModel/Timeline'
 import {
+	PeripheralDeviceId,
 	RundownId,
 	RundownPlaylistId,
 	ShowStyleBaseId,
@@ -88,7 +89,8 @@ export interface CorelibPubSubTypes {
 		token?: string
 	) => CollectionName.ExternalMessageQueue
 	[CorelibPubSub.peripheralDevices]: (
-		selector: MongoQuery<PeripheralDevice>,
+		/** PeripheralDeviceId to fetch for, or null to fetch all */
+		deviceIds: PeripheralDeviceId[] | null,
 		token?: string
 	) => CollectionName.PeripheralDevices
 	[CorelibPubSub.peripheralDevicesAndSubDevices]: (studioId: StudioId) => CollectionName.PeripheralDevices

--- a/packages/corelib/src/pubsub.ts
+++ b/packages/corelib/src/pubsub.ts
@@ -121,8 +121,8 @@ export interface CorelibPubSubTypes {
 		showStyleBaseIds: ShowStyleBaseId[] | null,
 		token?: string
 	) => CollectionName.Rundowns
-	[CorelibPubSub.adLibActions]: (selector: MongoQuery<AdLibAction>, token?: string) => CollectionName.AdLibActions
-	[CorelibPubSub.adLibPieces]: (selector: MongoQuery<AdLibPiece>, token?: string) => CollectionName.AdLibPieces
+	[CorelibPubSub.adLibActions]: (rundownIds: RundownId[], token?: string) => CollectionName.AdLibActions
+	[CorelibPubSub.adLibPieces]: (rundownIds: RundownId[], token?: string) => CollectionName.AdLibPieces
 	[CorelibPubSub.pieces]: (selector: MongoQuery<Piece>, token?: string) => CollectionName.Pieces
 	[CorelibPubSub.pieceInstances]: (
 		selector: MongoQuery<PieceInstance>,

--- a/packages/corelib/src/pubsub.ts
+++ b/packages/corelib/src/pubsub.ts
@@ -53,9 +53,13 @@ export enum CorelibPubSub {
 	 */
 	rundownPlaylists = 'rundownPlaylists',
 	/**
-	 * Fetch Rundowns. Either all in the system, limited to certain ShowStyleBases, or to specific RundownPlaylists by id.
+	 * Fetch Rundowns belonging to specific RundownPlaylists by id.
 	 */
-	rundowns = 'rundowns',
+	rundownsInPlaylists = 'rundownsInPlaylists',
+	/**
+	 * Fetch Rundowns belonging to certain ShowStyleBases.
+	 */
+	rundownsWithShowStyleBases = 'rundownsWithShowStyleBases',
 	/**
 	 * Fetch cached ingest data
 	 */
@@ -223,11 +227,9 @@ export interface CorelibPubSubTypes {
 		studioIds: StudioId[] | null,
 		token?: string
 	) => CollectionName.RundownPlaylists
-	[CorelibPubSub.rundowns]: (
-		/** RundownPlaylistId to fetch for, or null to not check */
-		playlistIds: RundownPlaylistId[] | null,
-		/** ShowStyleBaseId to fetch for, or null to not check */
-		showStyleBaseIds: ShowStyleBaseId[] | null,
+	[CorelibPubSub.rundownsInPlaylists]: (playlistIds: RundownPlaylistId[], token?: string) => CollectionName.Rundowns
+	[CorelibPubSub.rundownsWithShowStyleBases]: (
+		showStyleBaseIds: ShowStyleBaseId[],
 		token?: string
 	) => CollectionName.Rundowns
 	[CorelibPubSub.adLibActions]: (rundownIds: RundownId[], token?: string) => CollectionName.AdLibActions
@@ -248,8 +250,10 @@ export interface CorelibPubSubTypes {
 		rundownIds: RundownId[],
 		/** PartInstanceIds to fetch for, or null to fetch all */
 		partInstanceIds: PartInstanceId[] | null,
-		/** Only include PieceInstances which are playing as an adlib, or with tags */
-		onlyPlayingAdlibsOrWithTags: boolean,
+		filter: {
+			/** Only include PieceInstances which are playing as an adlib, or with tags */
+			onlyPlayingAdlibsOrWithTags?: boolean
+		},
 		token?: string
 	) => CollectionName.PieceInstances
 	[CorelibPubSub.pieceInstancesSimple]: (
@@ -257,7 +261,12 @@ export interface CorelibPubSubTypes {
 		playlistActivationId: RundownPlaylistActivationId | null,
 		token?: string
 	) => CollectionName.PieceInstances
-	[CorelibPubSub.parts]: (rundownIds: RundownId[], token?: string) => CollectionName.Parts
+	[CorelibPubSub.parts]: (
+		rundownIds: RundownId[],
+		/** SegmentIds to fetch for, or null to fetch all */
+		segmentIds: SegmentId[] | null,
+		token?: string
+	) => CollectionName.Parts
 	[CorelibPubSub.partInstances]: (
 		rundownIds: RundownId[],
 		playlistActivationId: RundownPlaylistActivationId | null,
@@ -273,13 +282,22 @@ export interface CorelibPubSubTypes {
 		segmentPlayoutId: SegmentPlayoutId,
 		token?: string
 	) => CollectionName.PartInstances
-	[CorelibPubSub.segments]: (rundownIds: RundownId[], omitHidden: boolean, token?: string) => CollectionName.Segments
+	[CorelibPubSub.segments]: (
+		rundownIds: RundownId[],
+		filter: {
+			/** Omit any Segments marked with `isHidden` */
+			omitHidden?: boolean
+		},
+		token?: string
+	) => CollectionName.Segments
 	[CorelibPubSub.showStyleBases]: (
 		/** ShowStyleBaseIds to fetch for, or null to fetch all */
 		showStyleBaseIds: ShowStyleBaseId[] | null,
 		token?: string
 	) => CollectionName.ShowStyleBases
 	[CorelibPubSub.showStyleVariants]: (
+		/** ShowStyleBaseIds to fetch for, or null to fetch all */
+		showStyleBaseIds: ShowStyleBaseId[] | null,
 		/** ShowStyleVariantId to fetch for, or null to fetch all */
 		showStyleVariantIds: ShowStyleVariantId[] | null,
 		token?: string

--- a/packages/corelib/src/pubsub.ts
+++ b/packages/corelib/src/pubsub.ts
@@ -28,6 +28,7 @@ import { PieceInstance } from './dataModel/PieceInstance'
 import { TimelineComplete } from './dataModel/Timeline'
 import {
 	PartId,
+	PartInstanceId,
 	PeripheralDeviceId,
 	RundownId,
 	RundownPlaylistId,
@@ -146,7 +147,11 @@ export interface CorelibPubSubTypes {
 		token?: string
 	) => CollectionName.Pieces
 	[CorelibPubSub.pieceInstances]: (
-		selector: MongoQuery<PieceInstance>,
+		rundownIds: RundownId[],
+		/** PartInstanceIds to fetch for, or null to fetch all */
+		partInstanceIds: PartInstanceId[] | null,
+		/** Only include PieceInstances which are playing as an adlib, or with tags */
+		onlyPlayingAdlibsOrWithTags: boolean,
 		token?: string
 	) => CollectionName.PieceInstances
 	[CorelibPubSub.pieceInstancesSimple]: (

--- a/packages/corelib/src/pubsub.ts
+++ b/packages/corelib/src/pubsub.ts
@@ -59,8 +59,6 @@ export enum CorelibPubSub {
 	timeline = 'timeline',
 	timelineDatastore = 'timelineDatastore',
 
-	expectedMediaItems = 'expectedMediaItems',
-
 	expectedPackages = 'expectedPackages',
 	expectedPackageWorkStatuses = 'expectedPackageWorkStatuses',
 	packageContainerStatuses = 'packageContainerStatuses',
@@ -85,10 +83,6 @@ export enum CorelibPubSub {
 export interface CorelibPubSubTypes {
 	[CorelibPubSub.blueprints]: (selector: MongoQuery<Blueprint>, token?: string) => CollectionName.Blueprints
 
-	[CorelibPubSub.expectedMediaItems]: (
-		selector: MongoQuery<ExpectedMediaItem>,
-		token?: string
-	) => CollectionName.ExpectedMediaItems
 	[CorelibPubSub.externalMessageQueue]: (
 		selector: MongoQuery<ExternalMessageQueueObj>,
 		token?: string

--- a/packages/corelib/src/pubsub.ts
+++ b/packages/corelib/src/pubsub.ts
@@ -19,7 +19,7 @@ import { BucketAdLibAction } from './dataModel/BucketAdLibAction'
 import { BucketAdLib } from './dataModel/BucketAdLibPiece'
 import { ExpectedMediaItem } from './dataModel/ExpectedMediaItem'
 import { ExpectedPackageWorkStatus } from './dataModel/ExpectedPackageWorkStatuses'
-import { ExpectedPackageDB, ExpectedPackageDBBase } from './dataModel/ExpectedPackages'
+import { ExpectedPackageDBBase } from './dataModel/ExpectedPackages'
 import { ExternalMessageQueueObj } from './dataModel/ExternalMessageQueue'
 import { PackageContainerStatusDB } from './dataModel/PackageContainerStatus'
 import { PeripheralDevice } from './dataModel/PeripheralDevice'
@@ -165,16 +165,13 @@ export interface CorelibPubSubTypes {
 		selector: MongoQuery<BucketAdLibAction>,
 		token?: string
 	) => CollectionName.BucketAdLibActions
-	[CorelibPubSub.expectedPackages]: (
-		selector: MongoQuery<ExpectedPackageDB>,
-		token?: string
-	) => CollectionName.ExpectedPackages
+	[CorelibPubSub.expectedPackages]: (studioIds: StudioId[], token?: string) => CollectionName.ExpectedPackages
 	[CorelibPubSub.expectedPackageWorkStatuses]: (
-		selector: MongoQuery<ExpectedPackageWorkStatus>,
+		studioIds: StudioId[],
 		token?: string
 	) => CollectionName.ExpectedPackageWorkStatuses
 	[CorelibPubSub.packageContainerStatuses]: (
-		selector: MongoQuery<PackageContainerStatusDB>,
+		studioIds: StudioId[],
 		token?: string
 	) => CollectionName.PackageContainerStatuses
 }

--- a/packages/corelib/src/pubsub.ts
+++ b/packages/corelib/src/pubsub.ts
@@ -37,6 +37,7 @@ import {
 } from '@sofie-automation/shared-lib/dist/core/model/Ids'
 import {
 	BlueprintId,
+	BucketId,
 	RundownPlaylistActivationId,
 	SegmentId,
 	SegmentPlayoutId,
@@ -193,12 +194,14 @@ export interface CorelibPubSubTypes {
 	) => CollectionName.Studios
 	[CorelibPubSub.timelineDatastore]: (studioId: StudioId, token?: string) => CollectionName.TimelineDatastore
 	[CorelibPubSub.bucketAdLibPieces]: (
-		selector: MongoQuery<BucketAdLib>,
-		token?: string
+		studioId: StudioId,
+		bucketId: BucketId,
+		showStyleVariantIds: ShowStyleVariantId[]
 	) => CollectionName.BucketAdLibPieces
 	[CorelibPubSub.bucketAdLibActions]: (
-		selector: MongoQuery<BucketAdLibAction>,
-		token?: string
+		studioId: StudioId,
+		bucketId: BucketId,
+		showStyleVariantIds: ShowStyleVariantId[]
 	) => CollectionName.BucketAdLibActions
 	[CorelibPubSub.expectedPackages]: (studioIds: StudioId[], token?: string) => CollectionName.ExpectedPackages
 	[CorelibPubSub.expectedPackageWorkStatuses]: (

--- a/packages/corelib/src/pubsub.ts
+++ b/packages/corelib/src/pubsub.ts
@@ -143,7 +143,7 @@ export interface CorelibPubSubTypes {
 		segmentPlayoutId: SegmentPlayoutId,
 		token?: string
 	) => CollectionName.PartInstances
-	[CorelibPubSub.segments]: (selector: MongoQuery<DBSegment>, token?: string) => CollectionName.Segments
+	[CorelibPubSub.segments]: (rundownIds: RundownId[], omitHidden: boolean, token?: string) => CollectionName.Segments
 	[CorelibPubSub.showStyleBases]: (
 		selector: MongoQuery<DBShowStyleBase>,
 		token?: string

--- a/packages/live-status-gateway/src/collections/adLibActions.ts
+++ b/packages/live-status-gateway/src/collections/adLibActions.ts
@@ -45,9 +45,9 @@ export class AdLibActionsHandler
 			if (this._subscriptionId) this._coreHandler.unsubscribe(this._subscriptionId)
 			if (this._dbObserver) this._dbObserver.stop()
 			if (this._curRundownId && this._curPartInstance) {
-				this._subscriptionId = await this._coreHandler.setupSubscription(this._publicationName, {
-					rundownId: this._curRundownId,
-				})
+				this._subscriptionId = await this._coreHandler.setupSubscription(this._publicationName, [
+					this._curRundownId,
+				])
 				this._dbObserver = this._coreHandler.setupObserver(this._collectionName)
 				this._dbObserver.added = (id) => {
 					void this.changed(id, 'added').catch(this._logger.error)

--- a/packages/live-status-gateway/src/collections/adLibs.ts
+++ b/packages/live-status-gateway/src/collections/adLibs.ts
@@ -45,9 +45,9 @@ export class AdLibsHandler
 			if (this._subscriptionId) this._coreHandler.unsubscribe(this._subscriptionId)
 			if (this._dbObserver) this._dbObserver.stop()
 			if (this._curRundownId && this._curPartInstance) {
-				this._subscriptionId = await this._coreHandler.setupSubscription(this._publicationName, {
-					rundownId: this._curRundownId,
-				})
+				this._subscriptionId = await this._coreHandler.setupSubscription(this._publicationName, [
+					this._curRundownId,
+				])
 				this._dbObserver = this._coreHandler.setupObserver(this._collectionName)
 				this._dbObserver.added = (id) => {
 					void this.changed(id, 'added').catch(this._logger.error)

--- a/packages/live-status-gateway/src/collections/globalAdLibActions.ts
+++ b/packages/live-status-gateway/src/collections/globalAdLibActions.ts
@@ -54,10 +54,9 @@ export class GlobalAdLibActionsHandler
 			if (this._subscriptionId) this._coreHandler.unsubscribe(this._subscriptionId)
 			if (this._dbObserver) this._dbObserver.stop()
 			if (this._curRundownId) {
-				this._subscriptionId = await this._coreHandler.setupSubscription(
-					this._publicationName,
-					this._curRundownId
-				)
+				this._subscriptionId = await this._coreHandler.setupSubscription(this._publicationName, [
+					this._curRundownId,
+				])
 				this._dbObserver = this._coreHandler.setupObserver(this._collectionName)
 				this._dbObserver.added = (id) => {
 					void this.changed(id, 'added').catch(this._logger.error)

--- a/packages/live-status-gateway/src/collections/globalAdLibActions.ts
+++ b/packages/live-status-gateway/src/collections/globalAdLibActions.ts
@@ -54,9 +54,10 @@ export class GlobalAdLibActionsHandler
 			if (this._subscriptionId) this._coreHandler.unsubscribe(this._subscriptionId)
 			if (this._dbObserver) this._dbObserver.stop()
 			if (this._curRundownId) {
-				this._subscriptionId = await this._coreHandler.setupSubscription(this._publicationName, {
-					rundownId: this._curRundownId,
-				})
+				this._subscriptionId = await this._coreHandler.setupSubscription(
+					this._publicationName,
+					this._curRundownId
+				)
 				this._dbObserver = this._coreHandler.setupObserver(this._collectionName)
 				this._dbObserver.added = (id) => {
 					void this.changed(id, 'added').catch(this._logger.error)

--- a/packages/live-status-gateway/src/collections/globalAdLibs.ts
+++ b/packages/live-status-gateway/src/collections/globalAdLibs.ts
@@ -54,9 +54,10 @@ export class GlobalAdLibsHandler
 			if (this._subscriptionId) this._coreHandler.unsubscribe(this._subscriptionId)
 			if (this._dbObserver) this._dbObserver.stop()
 			if (this._curRundownId) {
-				this._subscriptionId = await this._coreHandler.setupSubscription(this._publicationName, {
-					rundownId: this._curRundownId,
-				})
+				this._subscriptionId = await this._coreHandler.setupSubscription(
+					this._publicationName,
+					this._curRundownId
+				)
 				this._dbObserver = this._coreHandler.setupObserver(this._collectionName)
 				this._dbObserver.added = (id) => {
 					void this.changed(id, 'added').catch(this._logger.error)

--- a/packages/live-status-gateway/src/collections/globalAdLibs.ts
+++ b/packages/live-status-gateway/src/collections/globalAdLibs.ts
@@ -54,10 +54,9 @@ export class GlobalAdLibsHandler
 			if (this._subscriptionId) this._coreHandler.unsubscribe(this._subscriptionId)
 			if (this._dbObserver) this._dbObserver.stop()
 			if (this._curRundownId) {
-				this._subscriptionId = await this._coreHandler.setupSubscription(
-					this._publicationName,
-					this._curRundownId
-				)
+				this._subscriptionId = await this._coreHandler.setupSubscription(this._publicationName, [
+					this._curRundownId,
+				])
 				this._dbObserver = this._coreHandler.setupObserver(this._collectionName)
 				this._dbObserver.added = (id) => {
 					void this.changed(id, 'added').catch(this._logger.error)

--- a/packages/live-status-gateway/src/collections/part.ts
+++ b/packages/live-status-gateway/src/collections/part.ts
@@ -64,7 +64,11 @@ export class PartHandler
 			if (this._dbObserver) this._dbObserver.stop()
 			if (this._activePlaylist) {
 				const rundownIds = this._activePlaylist.rundownIdsInOrder
-				this._subscriptionId = await this._coreHandler.setupSubscription(this._publicationName, rundownIds)
+				this._subscriptionId = await this._coreHandler.setupSubscription(
+					this._publicationName,
+					rundownIds,
+					null
+				)
 				this._dbObserver = this._coreHandler.setupObserver(this._collectionName)
 				this._dbObserver.added = (id) => {
 					void this.changed(id, 'added').catch(this._logger.error)

--- a/packages/live-status-gateway/src/collections/playlist.ts
+++ b/packages/live-status-gateway/src/collections/playlist.ts
@@ -60,9 +60,7 @@ export class PlaylistHandler
 		if (!this._studioId) return
 		if (!this._collectionName) return
 		if (!this._publicationName) return
-		this._subscriptionId = await this._coreHandler.setupSubscription(this._publicationName, {
-			studioId: this._studioId,
-		})
+		this._subscriptionId = await this._coreHandler.setupSubscription(this._publicationName, null, [this._studioId])
 		this._dbObserver = this._coreHandler.setupObserver(this._collectionName)
 		if (this._collectionName) {
 			const col = this._core.getCollection(this._collectionName)

--- a/packages/live-status-gateway/src/collections/rundownHandler.ts
+++ b/packages/live-status-gateway/src/collections/rundownHandler.ts
@@ -12,7 +12,7 @@ import { RundownsHandler } from './rundownsHandler'
 import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 
 export class RundownHandler
-	extends CollectionBase<DBRundown, CorelibPubSub.rundowns, CollectionName.Rundowns>
+	extends CollectionBase<DBRundown, CorelibPubSub.rundownsInPlaylists, CollectionName.Rundowns>
 	implements
 		Collection<DBRundown>,
 		CollectionObserver<DBRundownPlaylist>,
@@ -23,7 +23,7 @@ export class RundownHandler
 	private _curRundownId: RundownId | undefined
 
 	constructor(logger: Logger, coreHandler: CoreHandler, private _rundownsHandler?: RundownsHandler) {
-		super(RundownHandler.name, CollectionName.Rundowns, CorelibPubSub.rundowns, logger, coreHandler)
+		super(RundownHandler.name, CollectionName.Rundowns, CorelibPubSub.rundownsInPlaylists, logger, coreHandler)
 		this.observerName = this._name
 	}
 
@@ -67,11 +67,9 @@ export class RundownHandler
 			if (this._subscriptionId) this._coreHandler.unsubscribe(this._subscriptionId)
 			if (this._dbObserver) this._dbObserver.stop()
 			if (this._curPlaylistId) {
-				this._subscriptionId = await this._coreHandler.setupSubscription(
-					this._publicationName,
-					[this._curPlaylistId],
-					null
-				)
+				this._subscriptionId = await this._coreHandler.setupSubscription(this._publicationName, [
+					this._curPlaylistId,
+				])
 				this._dbObserver = this._coreHandler.setupObserver(this._collectionName)
 				this._dbObserver.added = (id) => {
 					void this.changed(id, 'added').catch(this._logger.error)

--- a/packages/live-status-gateway/src/collections/segmentHandler.ts
+++ b/packages/live-status-gateway/src/collections/segmentHandler.ts
@@ -75,7 +75,9 @@ export class SegmentHandler
 				this._subscriptionId = await this._coreHandler.setupSubscription(
 					this._publicationName,
 					this._rundownIds,
-					true
+					{
+						omitHidden: true,
+					}
 				)
 				this._dbObserver = this._coreHandler.setupObserver(this._collectionName)
 				this._dbObserver.added = (id) => {

--- a/packages/live-status-gateway/src/collections/segmentHandler.ts
+++ b/packages/live-status-gateway/src/collections/segmentHandler.ts
@@ -72,10 +72,11 @@ export class SegmentHandler
 			if (this._subscriptionId) this._coreHandler.unsubscribe(this._subscriptionId)
 			if (this._dbObserver) this._dbObserver.stop()
 			if (this._rundownIds.length) {
-				this._subscriptionId = await this._coreHandler.setupSubscription(this._publicationName, {
-					rundownId: { $in: this._rundownIds },
-					isHidden: { $ne: true },
-				})
+				this._subscriptionId = await this._coreHandler.setupSubscription(
+					this._publicationName,
+					this._rundownIds,
+					true
+				)
 				this._dbObserver = this._coreHandler.setupObserver(this._collectionName)
 				this._dbObserver.added = (id) => {
 					void this.changed(id, 'added').catch(this._logger.error)

--- a/packages/live-status-gateway/src/collections/showStyleBase.ts
+++ b/packages/live-status-gateway/src/collections/showStyleBase.ts
@@ -50,9 +50,9 @@ export class ShowStyleBaseHandler
 			if (this._subscriptionId) this._coreHandler.unsubscribe(this._subscriptionId)
 			if (this._dbObserver) this._dbObserver.stop()
 			if (this._showStyleBaseId) {
-				this._subscriptionId = await this._coreHandler.setupSubscription(this._publicationName, {
-					_id: this._showStyleBaseId,
-				})
+				this._subscriptionId = await this._coreHandler.setupSubscription(this._publicationName, [
+					this._showStyleBaseId,
+				])
 				this._dbObserver = this._coreHandler.setupObserver(this._collectionName)
 				this._dbObserver.added = (id) => {
 					void this.changed(id, 'added').catch(this._logger.error)

--- a/packages/live-status-gateway/src/collections/studio.ts
+++ b/packages/live-status-gateway/src/collections/studio.ts
@@ -22,7 +22,7 @@ export class StudioHandler
 		if (!this._collectionName) return
 		if (!this._publicationName) return
 		if (!this._studioId) return
-		this._subscriptionId = await this._coreHandler.setupSubscription(this._publicationName, { _id: this._studioId })
+		this._subscriptionId = await this._coreHandler.setupSubscription(this._publicationName, [this._studioId])
 		this._dbObserver = this._coreHandler.setupObserver(this._collectionName)
 
 		if (this._collectionName) {

--- a/packages/shared-lib/src/pubsub/peripheralDevice.ts
+++ b/packages/shared-lib/src/pubsub/peripheralDevice.ts
@@ -15,23 +15,41 @@ import { DeviceTriggerMountedAction, PreviewWrappedAdLib } from '../input-gatewa
  * Ids of possible DDP subscriptions for any PeripheralDevice.
  */
 export enum PeripheralDevicePubSub {
-	peripheralDeviceCommands = 'peripheralDeviceCommands',
+	// Common:
 
-	// For a PeripheralDevice
+	/** Commands for the PeripheralDevice to execute */
+	peripheralDeviceCommands = 'peripheralDeviceCommands',
+	/** Properties/settings of the PeripheralDevice */
+	peripheralDeviceForDevice = 'peripheralDeviceForDevice',
+
+	// Playout gateway:
+
+	/** Playout gateway: Rundowns in the Studio of the PeripheralDevice */
 	rundownsForDevice = 'rundownsForDevice',
 
-	// custom publications:
-	peripheralDeviceForDevice = 'peripheralDeviceForDevice',
+	/** Playout gateway: Simplified timeline mappings in the Studio of the PeripheralDevice */
 	mappingsForDevice = 'mappingsForDevice',
+	/** Playout gateway: Simplified timeline in the Studio of the PeripheralDevice */
 	timelineForDevice = 'timelineForDevice',
+	/** Playout gateway: Timeline datastore entries in the Studio of the PeripheralDevice */
 	timelineDatastoreForDevice = 'timelineDatastoreForDevice',
+	/** Playout gateway: ExpectedPlayoutItems in the Studio of the PeripheralDevice */
 	expectedPlayoutItemsForDevice = 'expectedPlayoutItemsForDevice',
 
+	// Input gateway:
+
+	/** Input gateway: Calculated triggered actions */
 	mountedTriggersForDevice = 'mountedTriggersForDevice',
+	/** Input gateway: Calculated trigger previews */
 	mountedTriggersForDevicePreview = 'mountedTriggersForDevicePreview',
 
+	// Package manager:
+
+	/** Package manager: Info about the active playlist in the Studio of the PeripheralDevice */
 	packageManagerPlayoutContext = 'packageManagerPlayoutContext',
+	/** Package manager: The package containers in the Studio of the PeripheralDevice */
 	packageManagerPackageContainers = 'packageManagerPackageContainers',
+	/** Package manager: The expected packages in the Studio of the PeripheralDevice */
 	packageManagerExpectedPackages = 'packageManagerExpectedPackages',
 }
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

builds on #1056 

* **What is the current behavior?** (You can also link to an open issue here)

The publications exposed over ddp are mostly done by allowing the caller to define the mongo query that will be used.

* **What is the new behavior (if this is a feature change)?**

These have all been replaced to provide a strict set of parameters that can be provided in the publication call.
The aim of this is to make the code more self-documenting on what publications are being run, and make it easier for us to figure review what mongo queries the subscriptions are running, so that they can both be optimised (with indices) and combined where necessary

* **Other information**:

No attempt has been made to optimise the usages of these publications (except a couple of very simple circumstances).  

Further analysis could be done to look into:
1) Is is better to run a subscription per rundown, or for an array of rundownIds? In particular, what is the network/cpu impact when the list of rundownIds changes?
2) Are all of the subscriptions necessary? It seems like many deep inside of views are running subscriptions. Could/should they be pushed out to higher levels? Would there be any benefit to doing so considering how meteor deduplicates the content?

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] Automated tests to cover the new functionality and/or guard against regressions have been added
- [ ] The functionality has been tested by NRK
