### PR TITLE
fix: Cannot read properties of undefined (reading 'parentElement') at startLive SOFIE-2772

### DIFF
--- a/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
@@ -219,8 +219,8 @@ export const BUDGET_GAP_PART = {
 export class SegmentTimelineClass extends React.Component<Translated<IProps>, IStateHeader> {
 	static whyDidYouRender = true
 
-	timeline: HTMLDivElement
-	segmentBlock: HTMLDivElement
+	timeline: HTMLDivElement | undefined
+	segmentBlock: HTMLDivElement | undefined
 
 	private _touchSize: number = 0
 	private _touchAttached: boolean = false
@@ -300,8 +300,8 @@ export class SegmentTimelineClass extends React.Component<Translated<IProps>, IS
 		}
 	}
 
-	private setTimelineRef = (el: HTMLDivElement) => {
-		this.timeline = el
+	private setTimelineRef = (el: HTMLDivElement | null) => {
+		this.timeline = el ?? undefined
 	}
 
 	private convertTimeToPixels = (time: number) => {

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -87,7 +87,7 @@ export const SegmentTimelineContainer = withResolvedSegment(
 
 		isVisible: boolean
 		rundownCurrentPartInstanceId: PartInstanceId | null
-		timelineDiv: HTMLDivElement
+		timelineDiv: HTMLDivElement | undefined
 		intersectionObserver: IntersectionObserver | undefined
 		mountedTime: number
 		nextPartOffset: number
@@ -628,6 +628,10 @@ export const SegmentTimelineContainer = withResolvedSegment(
 
 		startLive = () => {
 			window.addEventListener(RundownTiming.Events.timeupdateHighResolution, this.onAirLineRefresh)
+
+			const watchElement = this.timelineDiv?.parentElement
+			if (!watchElement) return
+
 			// As of Chrome 76, IntersectionObserver rootMargin works in screen pixels when root
 			// is viewport. This seems like an implementation bug and IntersectionObserver is
 			// an Experimental Feature in Chrome, so this might change in the future.
@@ -637,7 +641,7 @@ export const SegmentTimelineContainer = withResolvedSegment(
 				rootMargin: `-${getHeaderHeight() * zoomFactor}px 0px -${20 * zoomFactor}px 0px`,
 				threshold: [0, 0.25, 0.5, 0.75, 0.98],
 			})
-			this.intersectionObserver.observe(this.timelineDiv.parentElement!)
+			this.intersectionObserver.observe(watchElement)
 		}
 
 		stopLive = () => {

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -33,6 +33,7 @@ import { computeSegmentDuration, RundownTimingContext } from '../../lib/rundownT
 import { RundownViewShelf } from '../RundownView/RundownViewShelf'
 import { PartInstanceId, SegmentId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { PartInstances, Parts, Segments } from '../../collections'
+import { logger } from '../../../lib/logging'
 
 // Kept for backwards compatibility
 export { SegmentUi, PartUi, PieceUi, ISourceLayerUi, IOutputLayerUi } from '../SegmentContainer/withResolvedSegment'
@@ -630,7 +631,10 @@ export const SegmentTimelineContainer = withResolvedSegment(
 			window.addEventListener(RundownTiming.Events.timeupdateHighResolution, this.onAirLineRefresh)
 
 			const watchElement = this.timelineDiv?.parentElement
-			if (!watchElement) return
+			if (!watchElement) {
+				logger.warn(`Missing timelineDiv.parentElement in SegmentTimelineContainer.startLive`)
+				return
+			}
 
 			// As of Chrome 76, IntersectionObserver rootMargin works in screen pixels when root
 			// is viewport. This seems like an implementation bug and IntersectionObserver is


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
This pull request is posted on behalf of the NRK.

## Type of Contribution

This is a Bug fix

## Current Behavior

The Rundown View can crash under some circumstances

## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
