### PR TITLE
chore: remove unnecessary usages of meteor react component SOFIE-2751

### DIFF
--- a/meteor/client/lib/notifications/NotificationCenterPanel.tsx
+++ b/meteor/client/lib/notifications/NotificationCenterPanel.tsx
@@ -4,7 +4,6 @@ import ClassNames from 'classnames'
 // @ts-expect-error No types available
 import * as VelocityReact from 'velocity-react'
 import { translateWithTracker, Translated, withTracker } from '../ReactMeteorData/ReactMeteorData'
-import { MeteorReactComponent } from '../MeteorReactComponent'
 import {
 	NotificationCenter,
 	Notification,
@@ -183,7 +182,7 @@ export const NotificationCenterPopUps = translateWithTracker<IProps, IState, ITr
 		highlightedLevel: NotificationCenter.getHighlightedLevel(),
 	}
 })(
-	class NotificationCenterPopUps extends MeteorReactComponent<Translated<IProps & ITrackedProps>, IState> {
+	class NotificationCenterPopUps extends React.Component<Translated<IProps & ITrackedProps>, IState> {
 		private readonly DISMISS_ANIMATION_DURATION = 500
 		private readonly LEAVE_ANIMATION_DURATION = 150
 
@@ -505,7 +504,7 @@ export const NotificationCenterPanelToggle = withTracker<IToggleProps, {}, ITrac
 		}
 	}
 )(
-	class NotificationCenterPanelToggle extends MeteorReactComponent<IToggleProps & ITrackedCountProps> {
+	class NotificationCenterPanelToggle extends React.Component<IToggleProps & ITrackedCountProps> {
 		render(): JSX.Element {
 			return (
 				<button

--- a/meteor/client/ui/Account/AccountPage.tsx
+++ b/meteor/client/ui/Account/AccountPage.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import { Accounts } from 'meteor/accounts-base'
 import { Translated, translateWithTracker } from '../../lib/ReactMeteorData/react-meteor-data'
 import type { RouteComponentProps } from 'react-router'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { NotificationCenter, Notification, NoticeLevel } from '../../../lib/notifications/notifications'
 import { MeteorCall } from '../../../lib/api/methods'
 import { getUser, User, getUserRoles } from '../../../lib/collections/Users'
@@ -32,7 +31,7 @@ export const AccountPage = translateWithTracker(() => {
 		organization: organization,
 	}
 })(
-	class extends MeteorReactComponent<Translated<IAccountPageProps>, IAccountPageState> {
+	class AccountPage extends React.Component<Translated<IAccountPageProps>, IAccountPageState> {
 		constructor(props: any) {
 			super(props)
 		}

--- a/meteor/client/ui/Account/NotLoggedIn/LoginPage.tsx
+++ b/meteor/client/ui/Account/NotLoggedIn/LoginPage.tsx
@@ -4,7 +4,6 @@ import { Accounts } from 'meteor/accounts-base'
 import { Translated, translateWithTracker } from '../../../lib/ReactMeteorData/react-meteor-data'
 import { Link } from 'react-router-dom'
 import type { RouteComponentProps } from 'react-router'
-import { MeteorReactComponent } from '../../../lib/MeteorReactComponent'
 import { StatusResponse } from '../../../../lib/api/systemStatus'
 import { getUser, User } from '../../../../lib/collections/Users'
 import { NotLoggedInContainer } from './lib'
@@ -29,7 +28,7 @@ export const LoginPage = translateWithTracker((_props: ILoginProps) => {
 	const user = getUser()
 	return { user: user ? user : null }
 })(
-	class extends MeteorReactComponent<Translated<ILoginPageProps>, ILoginPageState> {
+	class LoginPage extends React.Component<Translated<ILoginPageProps>, ILoginPageState> {
 		// private _subscriptions: Array<Meteor.SubscriptionHandle> = []
 
 		constructor(props: Translated<ILoginPageProps>) {

--- a/meteor/client/ui/Account/NotLoggedIn/LostPassword.tsx
+++ b/meteor/client/ui/Account/NotLoggedIn/LostPassword.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { Translated, translateWithTracker } from '../../../lib/ReactMeteorData/react-meteor-data'
 import type { RouteComponentProps } from 'react-router'
-import { MeteorReactComponent } from '../../../lib/MeteorReactComponent'
 import { getUser } from '../../../../lib/collections/Users'
 import { MeteorCall } from '../../../../lib/api/methods'
 import { NotLoggedInContainer } from './lib'
@@ -22,7 +21,7 @@ export const LostPasswordPage = translateWithTracker((props: ILostPasswordPagePr
 
 	return {}
 })(
-	class extends MeteorReactComponent<Translated<ILostPasswordPageProps>, ILostPasswordPageState> {
+	class LostPassword extends React.Component<Translated<ILostPasswordPageProps>, ILostPasswordPageState> {
 		constructor(props: Translated<ILostPasswordPageProps>) {
 			super(props)
 

--- a/meteor/client/ui/Account/NotLoggedIn/ResetPasswordPage.tsx
+++ b/meteor/client/ui/Account/NotLoggedIn/ResetPasswordPage.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import { Accounts } from 'meteor/accounts-base'
 import { Translated, translateWithTracker } from '../../../lib/ReactMeteorData/react-meteor-data'
 import type { RouteComponentProps } from 'react-router'
-import { MeteorReactComponent } from '../../../lib/MeteorReactComponent'
 import { getUser } from '../../../../lib/collections/Users'
 import { NotLoggedInContainer } from './lib'
 import { Link } from 'react-router-dom'
@@ -23,7 +22,7 @@ export const ResetPasswordPage = translateWithTracker((props: IResetPageProps) =
 
 	return {}
 })(
-	class extends MeteorReactComponent<Translated<IResetPageProps>, IResetPageState> {
+	class ResetPasswordPage extends React.Component<Translated<IResetPageProps>, IResetPageState> {
 		constructor(props: Translated<IResetPageProps>) {
 			super(props)
 

--- a/meteor/client/ui/Account/NotLoggedIn/SignupPage.tsx
+++ b/meteor/client/ui/Account/NotLoggedIn/SignupPage.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { Translated, translateWithTracker } from '../../../lib/ReactMeteorData/react-meteor-data'
 import type { RouteComponentProps } from 'react-router'
-import { MeteorReactComponent } from '../../../lib/MeteorReactComponent'
 import { getUser } from '../../../../lib/collections/Users'
 import { NotLoggedInContainer } from './lib'
 import { Link } from 'react-router-dom'
@@ -26,7 +25,7 @@ export const SignupPage = translateWithTracker((props: ISignupPageProps) => {
 	if (user) props.history.push('/rundowns')
 	return {}
 })(
-	class SignupPage extends MeteorReactComponent<Translated<ISignupPageProps>, ISignupPageState> {
+	class SignupPage extends React.Component<Translated<ISignupPageProps>, ISignupPageState> {
 		private applications: string[] = [
 			'Doing TV shows from a studio',
 			'Doing streaming on the web from a studio',

--- a/meteor/client/ui/Header.tsx
+++ b/meteor/client/ui/Header.tsx
@@ -8,7 +8,6 @@ import { ErrorBoundary } from '../lib/ErrorBoundary'
 import { SupportPopUpToggle, SupportPopUp } from './SupportPopUp'
 // @ts-expect-error No types available
 import * as VelocityReact from 'velocity-react'
-import { MeteorReactComponent } from '../lib/MeteorReactComponent'
 import { translateWithTracker, Translated } from '../lib/ReactMeteorData/ReactMeteorData'
 import { Settings } from '../../lib/Settings'
 import { CoreSystem } from '../collections'
@@ -29,7 +28,7 @@ interface IStateHeader {
 	isSupportPanelOpen: boolean
 }
 
-class Header extends MeteorReactComponent<Translated<IPropsHeader & ITrackedPropsHeader>, IStateHeader> {
+class Header extends React.Component<Translated<IPropsHeader & ITrackedPropsHeader>, IStateHeader> {
 	constructor(props: Translated<IPropsHeader & ITrackedPropsHeader>) {
 		super(props)
 

--- a/meteor/client/ui/RundownList/GettingStarted.tsx
+++ b/meteor/client/ui/RundownList/GettingStarted.tsx
@@ -1,49 +1,40 @@
 import React from 'react'
 import Tooltip from 'rc-tooltip'
-import { withTranslation } from 'react-i18next'
-import { Translated } from '../../lib/ReactMeteorData/ReactMeteorData'
+import { useTranslation } from 'react-i18next'
 import { ToolTipStep } from '../RundownList'
 
 export interface IGettingStartedProps {
 	step: ToolTipStep
 }
 
-export const GettingStarted = withTranslation()(
-	class GettingStarted extends React.Component<Translated<IGettingStartedProps>> {
-		constructor(props: Translated<IGettingStartedProps>) {
-			super(props)
-		}
+export function GettingStarted({ step }: Readonly<IGettingStartedProps>): JSX.Element {
+	const { t } = useTranslation()
 
-		render(): JSX.Element {
-			const { t, step } = this.props
-
-			return (
-				<div className="mtl gutter has-statusbar">
-					<h1>{t('Getting Started')}</h1>
-					<div>
-						<ul>
-							<li>
-								{t('Start with giving this browser configuration permissions by adding this to the URL: ')}&nbsp;
-								<Tooltip overlay={t('Start Here!')} visible={step === ToolTipStep.TOOLTIP_START_HERE} placement="top">
-									<a href="?configure=1">?configure=1</a>
-								</Tooltip>
-							</li>
-							<li>
-								{t('Then, run the migrations script:')}&nbsp;
-								<Tooltip
-									overlay={t('Run Migrations to get set up')}
-									visible={step === ToolTipStep.TOOLTIP_RUN_MIGRATIONS}
-									placement="bottom"
-								>
-									<a href="/settings/tools/migration">{t('Migrations')}</a>
-								</Tooltip>
-							</li>
-						</ul>
-						{t('Documentation is available at')}&nbsp;
-						<a href="https://github.com/nrkno/Sofie-TV-automation/">https://github.com/nrkno/Sofie-TV-automation/</a>
-					</div>
-				</div>
-			)
-		}
-	}
-)
+	return (
+		<div className="mtl gutter has-statusbar">
+			<h1>{t('Getting Started')}</h1>
+			<div>
+				<ul>
+					<li>
+						{t('Start with giving this browser configuration permissions by adding this to the URL: ')}&nbsp;
+						<Tooltip overlay={t('Start Here!')} visible={step === ToolTipStep.TOOLTIP_START_HERE} placement="top">
+							<a href="?configure=1">?configure=1</a>
+						</Tooltip>
+					</li>
+					<li>
+						{t('Then, run the migrations script:')}&nbsp;
+						<Tooltip
+							overlay={t('Run Migrations to get set up')}
+							visible={step === ToolTipStep.TOOLTIP_RUN_MIGRATIONS}
+							placement="bottom"
+						>
+							<a href="/settings/tools/migration">{t('Migrations')}</a>
+						</Tooltip>
+					</li>
+				</ul>
+				{t('Documentation is available at')}&nbsp;
+				<a href="https://github.com/nrkno/Sofie-TV-automation/">https://github.com/nrkno/Sofie-TV-automation/</a>
+			</div>
+		</div>
+	)
+}

--- a/meteor/client/ui/RundownList/RegisterHelp.tsx
+++ b/meteor/client/ui/RundownList/RegisterHelp.tsx
@@ -1,8 +1,7 @@
 import React from 'react'
-import { withTranslation } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 import { literal } from '../../../lib/lib'
 import { ReactNotification } from '../../lib/notifications/ReactNotification'
-import { Translated } from '../../lib/ReactMeteorData/ReactMeteorData'
 import { ToolTipStep } from '../RundownList'
 import { NotificationAction } from '../../../lib/notifications/notifications'
 
@@ -10,49 +9,41 @@ export interface IRegisterHelpProps {
 	step: ToolTipStep
 }
 
-export const RegisterHelp = withTranslation()(
-	class RegisterHelp extends React.Component<Translated<IRegisterHelpProps>> {
-		constructor(props: Translated<IRegisterHelpProps>) {
-			super(props)
-		}
+export function RegisterHelp({ step }: Readonly<IRegisterHelpProps>): JSX.Element {
+	const { t } = useTranslation()
 
-		render(): JSX.Element {
-			const { t, step } = this.props
-
-			return (
-				<React.Fragment>
-					{step === ToolTipStep.TOOLTIP_START_HERE ? (
-						<ReactNotification
-							actions={[
-								literal<NotificationAction>({
-									label: 'Enable',
-									action: () => {
-										window.location.assign('/?configure=1')
-									},
-									type: 'button',
-								}),
-							]}
-						>
-							{t('Enable configuration mode by adding ?configure=1 to the address bar.')}
-						</ReactNotification>
-					) : undefined}
-					{step === ToolTipStep.TOOLTIP_START_HERE || step === ToolTipStep.TOOLTIP_RUN_MIGRATIONS ? (
-						<ReactNotification
-							actions={[
-								literal<NotificationAction>({
-									label: 'Go to migrations',
-									action: () => {
-										window.location.assign('/settings/tools/migration')
-									},
-									type: 'button',
-								}),
-							]}
-						>
-							{t('You need to run migrations to set the system up for operation.')}
-						</ReactNotification>
-					) : undefined}
-				</React.Fragment>
-			)
-		}
-	}
-)
+	return (
+		<React.Fragment>
+			{step === ToolTipStep.TOOLTIP_START_HERE ? (
+				<ReactNotification
+					actions={[
+						literal<NotificationAction>({
+							label: 'Enable',
+							action: () => {
+								window.location.assign('/?configure=1')
+							},
+							type: 'button',
+						}),
+					]}
+				>
+					{t('Enable configuration mode by adding ?configure=1 to the address bar.')}
+				</ReactNotification>
+			) : undefined}
+			{step === ToolTipStep.TOOLTIP_START_HERE || step === ToolTipStep.TOOLTIP_RUN_MIGRATIONS ? (
+				<ReactNotification
+					actions={[
+						literal<NotificationAction>({
+							label: 'Go to migrations',
+							action: () => {
+								window.location.assign('/settings/tools/migration')
+							},
+							type: 'button',
+						}),
+					]}
+				>
+					{t('You need to run migrations to set the system up for operation.')}
+				</ReactNotification>
+			) : undefined}
+		</React.Fragment>
+	)
+}

--- a/meteor/client/ui/RundownView/RundownTiming/NextBreakTiming.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming/NextBreakTiming.tsx
@@ -1,8 +1,7 @@
 import React from 'react'
-import { WithTranslation, withTranslation } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 import Moment from 'react-moment'
 import { Rundown } from '@sofie-automation/corelib/dist/dataModel/Rundown'
-import { Translated } from '../../../lib/ReactMeteorData/ReactMeteorData'
 import { WithTiming, withTiming } from './withTiming'
 import ClassNames from 'classnames'
 import { PlaylistTiming } from '@sofie-automation/corelib/dist/playout/rundownTiming'
@@ -14,34 +13,24 @@ interface INextBreakTimingProps {
 	lastChild?: boolean
 }
 
-export const NextBreakTiming = withTranslation()(
-	withTiming<INextBreakTimingProps & WithTranslation, {}>()(
-		class NextBreakTiming extends React.Component<Translated<WithTiming<INextBreakTimingProps>>> {
-			render(): JSX.Element | null {
-				const { t, rundownsBeforeBreak: _rundownsBeforeBreak } = this.props
-				const rundownsBeforeBreak = _rundownsBeforeBreak || this.props.timingDurations.rundownsBeforeNextBreak || []
-				const breakRundown = rundownsBeforeBreak.length
-					? rundownsBeforeBreak[rundownsBeforeBreak.length - 1]
-					: undefined
+export const NextBreakTiming = withTiming<INextBreakTimingProps, {}>()(function NextBreakTiming(
+	props: Readonly<WithTiming<INextBreakTimingProps>>
+): JSX.Element | null {
+	const { t } = useTranslation()
+	const { rundownsBeforeBreak: _rundownsBeforeBreak } = props
+	const rundownsBeforeBreak = _rundownsBeforeBreak || props.timingDurations.rundownsBeforeNextBreak || []
+	const breakRundown = rundownsBeforeBreak.length ? rundownsBeforeBreak[rundownsBeforeBreak.length - 1] : undefined
 
-				if (!breakRundown) {
-					return null
-				}
+	if (!breakRundown) {
+		return null
+	}
 
-				const expectedEnd = PlaylistTiming.getExpectedEnd(breakRundown.timing)
+	const expectedEnd = PlaylistTiming.getExpectedEnd(breakRundown.timing)
 
-				return (
-					<React.Fragment>
-						<span
-							className={ClassNames('timing-clock plan-end right', { 'visual-last-child': this.props.lastChild })}
-							role="timer"
-						>
-							<span className="timing-clock-label right">{t(this.props.breakText || 'Next Break')}</span>
-							<Moment interval={0} format="HH:mm:ss" date={expectedEnd} />
-						</span>
-					</React.Fragment>
-				)
-			}
-		}
+	return (
+		<span className={ClassNames('timing-clock plan-end right', { 'visual-last-child': props.lastChild })} role="timer">
+			<span className="timing-clock-label right">{t(props.breakText || 'Next Break')}</span>
+			<Moment interval={0} format="HH:mm:ss" date={expectedEnd} />
+		</span>
 	)
-)
+})

--- a/meteor/client/ui/RundownView/RundownTiming/RundownTimingProvider.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming/RundownTimingProvider.tsx
@@ -3,7 +3,6 @@ import { Meteor } from 'meteor/meteor'
 import * as PropTypes from 'prop-types'
 import { withTracker } from '../../../lib/ReactMeteorData/react-meteor-data'
 import { getCurrentTime, protectString } from '../../../../lib/lib'
-import { MeteorReactComponent } from '../../../lib/MeteorReactComponent'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { PartInstance, wrapPartToTemporaryInstance } from '../../../../lib/collections/PartInstances'
 import { RundownTiming, TimeEventArgs } from './RundownTiming'
@@ -183,7 +182,7 @@ export const RundownTimingProvider = withTracker<
 	}
 })(
 	class RundownTimingProvider
-		extends MeteorReactComponent<
+		extends React.Component<
 			PropsWithChildren<IRundownTimingProviderProps> & IRundownTimingProviderTrackedProps,
 			IRundownTimingProviderState
 		>
@@ -274,7 +273,6 @@ export const RundownTimingProvider = withTracker<
 		}
 
 		componentWillUnmount(): void {
-			this._cleanUp()
 			delete (window as any)['rundownTimingContext']
 			Meteor.clearInterval(this.refreshTimer)
 		}

--- a/meteor/client/ui/RundownView/RundownViewShelf.tsx
+++ b/meteor/client/ui/RundownView/RundownViewShelf.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import * as _ from 'underscore'
 import { Translated, translateWithTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { SegmentUi } from '../SegmentTimeline/SegmentTimelineContainer'
 import { unprotectString } from '../../../lib/lib'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
@@ -56,7 +55,7 @@ interface IRundownViewShelfState {
 	singleClickMode: boolean
 }
 
-class RundownViewShelfInner extends MeteorReactComponent<
+class RundownViewShelfInner extends React.Component<
 	Translated<IRundownViewShelfProps & IRundownViewShelfTrackedProps>,
 	IRundownViewShelfState
 > {

--- a/meteor/client/ui/SegmentTimeline/BreakSegment.tsx
+++ b/meteor/client/ui/SegmentTimeline/BreakSegment.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { WithTranslation, withTranslation } from 'react-i18next'
 import Moment from 'react-moment'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { Translated } from '../../lib/ReactMeteorData/ReactMeteorData'
 import { RundownUtils } from '../../lib/rundown'
 import { WithTiming, withTiming } from '../RundownView/RundownTiming/withTiming'
@@ -10,7 +9,7 @@ interface IProps {
 	breakTime: number | undefined
 }
 
-class BreakSegmentInner extends MeteorReactComponent<Translated<WithTiming<IProps>>> {
+class BreakSegmentInner extends React.Component<Translated<WithTiming<IProps>>> {
 	constructor(props: Translated<WithTiming<IProps>>) {
 		super(props)
 	}

--- a/meteor/client/ui/Settings/BlueprintSettings.tsx
+++ b/meteor/client/ui/Settings/BlueprintSettings.tsx
@@ -3,7 +3,6 @@ import { EditAttribute } from '../../lib/EditAttribute'
 import { Translated, translateWithTracker } from '../../lib/ReactMeteorData/react-meteor-data'
 import { Spinner } from '../../lib/Spinner'
 import { doModalDialog } from '../../lib/ModalDialog'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { Blueprint } from '@sofie-automation/corelib/dist/dataModel/Blueprint'
 import Moment from 'react-moment'
 import { Link } from 'react-router-dom'
@@ -45,7 +44,7 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 		assignedSystem: CoreSystem.findOne({ blueprintId: id }),
 	}
 })(
-	class BlueprintSettings extends MeteorReactComponent<Translated<IProps & ITrackedProps>, IState> {
+	class BlueprintSettings extends React.Component<Translated<IProps & ITrackedProps>, IState> {
 		constructor(props: Translated<IProps & ITrackedProps>) {
 			super(props)
 			this.state = {

--- a/meteor/client/ui/Settings/DeviceSettings.tsx
+++ b/meteor/client/ui/Settings/DeviceSettings.tsx
@@ -9,7 +9,6 @@ import { EditAttribute } from '../../lib/EditAttribute'
 import { doModalDialog } from '../../lib/ModalDialog'
 import { Translated, translateWithTracker } from '../../lib/ReactMeteorData/react-meteor-data'
 import { Spinner } from '../../lib/Spinner'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { PeripheralDevicesAPI } from '../../lib/clientAPI'
 
 import { NotificationCenter, Notification, NoticeLevel } from '../../../lib/notifications/notifications'
@@ -46,7 +45,7 @@ export default translateWithTracker<IDeviceSettingsProps, IDeviceSettingsState, 
 		}
 	}
 )(
-	class DeviceSettings extends MeteorReactComponent<Translated<IDeviceSettingsProps & IDeviceSettingsTrackedProps>> {
+	class DeviceSettings extends React.Component<Translated<IDeviceSettingsProps & IDeviceSettingsTrackedProps>> {
 		renderSpecifics() {
 			if (this.props.device && this.props.device.subType === PERIPHERAL_SUBTYPE_PROCESS) {
 				if (this.props.device.configManifest) {

--- a/meteor/client/ui/Settings/Migration.tsx
+++ b/meteor/client/ui/Settings/Migration.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { Translated, translateWithTracker } from '../../lib/ReactMeteorData/react-meteor-data'
 import { doModalDialog } from '../../lib/ModalDialog'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import ClassNames from 'classnames'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faClipboardCheck, faDatabase, faCoffee, faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons'
@@ -47,7 +46,7 @@ interface ITrackedProps {}
 export const MigrationView = translateWithTracker<IProps, IState, ITrackedProps>((_props: IProps) => {
 	return {}
 })(
-	class MigrationView extends MeteorReactComponent<Translated<IProps & ITrackedProps>, IState> {
+	class MigrationView extends React.Component<Translated<IProps & ITrackedProps>, IState> {
 		private cancelRequests: boolean
 		constructor(props: Translated<IProps & ITrackedProps>) {
 			super(props)
@@ -67,7 +66,6 @@ export const MigrationView = translateWithTracker<IProps, IState, ITrackedProps>
 			this.updateVersions()
 		}
 		componentWillUnmount(): void {
-			super.componentWillUnmount()
 			this.cancelRequests = true
 		}
 		clickRefresh() {

--- a/meteor/client/ui/Settings/ShowStyleBaseSettings.tsx
+++ b/meteor/client/ui/Settings/ShowStyleBaseSettings.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { Translated, translateWithTracker } from '../../lib/ReactMeteorData/react-meteor-data'
 import { Spinner } from '../../lib/Spinner'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { OutputLayers, DBShowStyleBase, SourceLayers } from '@sofie-automation/corelib/dist/dataModel/ShowStyleBase'
 import { DBShowStyleVariant } from '@sofie-automation/corelib/dist/dataModel/ShowStyleVariant'
 import RundownLayoutEditor from './RundownLayoutEditor'
@@ -100,7 +99,7 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 		layerMappings: mappings,
 	}
 })(
-	class ShowStyleBaseSettings extends MeteorReactComponent<Translated<IProps & ITrackedProps>, IState> {
+	class ShowStyleBaseSettings extends React.Component<Translated<IProps & ITrackedProps>, IState> {
 		constructor(props: Translated<IProps & ITrackedProps>) {
 			super(props)
 			this.state = {

--- a/meteor/client/ui/Settings/SystemManagement.tsx
+++ b/meteor/client/ui/Settings/SystemManagement.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { translateWithTracker, Translated } from '../../lib/ReactMeteorData/ReactMeteorData'
 import { ICoreSystem, SofieLogo } from '../../../lib/collections/CoreSystem'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { meteorSubscribe, MeteorPubSub } from '../../../lib/api/pubsub'
 import { EditAttribute } from '../../lib/EditAttribute'
 import { doModalDialog } from '../../lib/ModalDialog'
@@ -28,7 +27,7 @@ export default translateWithTracker<IProps, {}, ITrackedProps>((_props: IProps) 
 		coreSystem: CoreSystem.findOne(),
 	}
 })(
-	class SystemManagement extends MeteorReactComponent<Translated<IProps & ITrackedProps>> {
+	class SystemManagement extends React.Component<Translated<IProps & ITrackedProps>> {
 		componentDidMount(): void {
 			meteorSubscribe(MeteorPubSub.coreSystem)
 		}

--- a/meteor/client/ui/Settings/components/rundownLayouts/RundownHeaderLayoutSettings.tsx
+++ b/meteor/client/ui/Settings/components/rundownLayouts/RundownHeaderLayoutSettings.tsx
@@ -1,92 +1,86 @@
 import React from 'react'
-import { withTranslation } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 import { RundownLayouts } from '../../../../collections'
 import { RundownLayoutBase, RundownLayoutType } from '../../../../../lib/collections/RundownLayouts'
 import { EditAttribute } from '../../../../lib/EditAttribute'
-import { MeteorReactComponent } from '../../../../lib/MeteorReactComponent'
-import { Translated } from '../../../../lib/ReactMeteorData/ReactMeteorData'
 import { LabelActual } from '../../../../lib/Components/LabelAndOverrides'
 
 interface IProps {
 	item: RundownLayoutBase
 }
 
-interface IState {}
+export default function RundownHeaderLayoutSettings(props: Readonly<IProps>): JSX.Element | null {
+	const { t } = useTranslation()
 
-export default withTranslation()(
-	class RundownHeaderLayoutSettings extends MeteorReactComponent<Translated<IProps>, IState> {
-		render(): JSX.Element | null {
-			const { t } = this.props
+	if (props.item.type !== RundownLayoutType.RUNDOWN_HEADER_LAYOUT) return null
 
-			return this.props.item.type === RundownLayoutType.RUNDOWN_HEADER_LAYOUT ? (
-				<React.Fragment>
-					<label className="field">
-						<LabelActual label={t('Expected End text')} />
-						<EditAttribute
-							modifiedClassName="bghl"
-							attribute={'plannedEndText'}
-							obj={this.props.item}
-							type="text"
-							collection={RundownLayouts}
-							className="input text-input input-l"
-						></EditAttribute>
-						<span className="text-s dimmed field-hint">{t('Text to show above countdown to end of show')}</span>
-					</label>
+	return (
+		<React.Fragment>
+			<label className="field">
+				<LabelActual label={t('Expected End text')} />
+				<EditAttribute
+					modifiedClassName="bghl"
+					attribute={'plannedEndText'}
+					obj={props.item}
+					type="text"
+					collection={RundownLayouts}
+					className="input text-input input-l"
+				></EditAttribute>
+				<span className="text-s dimmed field-hint">{t('Text to show above countdown to end of show')}</span>
+			</label>
 
-					<label className="field">
-						<LabelActual label={t('Hide Expected End timing when a break is next')} />
-						<EditAttribute
-							modifiedClassName="bghl"
-							attribute={'hideExpectedEndBeforeBreak'}
-							obj={this.props.item}
-							type="checkbox"
-							collection={RundownLayouts}
-							className="input"
-						></EditAttribute>
-						<span className="text-s dimmed field-hint">
-							{t('While there are still breaks coming up in the show, hide the Expected End timers')}
-						</span>
-					</label>
-					<label className="field">
-						<LabelActual label={t('Show next break timing')} />
-						<EditAttribute
-							modifiedClassName="bghl"
-							attribute={'showNextBreakTiming'}
-							obj={this.props.item}
-							type="checkbox"
-							collection={RundownLayouts}
-							className="input"
-						></EditAttribute>
-						<span className="text-s dimmed field-hint">{t('Whether to show countdown to next break')}</span>
-					</label>
-					<label className="field">
-						<LabelActual label={t('Last rundown is not break')} />
-						<EditAttribute
-							modifiedClassName="bghl"
-							attribute={'lastRundownIsNotBreak'}
-							obj={this.props.item}
-							type="checkbox"
-							collection={RundownLayouts}
-							className="input"
-						></EditAttribute>
-						<span className="text-s dimmed field-hint">
-							{t("Don't treat the end of the last rundown in a playlist as a break")}
-						</span>
-					</label>
-					<label className="field">
-						<LabelActual label={t('Next Break text')} />
-						<EditAttribute
-							modifiedClassName="bghl"
-							attribute={'nextBreakText'}
-							obj={this.props.item}
-							type="text"
-							collection={RundownLayouts}
-							className="input text-input input-l"
-						></EditAttribute>
-						<span className="text-s dimmed field-hint">{t('Text to show above countdown to next break')}</span>
-					</label>
-				</React.Fragment>
-			) : null
-		}
-	}
-)
+			<label className="field">
+				<LabelActual label={t('Hide Expected End timing when a break is next')} />
+				<EditAttribute
+					modifiedClassName="bghl"
+					attribute={'hideExpectedEndBeforeBreak'}
+					obj={props.item}
+					type="checkbox"
+					collection={RundownLayouts}
+					className="input"
+				></EditAttribute>
+				<span className="text-s dimmed field-hint">
+					{t('While there are still breaks coming up in the show, hide the Expected End timers')}
+				</span>
+			</label>
+			<label className="field">
+				<LabelActual label={t('Show next break timing')} />
+				<EditAttribute
+					modifiedClassName="bghl"
+					attribute={'showNextBreakTiming'}
+					obj={props.item}
+					type="checkbox"
+					collection={RundownLayouts}
+					className="input"
+				></EditAttribute>
+				<span className="text-s dimmed field-hint">{t('Whether to show countdown to next break')}</span>
+			</label>
+			<label className="field">
+				<LabelActual label={t('Last rundown is not break')} />
+				<EditAttribute
+					modifiedClassName="bghl"
+					attribute={'lastRundownIsNotBreak'}
+					obj={props.item}
+					type="checkbox"
+					collection={RundownLayouts}
+					className="input"
+				></EditAttribute>
+				<span className="text-s dimmed field-hint">
+					{t("Don't treat the end of the last rundown in a playlist as a break")}
+				</span>
+			</label>
+			<label className="field">
+				<LabelActual label={t('Next Break text')} />
+				<EditAttribute
+					modifiedClassName="bghl"
+					attribute={'nextBreakText'}
+					obj={props.item}
+					type="text"
+					collection={RundownLayouts}
+					className="input text-input input-l"
+				></EditAttribute>
+				<span className="text-s dimmed field-hint">{t('Text to show above countdown to next break')}</span>
+			</label>
+		</React.Fragment>
+	)
+}

--- a/meteor/client/ui/Settings/components/rundownLayouts/ShelfLayoutSettings.tsx
+++ b/meteor/client/ui/Settings/components/rundownLayouts/ShelfLayoutSettings.tsx
@@ -1,102 +1,94 @@
 import React from 'react'
-import { withTranslation } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 import { RundownLayouts } from '../../../../collections'
 import { RundownLayoutBase, RundownLayoutType } from '../../../../../lib/collections/RundownLayouts'
 import { EditAttribute } from '../../../../lib/EditAttribute'
-import { MeteorReactComponent } from '../../../../lib/MeteorReactComponent'
-import { Translated } from '../../../../lib/ReactMeteorData/ReactMeteorData'
 import { LabelActual } from '../../../../lib/Components/LabelAndOverrides'
 
 interface IProps {
 	item: RundownLayoutBase
 }
 
-interface IState {}
+export default function ShelfLayoutSettings(props: Readonly<IProps>): JSX.Element {
+	const { t } = useTranslation()
 
-export default withTranslation()(
-	class ShelfLayoutSettings extends MeteorReactComponent<Translated<IProps>, IState> {
-		render(): JSX.Element {
-			const { t } = this.props
+	return (
+		<React.Fragment>
+			<label className="field">
+				<LabelActual label={t('Expose layout as a standalone page')} />
+				<EditAttribute
+					modifiedClassName="bghl"
+					attribute={'exposeAsStandalone'}
+					obj={props.item}
+					type="checkbox"
+					collection={RundownLayouts}
+					className="mod mas"
+				></EditAttribute>
+			</label>
 
-			return (
-				<React.Fragment>
-					<label className="field">
-						<LabelActual label={t('Expose layout as a standalone page')} />
-						<EditAttribute
-							modifiedClassName="bghl"
-							attribute={'exposeAsStandalone'}
-							obj={this.props.item}
-							type="checkbox"
-							collection={RundownLayouts}
-							className="mod mas"
-						></EditAttribute>
-					</label>
+			<label className="field">
+				<LabelActual label={t('Open shelf by default')} />
+				<EditAttribute
+					modifiedClassName="bghl"
+					attribute={'openByDefault'}
+					obj={props.item}
+					type="checkbox"
+					collection={RundownLayouts}
+					className="mod mas"
+				></EditAttribute>
+			</label>
 
-					<label className="field">
-						<LabelActual label={t('Open shelf by default')} />
-						<EditAttribute
-							modifiedClassName="bghl"
-							attribute={'openByDefault'}
-							obj={this.props.item}
-							type="checkbox"
-							collection={RundownLayouts}
-							className="mod mas"
-						></EditAttribute>
-					</label>
+			<label className="field">
+				<LabelActual label={t('Default shelf height')} />
+				<EditAttribute
+					modifiedClassName="bghl"
+					attribute={`startingHeight`}
+					obj={props.item}
+					type="int"
+					collection={RundownLayouts}
+					className="input text-input input-l"
+				/>
+			</label>
 
-					<label className="field">
-						<LabelActual label={t('Default shelf height')} />
-						<EditAttribute
-							modifiedClassName="bghl"
-							attribute={`startingHeight`}
-							obj={this.props.item}
-							type="int"
-							collection={RundownLayouts}
-							className="input text-input input-l"
-						/>
-					</label>
+			<label className="field">
+				<LabelActual label={t('Disable Context Menu')} />
+				<EditAttribute
+					modifiedClassName="bghl"
+					attribute={'disableContextMenu'}
+					obj={props.item}
+					options={RundownLayoutType}
+					type="checkbox"
+					collection={RundownLayouts}
+					className="mod mas"
+				></EditAttribute>
+			</label>
 
-					<label className="field">
-						<LabelActual label={t('Disable Context Menu')} />
-						<EditAttribute
-							modifiedClassName="bghl"
-							attribute={'disableContextMenu'}
-							obj={this.props.item}
-							options={RundownLayoutType}
-							type="checkbox"
-							collection={RundownLayouts}
-							className="mod mas"
-						></EditAttribute>
-					</label>
+			<label className="field">
+				<LabelActual label={t('Show Inspector')} />
+				<EditAttribute
+					modifiedClassName="bghl"
+					attribute={'showInspector'}
+					obj={props.item}
+					options={RundownLayoutType}
+					type="checkbox"
+					collection={RundownLayouts}
+					className="mod mas"
+				></EditAttribute>
+			</label>
 
-					<label className="field">
-						<LabelActual label={t('Show Inspector')} />
-						<EditAttribute
-							modifiedClassName="bghl"
-							attribute={'showInspector'}
-							obj={this.props.item}
-							options={RundownLayoutType}
-							type="checkbox"
-							collection={RundownLayouts}
-							className="mod mas"
-						></EditAttribute>
-					</label>
-
-					<label className="field">
-						<LabelActual label={t('Hide default AdLib Start/Execute options')} />
-						<EditAttribute
-							modifiedClassName="bghl"
-							attribute={'hideDefaultStartExecute'}
-							obj={this.props.item}
-							options={RundownLayoutType}
-							type="checkbox"
-							collection={RundownLayouts}
-							className="mod mas"
-						></EditAttribute>
-						<span className="text-s dimmed field-hint">{t('Only custom trigger modes will be shown')}</span>
-					</label>
-				</React.Fragment>
-			)
-		}
-	}
-)
+			<label className="field">
+				<LabelActual label={t('Hide default AdLib Start/Execute options')} />
+				<EditAttribute
+					modifiedClassName="bghl"
+					attribute={'hideDefaultStartExecute'}
+					obj={props.item}
+					options={RundownLayoutType}
+					type="checkbox"
+					collection={RundownLayouts}
+					className="mod mas"
+				></EditAttribute>
+				<span className="text-s dimmed field-hint">{t('Only custom trigger modes will be shown')}</span>
+			</label>
+		</React.Fragment>
+	)
+}

--- a/meteor/client/ui/Shelf/AdLibListItem.tsx
+++ b/meteor/client/ui/Shelf/AdLibListItem.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import ClassNames from 'classnames'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { ISourceLayer, IOutputLayer, IBlueprintActionTriggerMode } from '@sofie-automation/blueprints-integration'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { unprotectString } from '../../../lib/lib'
@@ -32,7 +31,7 @@ interface IListViewItemProps {
 }
 
 export const AdLibListItem = withMediaObjectStatus<IListViewItemProps, {}>()(
-	class AdLibListItem extends MeteorReactComponent<IListViewItemProps> {
+	class AdLibListItem extends React.Component<IListViewItemProps> {
 		constructor(props: IListViewItemProps) {
 			super(props)
 		}

--- a/meteor/client/ui/Shelf/AdLibRegionPanel.tsx
+++ b/meteor/client/ui/Shelf/AdLibRegionPanel.tsx
@@ -13,7 +13,6 @@ import { IAdLibPanelProps, AdLibFetchAndFilterProps, fetchAndFilter } from './Ad
 import { matchFilter } from './AdLibListView'
 import { doUserAction, UserAction } from '../../../lib/clientUserAction'
 import { translateWithTracker, Translated } from '../../lib/ReactMeteorData/ReactMeteorData'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { NotificationCenter, Notification, NoticeLevel } from '../../../lib/notifications/notifications'
 import { MeteorCall } from '../../../lib/api/methods'
 import {
@@ -49,7 +48,7 @@ interface IAdLibRegionPanelTrackedProps extends IDashboardPanelTrackedProps {
 	isLiveLine: boolean
 }
 
-class AdLibRegionPanelBase extends MeteorReactComponent<
+class AdLibRegionPanelBase extends React.Component<
 	Translated<IAdLibPanelProps & IAdLibRegionPanelProps & AdLibFetchAndFilterProps & IAdLibRegionPanelTrackedProps>,
 	IState
 > {

--- a/meteor/client/ui/Shelf/ColoredBoxPanel.tsx
+++ b/meteor/client/ui/Shelf/ColoredBoxPanel.tsx
@@ -4,12 +4,9 @@ import {
 	RundownLayoutBase,
 	RundownLayoutColoredBox,
 } from '../../../lib/collections/RundownLayouts'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { dashboardElementStyle } from './DashboardPanel'
 import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
-import { Translated } from '../../lib/ReactMeteorData/ReactMeteorData'
-import { withTranslation } from 'react-i18next'
 
 interface IColoredBoxPanelProps {
 	visible?: boolean
@@ -18,23 +15,18 @@ interface IColoredBoxPanelProps {
 	playlist: DBRundownPlaylist
 }
 
-interface IState {}
-class ColoredBoxPanelInner extends MeteorReactComponent<Translated<IColoredBoxPanelProps>, IState> {
-	render(): JSX.Element {
-		const isDashboardLayout = RundownLayoutsAPI.isDashboardLayout(this.props.layout)
+export function ColoredBoxPanel(props: Readonly<IColoredBoxPanelProps>): JSX.Element {
+	const isDashboardLayout = RundownLayoutsAPI.isDashboardLayout(props.layout)
 
-		return (
-			<div
-				className="colored-box-panel"
-				style={{
-					backgroundColor: this.props.panel.iconColor ?? 'transparent',
-					...(isDashboardLayout ? dashboardElementStyle(this.props.panel as DashboardLayoutColoredBox) : {}),
-				}}
-			>
-				<div className="wrapper"></div>
-			</div>
-		)
-	}
+	return (
+		<div
+			className="colored-box-panel"
+			style={{
+				backgroundColor: props.panel.iconColor ?? 'transparent',
+				...(isDashboardLayout ? dashboardElementStyle(props.panel as DashboardLayoutColoredBox) : {}),
+			}}
+		>
+			<div className="wrapper"></div>
+		</div>
+	)
 }
-
-export const ColoredBoxPanel = withTranslation()(ColoredBoxPanelInner)

--- a/meteor/client/ui/Shelf/DashboardPieceButton.tsx
+++ b/meteor/client/ui/Shelf/DashboardPieceButton.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { Meteor } from 'meteor/meteor'
 import ClassNames from 'classnames'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { RundownUtils } from '../../lib/rundown'
 import {
 	ISourceLayer,
@@ -63,7 +62,7 @@ interface IState {
 	active: boolean
 }
 
-export class DashboardPieceButtonBase<T = {}> extends MeteorReactComponent<
+export class DashboardPieceButtonBase<T = {}> extends React.Component<
 	React.PropsWithChildren<IDashboardButtonProps> & T,
 	IState
 > {
@@ -99,7 +98,6 @@ export class DashboardPieceButtonBase<T = {}> extends MeteorReactComponent<
 	}
 
 	componentWillUnmount(): void {
-		super.componentWillUnmount()
 		if (this.hoverTimeout) {
 			clearTimeout(this.hoverTimeout)
 			this.hoverTimeout = null

--- a/meteor/client/ui/Shelf/EndWordsPanel.tsx
+++ b/meteor/client/ui/Shelf/EndWordsPanel.tsx
@@ -9,7 +9,6 @@ import {
 import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
 import { dashboardElementStyle } from './DashboardPanel'
 import { Translated, translateWithTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { PieceInstance } from '@sofie-automation/corelib/dist/dataModel/PieceInstance'
 import { ScriptContent } from '@sofie-automation/blueprints-integration'
@@ -33,7 +32,7 @@ interface IEndsWordsPanelTrackedProps {
 
 interface IState {}
 
-class EndWordsPanelInner extends MeteorReactComponent<
+class EndWordsPanelInner extends React.Component<
 	Translated<IEndsWordsPanelProps & IEndsWordsPanelTrackedProps>,
 	IState
 > {

--- a/meteor/client/ui/Shelf/Inspector/ItemRenderers/ActionItemRenderer.tsx
+++ b/meteor/client/ui/Shelf/Inspector/ItemRenderers/ActionItemRenderer.tsx
@@ -4,7 +4,6 @@ import { PieceUi } from '../../../SegmentTimeline/SegmentTimelineContainer'
 import { RundownUtils } from '../../../../lib/rundown'
 import { Piece } from '@sofie-automation/corelib/dist/dataModel/Piece'
 import { IBlueprintActionTriggerMode } from '@sofie-automation/blueprints-integration'
-import { MeteorReactComponent } from '../../../../lib/MeteorReactComponent'
 import { translateWithTracker, Translated } from '../../../../lib/ReactMeteorData/ReactMeteorData'
 import { AdLibActionCommon } from '@sofie-automation/corelib/dist/dataModel/AdlibAction'
 import { createInMemorySyncMongoCollection } from '../../../../../lib/collections/lib'
@@ -86,7 +85,7 @@ export default translateWithTracker<IProps, {}, ITrackedProps>((props: IProps) =
 			.map((bucket) => bucket._id),
 	}
 })(
-	class ActionItemRenderer extends MeteorReactComponent<Translated<IProps & ITrackedProps>> {
+	class ActionItemRenderer extends React.Component<Translated<IProps & ITrackedProps>> {
 		componentDidMount(): void {
 			const action = this.getActionItem()
 
@@ -134,8 +133,6 @@ export default translateWithTracker<IProps, {}, ITrackedProps>((props: IProps) =
 		}
 
 		componentWillUnmount(): void {
-			super.componentWillUnmount()
-
 			if (this.props.targetAction) {
 				LocalActionItems.remove(this.props.targetAction._id)
 			}

--- a/meteor/client/ui/Shelf/MiniRundownPanel.tsx
+++ b/meteor/client/ui/Shelf/MiniRundownPanel.tsx
@@ -8,7 +8,6 @@ import {
 } from '../../../lib/collections/RundownLayouts'
 import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
 import { withTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { PartInstance } from '../../../lib/collections/PartInstances'
 import { DBSegment } from '@sofie-automation/corelib/dist/dataModel/Segment'
@@ -40,9 +39,7 @@ interface MiniRundownSegment {
 	cssClass: string
 }
 
-export class MiniRundownPanelInner extends MeteorReactComponent<
-	IMiniRundownPanelProps & IMiniRundownPanelTrackedProps
-> {
+export class MiniRundownPanelInner extends React.Component<IMiniRundownPanelProps & IMiniRundownPanelTrackedProps> {
 	static currentSegmentCssClass = 'current-segment'
 	static nextSegmentCssClass = 'next-segment'
 	static panelContainerId = 'mini-rundown-panel__container'

--- a/meteor/client/ui/Shelf/NextBreakTimingPanel.tsx
+++ b/meteor/client/ui/Shelf/NextBreakTimingPanel.tsx
@@ -8,7 +8,6 @@ import {
 import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
 import { dashboardElementStyle } from './DashboardPanel'
 import { Translated } from '../../lib/ReactMeteorData/ReactMeteorData'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { withTranslation } from 'react-i18next'
 import { NextBreakTiming } from '../RundownView/RundownTiming/NextBreakTiming'
@@ -20,7 +19,7 @@ interface INextBreakTimingPanelProps {
 	playlist: DBRundownPlaylist
 }
 
-export class NextBreakTimingPanelInner extends MeteorReactComponent<Translated<INextBreakTimingPanelProps>> {
+export class NextBreakTimingPanelInner extends React.Component<Translated<INextBreakTimingPanelProps>> {
 	render(): JSX.Element {
 		const { playlist, panel, layout } = this.props
 

--- a/meteor/client/ui/Shelf/NextInfoPanel.tsx
+++ b/meteor/client/ui/Shelf/NextInfoPanel.tsx
@@ -8,7 +8,6 @@ import {
 } from '../../../lib/collections/RundownLayouts'
 import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
 import { withTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { PartInstance } from '../../../lib/collections/PartInstances'
 import { DBSegment } from '@sofie-automation/corelib/dist/dataModel/Segment'
@@ -27,7 +26,7 @@ interface INextInfoPanelTrackedProps {
 	nextSegment?: DBSegment
 }
 
-export class NextInfoPanelInner extends MeteorReactComponent<INextInfoPanelProps & INextInfoPanelTrackedProps> {
+export class NextInfoPanelInner extends React.Component<INextInfoPanelProps & INextInfoPanelTrackedProps> {
 	render(): JSX.Element {
 		const isDashboardLayout = RundownLayoutsAPI.isDashboardLayout(this.props.layout)
 		const showAny =

--- a/meteor/client/ui/Shelf/PartNamePanel.tsx
+++ b/meteor/client/ui/Shelf/PartNamePanel.tsx
@@ -6,7 +6,6 @@ import {
 	RundownLayoutBase,
 	RundownLayoutPartName,
 } from '../../../lib/collections/RundownLayouts'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { dashboardElementStyle } from './DashboardPanel'
 import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
@@ -33,10 +32,7 @@ interface IPartNamePanelTrackedProps {
 	instanceToShow?: IFoundPieceInstance
 }
 
-class PartNamePanelInner extends MeteorReactComponent<
-	Translated<IPartNamePanelProps & IPartNamePanelTrackedProps>,
-	IState
-> {
+class PartNamePanelInner extends React.Component<Translated<IPartNamePanelProps & IPartNamePanelTrackedProps>, IState> {
 	render(): JSX.Element {
 		const isDashboardLayout = RundownLayoutsAPI.isDashboardLayout(this.props.layout)
 		const { t } = this.props

--- a/meteor/client/ui/Shelf/PartTimingPanel.tsx
+++ b/meteor/client/ui/Shelf/PartTimingPanel.tsx
@@ -6,7 +6,6 @@ import {
 	RundownLayoutPartTiming,
 } from '../../../lib/collections/RundownLayouts'
 import { Translated, translateWithTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { PartInstance } from '../../../lib/collections/PartInstances'
 import { dashboardElementStyle } from './DashboardPanel'
@@ -33,7 +32,7 @@ interface IPartTimingPanelTrackedProps {
 
 interface IState {}
 
-class PartTimingPanelInner extends MeteorReactComponent<
+class PartTimingPanelInner extends React.Component<
 	Translated<IPartTimingPanelProps & IPartTimingPanelTrackedProps>,
 	IState
 > {

--- a/meteor/client/ui/Shelf/PieceCountdownPanel.tsx
+++ b/meteor/client/ui/Shelf/PieceCountdownPanel.tsx
@@ -9,7 +9,6 @@ import {
 import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
 import { dashboardElementStyle } from './DashboardPanel'
 import { withTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { RundownUtils } from '../../lib/rundown'
 import { RundownTiming, TimingEvent } from '../RundownView/RundownTiming/RundownTiming'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
@@ -34,7 +33,7 @@ interface IState {
 	displayTimecode: number
 }
 
-export class PieceCountdownPanelInner extends MeteorReactComponent<
+export class PieceCountdownPanelInner extends React.Component<
 	IPieceCountdownPanelProps & IPieceCountdownPanelTrackedProps,
 	IState
 > {

--- a/meteor/client/ui/Shelf/PlaylistEndTimerPanel.tsx
+++ b/meteor/client/ui/Shelf/PlaylistEndTimerPanel.tsx
@@ -7,10 +7,7 @@ import {
 } from '../../../lib/collections/RundownLayouts'
 import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
 import { dashboardElementStyle } from './DashboardPanel'
-import { Translated } from '../../lib/ReactMeteorData/ReactMeteorData'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
-import { withTranslation } from 'react-i18next'
 import { PlaylistEndTiming } from '../RundownView/RundownTiming/PlaylistEndTiming'
 import { PlaylistTiming } from '@sofie-automation/corelib/dist/playout/rundownTiming'
 
@@ -21,39 +18,31 @@ interface IPlaylistEndTimerPanelProps {
 	playlist: DBRundownPlaylist
 }
 
-interface IState {}
+export function PlaylistEndTimerPanel({ playlist, panel, layout }: Readonly<IPlaylistEndTimerPanelProps>): JSX.Element {
+	const isDashboardLayout = RundownLayoutsAPI.isDashboardLayout(layout)
 
-export class PlaylistEndTimerPanelInner extends MeteorReactComponent<Translated<IPlaylistEndTimerPanelProps>, IState> {
-	render(): JSX.Element {
-		const { playlist, panel, layout } = this.props
-
-		const isDashboardLayout = RundownLayoutsAPI.isDashboardLayout(layout)
-
-		return (
-			<div
-				className={ClassNames(
-					'playlist-end-time-panel timing',
-					isDashboardLayout ? (panel as DashboardLayoutPlaylistEndTimer).customClasses : undefined
-				)}
-				style={isDashboardLayout ? dashboardElementStyle(panel as DashboardLayoutPlaylistEndTimer) : {}}
-			>
-				<PlaylistEndTiming
-					rundownPlaylist={this.props.playlist}
-					loop={playlist.loop}
-					expectedStart={PlaylistTiming.getExpectedStart(playlist.timing)}
-					expectedEnd={PlaylistTiming.getExpectedEnd(playlist.timing)}
-					expectedDuration={PlaylistTiming.getExpectedDuration(playlist.timing)}
-					endLabel={panel.plannedEndText}
-					hidePlannedEndLabel={panel.hidePlannedEndLabel}
-					hideDiffLabel={panel.hideDiffLabel}
-					hideCountdown={panel.hideCountdown}
-					hideDiff={panel.hideDiff}
-					hidePlannedEnd={panel.hidePlannedEnd}
-					rundownCount={0}
-				/>
-			</div>
-		)
-	}
+	return (
+		<div
+			className={ClassNames(
+				'playlist-end-time-panel timing',
+				isDashboardLayout ? (panel as DashboardLayoutPlaylistEndTimer).customClasses : undefined
+			)}
+			style={isDashboardLayout ? dashboardElementStyle(panel as DashboardLayoutPlaylistEndTimer) : {}}
+		>
+			<PlaylistEndTiming
+				rundownPlaylist={playlist}
+				loop={playlist.loop}
+				expectedStart={PlaylistTiming.getExpectedStart(playlist.timing)}
+				expectedEnd={PlaylistTiming.getExpectedEnd(playlist.timing)}
+				expectedDuration={PlaylistTiming.getExpectedDuration(playlist.timing)}
+				endLabel={panel.plannedEndText}
+				hidePlannedEndLabel={panel.hidePlannedEndLabel}
+				hideDiffLabel={panel.hideDiffLabel}
+				hideCountdown={panel.hideCountdown}
+				hideDiff={panel.hideDiff}
+				hidePlannedEnd={panel.hidePlannedEnd}
+				rundownCount={0}
+			/>
+		</div>
+	)
 }
-
-export const PlaylistEndTimerPanel = withTranslation()(PlaylistEndTimerPanelInner)

--- a/meteor/client/ui/Shelf/PlaylistNamePanel.tsx
+++ b/meteor/client/ui/Shelf/PlaylistNamePanel.tsx
@@ -5,7 +5,6 @@ import {
 	RundownLayoutBase,
 	RundownLayoutPlaylistName,
 } from '../../../lib/collections/RundownLayouts'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { dashboardElementStyle } from './DashboardPanel'
 import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
@@ -29,10 +28,7 @@ interface IPlaylistNamePanelTrackedProps {
 	currentRundown?: Rundown
 }
 
-class PlaylistNamePanelInner extends MeteorReactComponent<
-	IPlaylistNamePanelProps & IPlaylistNamePanelTrackedProps,
-	IState
-> {
+class PlaylistNamePanelInner extends React.Component<IPlaylistNamePanelProps & IPlaylistNamePanelTrackedProps, IState> {
 	render(): JSX.Element {
 		const isDashboardLayout = RundownLayoutsAPI.isDashboardLayout(this.props.layout)
 		const { panel } = this.props

--- a/meteor/client/ui/Shelf/PlaylistStartTimerPanel.tsx
+++ b/meteor/client/ui/Shelf/PlaylistStartTimerPanel.tsx
@@ -7,10 +7,7 @@ import {
 } from '../../../lib/collections/RundownLayouts'
 import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
 import { dashboardElementStyle } from './DashboardPanel'
-import { Translated } from '../../lib/ReactMeteorData/ReactMeteorData'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
-import { withTranslation } from 'react-i18next'
 import { PlaylistStartTiming } from '../RundownView/RundownTiming/PlaylistStartTiming'
 
 interface IPlaylistStartTimerPanelProps {
@@ -19,29 +16,27 @@ interface IPlaylistStartTimerPanelProps {
 	playlist: DBRundownPlaylist
 }
 
-interface IState {}
+export function PlaylistStartTimerPanel({
+	playlist,
+	panel,
+	layout,
+}: Readonly<IPlaylistStartTimerPanelProps>): JSX.Element {
+	const isDashboardLayout = RundownLayoutsAPI.isDashboardLayout(layout)
 
-class PlaylistStartTimerPanelInner extends MeteorReactComponent<Translated<IPlaylistStartTimerPanelProps>, IState> {
-	render(): JSX.Element {
-		const isDashboardLayout = RundownLayoutsAPI.isDashboardLayout(this.props.layout)
-
-		return (
-			<div
-				className={ClassNames(
-					'playlist-start-time-panel timing',
-					isDashboardLayout ? (this.props.panel as DashboardLayoutPlaylistStartTimer).customClasses : undefined
-				)}
-				style={isDashboardLayout ? dashboardElementStyle(this.props.panel as DashboardLayoutPlaylistStartTimer) : {}}
-			>
-				<PlaylistStartTiming
-					rundownPlaylist={this.props.playlist}
-					hideDiff={this.props.panel.hideDiff}
-					hidePlannedStart={this.props.panel.hidePlannedStart}
-					plannedStartText={this.props.panel.plannedStartText}
-				/>
-			</div>
-		)
-	}
+	return (
+		<div
+			className={ClassNames(
+				'playlist-start-time-panel timing',
+				isDashboardLayout ? (panel as DashboardLayoutPlaylistStartTimer).customClasses : undefined
+			)}
+			style={isDashboardLayout ? dashboardElementStyle(panel as DashboardLayoutPlaylistStartTimer) : {}}
+		>
+			<PlaylistStartTiming
+				rundownPlaylist={playlist}
+				hideDiff={panel.hideDiff}
+				hidePlannedStart={panel.hidePlannedStart}
+				plannedStartText={panel.plannedStartText}
+			/>
+		</div>
+	)
 }
-
-export const PlaylistStartTimerPanel = withTranslation()(PlaylistStartTimerPanelInner)

--- a/meteor/client/ui/Shelf/SegmentNamePanel.tsx
+++ b/meteor/client/ui/Shelf/SegmentNamePanel.tsx
@@ -5,7 +5,6 @@ import {
 	RundownLayoutBase,
 	RundownLayoutSegmentName,
 } from '../../../lib/collections/RundownLayouts'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { dashboardElementStyle } from './DashboardPanel'
 import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
@@ -27,7 +26,7 @@ interface ISegmentNamePanelTrackedProps {
 	name?: string
 }
 
-class SegmentNamePanelInner extends MeteorReactComponent<
+class SegmentNamePanelInner extends React.Component<
 	Translated<ISegmentNamePanelProps & ISegmentNamePanelTrackedProps>,
 	IState
 > {

--- a/meteor/client/ui/Shelf/SegmentTimingPanel.tsx
+++ b/meteor/client/ui/Shelf/SegmentTimingPanel.tsx
@@ -7,7 +7,6 @@ import {
 	RundownLayoutSegmentTiming,
 } from '../../../lib/collections/RundownLayouts'
 import { Translated, translateWithTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { RundownUtils } from '../../lib/rundown'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { DBSegment } from '@sofie-automation/corelib/dist/dataModel/Segment'
@@ -42,7 +41,7 @@ interface ISegmentTimingPanelTrackedProps {
 
 interface IState {}
 
-class SegmentTimingPanelInner extends MeteorReactComponent<
+class SegmentTimingPanelInner extends React.Component<
 	Translated<ISegmentTimingPanelProps & ISegmentTimingPanelTrackedProps>,
 	IState
 > {

--- a/meteor/client/ui/Shelf/ShowStylePanel.tsx
+++ b/meteor/client/ui/Shelf/ShowStylePanel.tsx
@@ -4,13 +4,11 @@ import {
 	RundownLayoutBase,
 	RundownLayoutShowStyleDisplay,
 } from '../../../lib/collections/RundownLayouts'
-import { Translated } from '../../lib/ReactMeteorData/ReactMeteorData'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { dashboardElementStyle } from './DashboardPanel'
 import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
 import { DBShowStyleVariant } from '@sofie-automation/corelib/dist/dataModel/ShowStyleVariant'
-import { withTranslation } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 import { UIShowStyleBase } from '../../../lib/api/showStyles'
 
 interface IShowStylePanelProps {
@@ -22,33 +20,28 @@ interface IShowStylePanelProps {
 	showStyleVariant: DBShowStyleVariant
 }
 
-interface IState {}
+export function ShowStylePanel(props: Readonly<IShowStylePanelProps>): JSX.Element {
+	const { t } = useTranslation()
 
-class ShowStylePanelInner extends MeteorReactComponent<Translated<IShowStylePanelProps>, IState> {
-	render(): JSX.Element {
-		const isDashboardLayout = RundownLayoutsAPI.isDashboardLayout(this.props.layout)
-		const { t } = this.props
+	const isDashboardLayout = RundownLayoutsAPI.isDashboardLayout(props.layout)
 
-		return (
-			<div
-				className="show-style-panel"
-				style={isDashboardLayout ? dashboardElementStyle(this.props.panel as DashboardLayoutShowStyleDisplay) : {}}
-			>
-				<div className="show-style-subpanel">
-					<div className="show-style-subpanel__label">{t('Show Style')}</div>
-					<div className="show-style-subpanel__name" title={this.props.showStyleBase.name}>
-						{this.props.showStyleBase.name}
-					</div>
-				</div>
-				<div className="show-style-subpanel">
-					<div className="show-style-subpanel__label">{t('Show Style Variant')}</div>
-					<div className="show-style-subpanel__name" title={this.props.showStyleVariant.name}>
-						{this.props.showStyleVariant.name}
-					</div>
+	return (
+		<div
+			className="show-style-panel"
+			style={isDashboardLayout ? dashboardElementStyle(props.panel as DashboardLayoutShowStyleDisplay) : {}}
+		>
+			<div className="show-style-subpanel">
+				<div className="show-style-subpanel__label">{t('Show Style')}</div>
+				<div className="show-style-subpanel__name" title={props.showStyleBase.name}>
+					{props.showStyleBase.name}
 				</div>
 			</div>
-		)
-	}
+			<div className="show-style-subpanel">
+				<div className="show-style-subpanel__label">{t('Show Style Variant')}</div>
+				<div className="show-style-subpanel__name" title={props.showStyleVariant.name}>
+					{props.showStyleVariant.name}
+				</div>
+			</div>
+		</div>
+	)
 }
-
-export const ShowStylePanel = withTranslation()(ShowStylePanelInner)

--- a/meteor/client/ui/Shelf/SystemStatusPanel.tsx
+++ b/meteor/client/ui/Shelf/SystemStatusPanel.tsx
@@ -6,7 +6,6 @@ import {
 	RundownLayoutSytemStatus,
 } from '../../../lib/collections/RundownLayouts'
 import { Translated, translateWithTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { dashboardElementStyle } from './DashboardPanel'
 import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
@@ -32,7 +31,7 @@ interface ISystemStatusPanelTrackedProps {
 	rundownIds: RundownId[]
 }
 
-class SystemStatusPanelInner extends MeteorReactComponent<
+class SystemStatusPanelInner extends React.Component<
 	Translated<ISystemStatusPanelProps & ISystemStatusPanelTrackedProps>,
 	IState
 > {

--- a/meteor/client/ui/Shelf/TextLabelPanel.tsx
+++ b/meteor/client/ui/Shelf/TextLabelPanel.tsx
@@ -5,7 +5,6 @@ import {
 	RundownLayoutBase,
 	RundownLayoutTextLabel,
 } from '../../../lib/collections/RundownLayouts'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { dashboardElementStyle } from './DashboardPanel'
 import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
@@ -17,25 +16,20 @@ interface ITextLabelPanelProps {
 	playlist: DBRundownPlaylist
 }
 
-interface IState {}
+export function TextLabelPanel({ panel, layout }: Readonly<ITextLabelPanelProps>): JSX.Element {
+	const isDashboardLayout = RundownLayoutsAPI.isDashboardLayout(layout)
 
-export class TextLabelPanel extends MeteorReactComponent<ITextLabelPanelProps, IState> {
-	render(): JSX.Element {
-		const isDashboardLayout = RundownLayoutsAPI.isDashboardLayout(this.props.layout)
-		const { panel } = this.props
-
-		return (
-			<div
-				className={ClassNames(
-					'text-label-panel',
-					isDashboardLayout ? (panel as DashboardLayoutTextLabel).customClasses : undefined
-				)}
-				style={isDashboardLayout ? dashboardElementStyle(this.props.panel as DashboardLayoutTextLabel) : {}}
-			>
-				<div className="wrapper">
-					<span className="text">{this.props.panel.text}</span>
-				</div>
+	return (
+		<div
+			className={ClassNames(
+				'text-label-panel',
+				isDashboardLayout ? (panel as DashboardLayoutTextLabel).customClasses : undefined
+			)}
+			style={isDashboardLayout ? dashboardElementStyle(panel as DashboardLayoutTextLabel) : {}}
+		>
+			<div className="wrapper">
+				<span className="text">{panel.text}</span>
 			</div>
-		)
-	}
+		</div>
+	)
 }

--- a/meteor/client/ui/Shelf/TimeOfDayPanel.tsx
+++ b/meteor/client/ui/Shelf/TimeOfDayPanel.tsx
@@ -4,12 +4,10 @@ import {
 	RundownLayoutBase,
 	RundownLayoutTimeOfDay,
 } from '../../../lib/collections/RundownLayouts'
-import { Translated } from '../../lib/ReactMeteorData/ReactMeteorData'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { dashboardElementStyle } from './DashboardPanel'
 import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
-import { withTranslation } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 import { TimeOfDay } from '../RundownView/RundownTiming/TimeOfDay'
 
 interface ITimeOfDayPanelProps {
@@ -19,25 +17,20 @@ interface ITimeOfDayPanelProps {
 	playlist: DBRundownPlaylist
 }
 
-interface IState {}
+export function TimeOfDayPanel({ panel, layout }: Readonly<ITimeOfDayPanelProps>): JSX.Element {
+	const { t } = useTranslation()
 
-class TimeOfDayPanelInner extends MeteorReactComponent<Translated<ITimeOfDayPanelProps>, IState> {
-	render(): JSX.Element {
-		const isDashboardLayout = RundownLayoutsAPI.isDashboardLayout(this.props.layout)
-		const { t, panel } = this.props
+	const isDashboardLayout = RundownLayoutsAPI.isDashboardLayout(layout)
 
-		return (
-			<div
-				className="time-of-day-panel timing"
-				style={isDashboardLayout ? dashboardElementStyle(this.props.panel as DashboardLayoutTimeOfDay) : {}}
-			>
-				<span className="timing-clock left">
-					{!panel.hideLabel && <span className="timing-clock-label">{t('Local Time')}</span>}
-					<TimeOfDay />
-				</span>
-			</div>
-		)
-	}
+	return (
+		<div
+			className="time-of-day-panel timing"
+			style={isDashboardLayout ? dashboardElementStyle(panel as DashboardLayoutTimeOfDay) : {}}
+		>
+			<span className="timing-clock left">
+				{!panel.hideLabel && <span className="timing-clock-label">{t('Local Time')}</span>}
+				<TimeOfDay />
+			</span>
+		</div>
+	)
 }
-
-export const TimeOfDayPanel = withTranslation()(TimeOfDayPanelInner)

--- a/meteor/client/ui/Status/Evaluations.tsx
+++ b/meteor/client/ui/Status/Evaluations.tsx
@@ -4,7 +4,6 @@ import { Translated, translateWithTracker } from '../../lib/ReactMeteorData/reac
 import Moment from 'react-moment'
 import { Time, unprotectString } from '../../../lib/lib'
 import * as _ from 'underscore'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { Evaluation } from '../../../lib/collections/Evaluations'
 import { DatePickerFromTo } from '../../lib/datePicker'
 import moment from 'moment'
@@ -35,7 +34,7 @@ const EvaluationView = translateWithTracker<IEvaluationProps, IEvaluationState, 
 		}
 	}
 )(
-	class EvaluationView extends MeteorReactComponent<
+	class EvaluationView extends React.Component<
 		Translated<IEvaluationProps & IEvaluationTrackedProps>,
 		IEvaluationState
 	> {
@@ -70,7 +69,6 @@ const EvaluationView = translateWithTracker<IEvaluationProps, IEvaluationState, 
 			if (this._sub) {
 				this._sub.stop()
 			}
-			this._cleanUp()
 		}
 
 		renderMessageHead() {

--- a/meteor/client/ui/Status/ExternalMessages.tsx
+++ b/meteor/client/ui/Status/ExternalMessages.tsx
@@ -130,7 +130,7 @@ const ExternalMessagesInStudio = translateWithTracker<
 		).fetch(),
 	}
 })(
-	class ExternalMessagesInStudio extends MeteorReactComponent<
+	class ExternalMessagesInStudio extends React.Component<
 		Translated<IExternalMessagesInStudioProps & IExternalMessagesInStudioTrackedProps>,
 		IExternalMessagesInStudioState
 	> {
@@ -173,7 +173,6 @@ const ExternalMessagesInStudio = translateWithTracker<
 			if (this._sub) {
 				this._sub.stop()
 			}
-			this._cleanUp()
 		}
 		removeMessage(msg: ExternalMessageQueueObj) {
 			MeteorCall.externalMessages.remove(msg._id).catch(catchError('externalMessages.remove'))

--- a/meteor/client/ui/TestTools/Mappings.tsx
+++ b/meteor/client/ui/TestTools/Mappings.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Translated, translateWithTracker, withTracker } from '../../lib/ReactMeteorData/react-meteor-data'
+import { withTracker } from '../../lib/ReactMeteorData/react-meteor-data'
 import * as _ from 'underscore'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { omit, Time, unprotectString } from '../../../lib/lib'
@@ -12,6 +12,7 @@ import { createSyncPeripheralDeviceCustomPublicationMongoCollection } from '../.
 import { StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { RoutedMappings } from '@sofie-automation/shared-lib/dist/core/model/Timeline'
 import { PeripheralDevicePubSubCollectionsNames } from '@sofie-automation/shared-lib/dist/pubsub/peripheralDevice'
+import { useTranslation } from 'react-i18next'
 
 const StudioMappings = createSyncPeripheralDeviceCustomPublicationMongoCollection(
 	PeripheralDevicePubSubCollectionsNames.studioMappings
@@ -24,35 +25,24 @@ interface IMappingsViewProps {
 		}
 	}
 }
-interface IMappingsViewState {}
-const MappingsView = translateWithTracker<IMappingsViewProps, IMappingsViewState, {}>((_props: IMappingsViewProps) => {
-	return {}
-})(
-	class MappingsView extends MeteorReactComponent<Translated<IMappingsViewProps>, IMappingsViewState> {
-		constructor(props: Translated<IMappingsViewProps>) {
-			super(props)
-		}
+function MappingsView(props: Readonly<IMappingsViewProps>): JSX.Element {
+	const { t } = useTranslation()
 
-		render(): JSX.Element {
-			const { t } = this.props
-
-			return (
-				<div className="mtl gutter">
-					<header className="mvs">
-						<h1>{t('Routed Mappings')}</h1>
-					</header>
-					<div className="mod mvl">
-						{this.props.match && this.props.match.params && (
-							<div>
-								<ComponentMappingsTable studioId={this.props.match.params.studioId} />
-							</div>
-						)}
+	return (
+		<div className="mtl gutter">
+			<header className="mvs">
+				<h1>{t('Routed Mappings')}</h1>
+			</header>
+			<div className="mod mvl">
+				{props.match && props.match.params && (
+					<div>
+						<ComponentMappingsTable studioId={props.match.params.studioId} />
 					</div>
-				</div>
-			)
-		}
-	}
-)
+				)}
+			</div>
+		</div>
+	)
+}
 
 interface IMappingsTableProps {
 	studioId: StudioId


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
This pull request is posted on behalf of the NRK.

## Type of Contribution

This is a Code improvement

## New Behavior
<!--
What is the new behavior?
-->

Many uses of the `MeteorReactComponent` are unnecessary and are not using any of the logic that class provides on top of `React.Component`.  
This moves these components to use `React.Component` instead, and converts some simpler ones into functional components.

## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->

Make sure to enable 'No whitespace' mode when reviewing, that cuts the number of lines changed to less than half.

`MeteorReactComponent` has been found to not cleanup subscriptions properly. This is part of an effort to remove all uses of `MeteorReactComponent`

## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
