### PR TITLE
fix(OpenAPI): ShowStyleVariants `additionalProperties` and `required` properties were mis-indented

### DIFF
--- a/packages/openapi/api/actions.yaml
+++ b/packages/openapi/api/actions.yaml
@@ -6,6 +6,11 @@ info:
   license:
     name: 'MIT License'
     url: 'http://opensource.org/licenses/MIT'
+  x-logo:
+    url: 'https://nrkno.github.io/sofie-core/img/sofie-logo.svg'
+    backgroundColor: '#FFFFFF'
+    altText: 'Sofie TV Automation'
+
 servers:
   - url: http://localhost:3000/api/v1.0
     description: Initial release of UserActions API - http - for use during development only!

--- a/packages/openapi/api/definitions/showstyles.yaml
+++ b/packages/openapi/api/definitions/showstyles.yaml
@@ -607,13 +607,13 @@ components:
               type: boolean
               example: true
           additionalProperties: true
-        required:
-          - name
-          - rank
-          - showStyleBaseId
-          - blueprintId
-          - config
-        additionalProperties: false
+      required:
+        - name
+        - rank
+        - showStyleBaseId
+        - blueprintId
+        - config
+      additionalProperties: false
     outputLayer:
       type: object
       properties:


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## The contributor
This PR is contributed by me.

## Type of contribution
<!-- Pick one by marking it with an "x" -->

This is a

- [x] Bug fix
- [ ] Feature
- [ ] Code improvement
- [ ] Documentation improvement
- [ ] Other (please specify)


## Current behavior
The ShowStyleVariant specification contains what amounts to a syntax error, with the `required` and `additionalProperties` mis-indented.


## New behavior
Syntax error is fixed.

Also, the `x-logo` OpenAPI extension is used to provide a logo for the generated docs, if supported.


## Test instructions
No testing required.


## Other information


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed
- [x] The functionality has been tested by the author
- [ ] Relevant unit tests has been added / updated
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated
