### PR TITLE
feat(live-status-gw): segment identifiers

### DIFF
--- a/packages/live-status-gateway/api/schemas/segments.yaml
+++ b/packages/live-status-gateway/api/schemas/segments.yaml
@@ -30,6 +30,9 @@ $defs:
       id:
         description: Unique id of the segment
         type: string
+      identifier:
+        description: User-facing identifier that can be used by the User to identify the contents of a segment in the Rundown source system
+        type: string
       rundownId:
         description: Unique id of the rundown this segment belongs to
         type: string

--- a/packages/live-status-gateway/api/schemas/segments.yaml
+++ b/packages/live-status-gateway/api/schemas/segments.yaml
@@ -31,7 +31,7 @@ $defs:
         description: Unique id of the segment
         type: string
       identifier:
-        description: User-facing identifier that can be used by the User to identify the contents of a segment in the Rundown source system
+        description: User-facing identifier that can be used to identify the contents of a segment in the Rundown source system
         type: string
       rundownId:
         description: Unique id of the rundown this segment belongs to

--- a/packages/live-status-gateway/src/topics/__tests__/segmentsTopic.spec.ts
+++ b/packages/live-status-gateway/src/topics/__tests__/segmentsTopic.spec.ts
@@ -87,7 +87,7 @@ describe('SegmentsTopic', () => {
 		const testPlaylist2 = makeTestPlaylist()
 		testPlaylist2.currentPartInfo = {
 			partInstanceId: protectString('PI_1'),
-			consumesNextSegmentId: true,
+			consumesQueuedSegmentId: true,
 			manuallySelected: false,
 			rundownId: protectString(RUNDOWN_1_ID),
 		}
@@ -159,6 +159,35 @@ describe('SegmentsTopic', () => {
 				{ id: '2_2', rundownId: RUNDOWN_2_ID, name: 'Segment 2_2' },
 				{ id: '1_1', rundownId: RUNDOWN_1_ID, name: 'Segment 1_1' },
 				{ id: '1_2', rundownId: RUNDOWN_1_ID, name: 'Segment 1_2' },
+			],
+		}
+		expect(mockSubscriber.send.mock.calls).toEqual([[JSON.stringify(expectedStatus)]])
+	})
+
+	it('includes segment identifier', async () => {
+		const topic = new SegmentsTopic(makeMockLogger())
+		const mockSubscriber = makeMockSubscriber()
+
+		const testPlaylist = makeTestPlaylist()
+		await topic.update(PlaylistHandler.name, testPlaylist)
+		await topic.update(SegmentsHandler.name, [
+			{ ...makeTestSegment('1_2', 2, RUNDOWN_1_ID), identifier: 'SomeIdentifier' },
+			makeTestSegment('1_1', 1, RUNDOWN_1_ID),
+		])
+
+		topic.addSubscriber(mockSubscriber)
+		mockSubscriber.send.mockClear()
+
+		const testPlaylist2 = makeTestPlaylist()
+		testPlaylist2.rundownIdsInOrder = [protectString(RUNDOWN_2_ID), protectString(RUNDOWN_1_ID)]
+		await topic.update(PlaylistHandler.name, testPlaylist2)
+
+		const expectedStatus: SegmentsStatus = {
+			event: 'segments',
+			rundownPlaylistId: unprotectString(testPlaylist._id),
+			segments: [
+				{ id: '1_1', rundownId: RUNDOWN_1_ID, name: 'Segment 1_1' },
+				{ id: '1_2', rundownId: RUNDOWN_1_ID, name: 'Segment 1_2', identifier: 'SomeIdentifier' },
 			],
 		}
 		expect(mockSubscriber.send.mock.calls).toEqual([[JSON.stringify(expectedStatus)]])

--- a/packages/live-status-gateway/src/topics/segmentsTopic.ts
+++ b/packages/live-status-gateway/src/topics/segmentsTopic.ts
@@ -11,6 +11,7 @@ import isShallowEqual from '@sofie-automation/shared-lib/dist/lib/isShallowEqual
 
 interface SegmentStatus {
 	id: string
+	identifier?: string
 	rundownId: string
 	name: string
 }
@@ -47,6 +48,7 @@ export class SegmentsTopic
 				id: unprotectString(segment._id),
 				rundownId: unprotectString(segment.rundownId),
 				name: segment.name,
+				identifier: segment.identifier,
 			})),
 		}
 


### PR DESCRIPTION
This PR is being opened on behalf of TV 2 Norge.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
A feature: new property exposed by the Live Status Gateway in the `segments` topics.


* **What is the current behavior?** (You can also link to an open issue here)
Segment identifier is not available to subscribers of the LSG.


* **What is the new behavior (if this is a feature change)?**
Segment identifier is available to subscribers of the LSG.


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [x] Automated tests to cover the new functionality and/or guard against regressions have been added
- [ ] The functionality has been tested by NRK
