### PR TITLE
fix: Duplicated segment identifiers in the GUI

### DIFF
--- a/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
@@ -1109,7 +1109,6 @@ export class SegmentTimelineClass extends React.Component<Translated<WithTiming<
 						)}
 				</div>
 
-				<div className="segment-timeline__identifier">{this.props.segment.identifier}</div>
 				{this.props.segment.segmentTiming?.expectedStart || this.props.segment.segmentTiming?.expectedEnd ? (
 					<div className="segment-timeline__expectedTime">
 						<SegmentTimeAnchorTime


### PR DESCRIPTION
This PR is being opened on behalf of TV 2 Norge.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix in the GUI.


* **What is the current behavior?** (You can also link to an open issue here)
Segment identifier is shown twice: it appears in its usual place and at the bottom of the container.
![image](https://github.com/nrkno/sofie-core/assets/9103996/c5085c71-7c3f-4f1d-bd12-0d50591f77e9)



* **What is the new behavior (if this is a feature change)?**
Segment identifier is shown only once, where it's expected.
![image](https://github.com/nrkno/sofie-core/assets/9103996/1575d2d6-03a7-4d90-abab-72d42a576c5a)


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] Automated tests to cover the new functionality and/or guard against regressions have been added
- [ ] The functionality has been tested by NRK
