### PR TITLE
fix: Playout ignores 'Play from here' offset SOFIE-2356

### DIFF
--- a/packages/job-worker/src/playout/__tests__/timeline.test.ts
+++ b/packages/job-worker/src/playout/__tests__/timeline.test.ts
@@ -435,7 +435,7 @@ async function doDeactivatePlaylist(context: MockJobContext, playlistId: Rundown
 }
 
 /** perform an update of the timeline */
-async function doUpdateTimeline(context: MockJobContext, playlistId: RundownPlaylistId, forceNowToTime?: Time) {
+async function doUpdateTimeline(context: MockJobContext, playlistId: RundownPlaylistId) {
 	await runJobWithPlayoutModel(
 		context,
 		{
@@ -443,7 +443,7 @@ async function doUpdateTimeline(context: MockJobContext, playlistId: RundownPlay
 		},
 		null,
 		async (playoutModel) => {
-			await updateTimeline(context, playoutModel, forceNowToTime)
+			await updateTimeline(context, playoutModel)
 		}
 	)
 }

--- a/packages/job-worker/src/playout/adlibUtils.ts
+++ b/packages/job-worker/src/playout/adlibUtils.ts
@@ -277,7 +277,7 @@ export function innerStopPieces(
 	}
 
 	const resolvedPieces = getResolvedPiecesForCurrentPartInstance(context, sourceLayers, currentPartInstance)
-	const offsetRelativeToNow = (timeOffset || 0) + (calculateNowOffsetLatency(context, playoutModel, undefined) || 0)
+	const offsetRelativeToNow = (timeOffset || 0) + (calculateNowOffsetLatency(context, playoutModel) || 0)
 	const stopAt = getCurrentTime() + offsetRelativeToNow
 	const relativeStopAt = stopAt - lastStartedPlayback
 

--- a/packages/job-worker/src/playout/model/PlayoutPartInstanceModel.ts
+++ b/packages/job-worker/src/playout/model/PlayoutPartInstanceModel.ts
@@ -184,11 +184,12 @@ export interface PlayoutPartInstanceModel {
 	setRank(rank: number): void
 
 	/**
-	 * Set the PartInstance as having been taken
+	 * Set the PartInstance as having been taken, if an offset is provided the plannedStartedPlayback of the PartInstance will be set to match,
+	 * to force the PartInstance to have started a certain distance in the past
 	 * @param takeTime The timestamp to record as when it was taken
-	 * @param playOffset The offset into the PartInstance to start playback from
+	 * @param playOffset If set, offset into the PartInstance to start playback from
 	 */
-	setTaken(takeTime: number, playOffset: number): void
+	setTaken(takeTime: number, playOffset: number | null): void
 
 	/**
 	 * Define some cached values, to be done when taking the PartInstance

--- a/packages/job-worker/src/playout/model/implementation/PlayoutPartInstanceModelImpl.ts
+++ b/packages/job-worker/src/playout/model/implementation/PlayoutPartInstanceModelImpl.ts
@@ -476,12 +476,18 @@ export class PlayoutPartInstanceModelImpl implements PlayoutPartInstanceModel {
 		this.#compareAndSetPartValue('_rank', rank)
 	}
 
-	setTaken(takeTime: number, playOffset: number): void {
+	setTaken(takeTime: number, playOffset: number | null): void {
 		this.#compareAndSetPartInstanceValue('isTaken', true)
 
 		const timings = { ...this.partInstanceImpl.timings }
 		timings.take = takeTime
-		timings.playOffset = playOffset
+		timings.playOffset = playOffset ?? 0
+
+		if (playOffset !== null) {
+			// Shift the startedPlayback into the past, to cause playout to start a while into the Part:
+			// Note: We won't use the takeTime here, since the takeTime is when we started executing the take, and we'd rather have the play-time to be Now instead
+			timings.plannedStartedPlayback = getCurrentTime() - playOffset
+		}
 
 		this.#compareAndSetPartInstanceValue('timings', timings, true)
 	}

--- a/packages/job-worker/src/playout/take.ts
+++ b/packages/job-worker/src/playout/take.ts
@@ -241,7 +241,7 @@ export async function performTakeToNextedPart(
 
 	playoutModel.cycleSelectedPartInstances()
 
-	takePartInstance.setTaken(now, timeOffset ?? 0)
+	takePartInstance.setTaken(now, timeOffset)
 
 	resetPreviousSegment(playoutModel)
 
@@ -255,7 +255,7 @@ export async function performTakeToNextedPart(
 	) {
 		startHold(context, currentPartInstance, nextPartInstance)
 	}
-	await afterTake(context, playoutModel, takePartInstance, timeOffset)
+	await afterTake(context, playoutModel, takePartInstance)
 
 	// Last:
 	const takeDoneTime = getCurrentTime()
@@ -463,14 +463,13 @@ export function updatePartInstanceOnTake(
 export async function afterTake(
 	context: JobContext,
 	playoutModel: PlayoutModel,
-	takePartInstance: PlayoutPartInstanceModel,
-	timeOffsetIntoPart: number | null = null
+	takePartInstance: PlayoutPartInstanceModel
 ): Promise<void> {
 	const span = context.startSpan('afterTake')
 	// This function should be called at the end of a "take" event (when the Parts have been updated)
 	// or after a new part has started playing
 
-	await updateTimeline(context, playoutModel, timeOffsetIntoPart || undefined)
+	await updateTimeline(context, playoutModel)
 
 	playoutModel.queueNotifyCurrentlyPlayingPartEvent(takePartInstance.partInstance.rundownId, takePartInstance)
 

--- a/packages/job-worker/src/playout/timeline/generate.ts
+++ b/packages/job-worker/src/playout/timeline/generate.ts
@@ -143,11 +143,7 @@ export async function updateStudioTimeline(
 	if (span) span.end()
 }
 
-export async function updateTimeline(
-	context: JobContext,
-	playoutModel: PlayoutModel,
-	timeOffsetIntoPart?: Time
-): Promise<void> {
+export async function updateTimeline(context: JobContext, playoutModel: PlayoutModel): Promise<void> {
 	const span = context.startSpan('updateTimeline')
 	logger.debug('updateTimeline running...')
 
@@ -162,7 +158,7 @@ export async function updateTimeline(
 	preserveOrReplaceNowTimesInObjects(playoutModel, timelineObjs)
 
 	if (playoutModel.isMultiGatewayMode) {
-		deNowifyMultiGatewayTimeline(context, playoutModel, timelineObjs, timeOffsetIntoPart, timingInfo)
+		deNowifyMultiGatewayTimeline(context, playoutModel, timelineObjs, timingInfo)
 
 		logAnyRemainingNowTimes(context, timelineObjs)
 	}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Using the 'play from here' context menu option will always play from the start of the selected part

* **What is the new behavior (if this is a feature change)?**

It now plays from the correct point within the part

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] Automated tests to cover the new functionality and/or guard against regressions have been added
- [ ] The functionality has been tested by NRK
