### PR TITLE
chore: refactor `RundownSystemStatus` to avoid `MeteorReactComponent` SOFIE-2751

### DIFF
--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1096,9 +1096,8 @@ const RundownHeader = withTranslation()(
 											layout={this.props.layout}
 										/>
 										<RundownSystemStatus
-											studio={this.props.studio}
-											playlist={this.props.playlist}
-											rundownIds={this.props.rundownIds}
+											studioId={this.props.studio._id}
+											playlistId={this.props.playlist._id}
 											firstRundown={this.props.firstRundown}
 										/>
 									</>

--- a/meteor/client/ui/RundownView/RundownSystemStatus.tsx
+++ b/meteor/client/ui/RundownView/RundownSystemStatus.tsx
@@ -1,4 +1,3 @@
-import { Meteor } from 'meteor/meteor'
 import React, { useMemo } from 'react'
 import ClassNames from 'classnames'
 import { useSubscription, useTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
@@ -8,54 +7,38 @@ import {
 	PeripheralDeviceType,
 } from '@sofie-automation/corelib/dist/dataModel/PeripheralDevice'
 import { Rundown } from '@sofie-automation/corelib/dist/dataModel/Rundown'
-import { Time, getCurrentTime, unprotectString } from '../../../lib/lib'
-import { useTranslation, withTranslation, WithTranslation } from 'react-i18next'
+import { Time, unprotectString } from '../../../lib/lib'
+import { useTranslation } from 'react-i18next'
 import { StatusCode } from '@sofie-automation/blueprints-integration'
 import { RundownPlaylistId, StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { PeripheralDevices } from '../../collections'
 import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
+import { useCurrentTime } from '../../lib/lib'
 
 interface IMOSStatusProps {
 	lastUpdate: Time
 }
 
-const MOSLastUpdateStatus = withTranslation()(
-	class MOSLastUpdateStatus extends React.Component<IMOSStatusProps & WithTranslation> {
-		_interval: number
+const MOSLastUpdateStatus = React.memo(function MOSLastUpdateStatus({ lastUpdate }: Readonly<IMOSStatusProps>) {
+	const { t } = useTranslation()
 
-		componentDidMount(): void {
-			this._interval = Meteor.setInterval(() => {
-				this.tick()
-			}, 5000)
-		}
+	const currentTime = useCurrentTime(5000)
+	const timeDiff = currentTime - lastUpdate
 
-		componentWillUnmount(): void {
-			Meteor.clearInterval(this._interval)
-		}
-
-		tick() {
-			this.forceUpdate()
-		}
-
-		render(): JSX.Element {
-			const { t } = this.props
-			const timeDiff = getCurrentTime() - this.props.lastUpdate
-			return (
-				<span>
-					{timeDiff < 3000 && t('Just now')}
-					{timeDiff >= 3000 && timeDiff < 60 * 1000 && t('Less than a minute ago')}
-					{timeDiff >= 60 * 1000 && timeDiff < 5 * 60 * 1000 && t('Less than five minutes ago')}
-					{timeDiff >= 5 * 60 * 1000 && timeDiff < 10 * 60 * 1000 && t('Around 10 minutes ago')}
-					{timeDiff >= 10 * 60 * 1000 && timeDiff < 30 * 60 * 1000 && t('More than 10 minutes ago')}
-					{timeDiff >= 30 * 60 * 1000 && timeDiff < 2 * 60 * 60 * 1000 && t('More than 30 minutes ago')}
-					{timeDiff >= 2 * 60 * 60 * 1000 && timeDiff < 5 * 60 * 60 * 1000 && t('More than 2 hours ago')}
-					{timeDiff >= 5 * 60 * 60 * 1000 && timeDiff < 24 * 60 * 60 * 1000 && t('More than 5 hours ago')}
-					{timeDiff >= 24 * 60 * 60 * 1000 && t('More than a day ago')}
-				</span>
-			)
-		}
-	}
-)
+	return (
+		<span>
+			{timeDiff < 3000 && t('Just now')}
+			{timeDiff >= 3000 && timeDiff < 60 * 1000 && t('Less than a minute ago')}
+			{timeDiff >= 60 * 1000 && timeDiff < 5 * 60 * 1000 && t('Less than five minutes ago')}
+			{timeDiff >= 5 * 60 * 1000 && timeDiff < 10 * 60 * 1000 && t('Around 10 minutes ago')}
+			{timeDiff >= 10 * 60 * 1000 && timeDiff < 30 * 60 * 1000 && t('More than 10 minutes ago')}
+			{timeDiff >= 30 * 60 * 1000 && timeDiff < 2 * 60 * 60 * 1000 && t('More than 30 minutes ago')}
+			{timeDiff >= 2 * 60 * 60 * 1000 && timeDiff < 5 * 60 * 60 * 1000 && t('More than 2 hours ago')}
+			{timeDiff >= 5 * 60 * 60 * 1000 && timeDiff < 24 * 60 * 60 * 1000 && t('More than 5 hours ago')}
+			{timeDiff >= 24 * 60 * 60 * 1000 && t('More than a day ago')}
+		</span>
+	)
+})
 
 interface IProps {
 	studioId: StudioId

--- a/meteor/client/ui/Shelf/ShelfDashboardLayout.tsx
+++ b/meteor/client/ui/Shelf/ShelfDashboardLayout.tsx
@@ -203,10 +203,10 @@ export function ShelfDashboardLayout(props: Readonly<IShelfDashboardLayoutProps>
 							return (
 								<SystemStatusPanel
 									key={panel._id}
-									playlist={props.playlist}
+									playlistId={props.playlist._id}
 									layout={rundownLayout}
 									panel={panel}
-									studio={props.studio}
+									studioId={props.studio._id}
 								/>
 							)
 						} else if (RundownLayoutsAPI.isShowStyleDisplay(panel)) {

--- a/meteor/client/ui/Shelf/SystemStatusPanel.tsx
+++ b/meteor/client/ui/Shelf/SystemStatusPanel.tsx
@@ -5,82 +5,79 @@ import {
 	RundownLayoutBase,
 	RundownLayoutSytemStatus,
 } from '../../../lib/collections/RundownLayouts'
-import { Translated, translateWithTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
-import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
+import { useTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
 import { dashboardElementStyle } from './DashboardPanel'
 import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
 import { RundownSystemStatus } from '../RundownView/RundownSystemStatus'
-import { DBRundown, Rundown } from '@sofie-automation/corelib/dist/dataModel/Rundown'
-import { UIStudio } from '../../../lib/api/studios'
-import { RundownId } from '@sofie-automation/corelib/dist/dataModel/Ids'
-import { Rundowns } from '../../collections'
+import { DBRundown } from '@sofie-automation/corelib/dist/dataModel/Rundown'
+import { RundownId, RundownPlaylistId, StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { RundownPlaylists, Rundowns } from '../../collections'
 import { RundownPlaylistCollectionUtil } from '../../../lib/collections/rundownPlaylistUtil'
+import { useTranslation } from 'react-i18next'
+import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 
 interface ISystemStatusPanelProps {
-	studio: UIStudio
-	visible?: boolean
+	studioId: StudioId
 	layout: RundownLayoutBase
 	panel: RundownLayoutSytemStatus
-	playlist: DBRundownPlaylist
+	playlistId: RundownPlaylistId
 }
 
-interface IState {}
+export function SystemStatusPanel({
+	panel,
+	layout,
+	studioId,
+	playlistId,
+}: Readonly<ISystemStatusPanelProps>): JSX.Element {
+	const { t } = useTranslation()
 
-interface ISystemStatusPanelTrackedProps {
-	firstRundown: Rundown | undefined
-	rundownIds: RundownId[]
-}
+	const firstRundown = useTracker(() => {
+		const playlist = RundownPlaylists.findOne(playlistId, {
+			fields: {
+				rundownIdsInOrder: 1,
+			},
+		}) as Pick<DBRundownPlaylist, '_id' | 'rundownIdsInOrder'> | undefined
+		if (!playlist) return undefined
 
-class SystemStatusPanelInner extends MeteorReactComponent<
-	Translated<ISystemStatusPanelProps & ISystemStatusPanelTrackedProps>,
-	IState
-> {
-	render(): JSX.Element {
-		const isDashboardLayout = RundownLayoutsAPI.isDashboardLayout(this.props.layout)
-		const { t, panel } = this.props
+		let rundownId: RundownId | undefined = undefined
 
-		return (
-			<div
-				className={ClassNames(
-					'system-status-panel timing',
-					isDashboardLayout ? (panel as DashboardLayoutSystemStatus).customClasses : undefined
-				)}
-				style={isDashboardLayout ? dashboardElementStyle(this.props.panel as DashboardLayoutSystemStatus) : {}}
-			>
-				<span className="timing-clock left">
-					<span className="timing-clock-label">{t('System Status')}</span>
-					<RundownSystemStatus
-						studio={this.props.studio}
-						playlist={this.props.playlist}
-						rundownIds={this.props.rundownIds}
-						firstRundown={this.props.firstRundown}
-					/>
-				</span>
-			</div>
-		)
-	}
-}
-
-export const SystemStatusPanel = translateWithTracker<ISystemStatusPanelProps, IState, ISystemStatusPanelTrackedProps>(
-	(props: ISystemStatusPanelProps) => {
-		const rundownIds = RundownPlaylistCollectionUtil.getRundownOrderedIDs(props.playlist)
-		let firstRundown: DBRundown | undefined
-
-		if (props.playlist.rundownIdsInOrder.length > 0) {
-			firstRundown = Rundowns.findOne({
-				playlistId: props.playlist._id,
-				_id: props.playlist.rundownIdsInOrder[0],
-			})
-		} else if (rundownIds.length > 0) {
-			firstRundown = Rundowns.findOne({
-				playlistId: props.playlist._id,
-				_id: rundownIds[0],
-			})
+		if (playlist.rundownIdsInOrder.length > 0) {
+			rundownId = playlist.rundownIdsInOrder[0]
+		} else {
+			rundownId = RundownPlaylistCollectionUtil.getRundownOrderedIDs(playlist)[0]
 		}
-		return {
-			rundownIds,
-			firstRundown,
+
+		if (rundownId) {
+			return Rundowns.findOne(
+				{
+					playlistId: playlistId,
+					_id: rundownId,
+				},
+				{
+					fields: {
+						externalNRCSName: 1,
+					},
+				}
+			) as Pick<DBRundown, 'externalNRCSName'> | undefined
+		} else {
+			return undefined
 		}
-	}
-)(SystemStatusPanelInner)
+	}, [playlistId])
+
+	const isDashboardLayout = RundownLayoutsAPI.isDashboardLayout(layout)
+
+	return (
+		<div
+			className={ClassNames(
+				'system-status-panel timing',
+				isDashboardLayout ? (panel as DashboardLayoutSystemStatus).customClasses : undefined
+			)}
+			style={isDashboardLayout ? dashboardElementStyle(panel as DashboardLayoutSystemStatus) : {}}
+		>
+			<span className="timing-clock left">
+				<span className="timing-clock-label">{t('System Status')}</span>
+				<RundownSystemStatus studioId={studioId} playlistId={playlistId} firstRundown={firstRundown} />
+			</span>
+		</div>
+	)
+}


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
This pull request is posted on behalf of the NRK.




## Type of Contribution

This is a bug fix



## New Behavior
The MeteorReactComponent class has been found to be not close subscriptions when rerunning computations.
The simplest and most reliable way to mitigate this is to replace this class with functional components can instead use the native react flow/approach to tracking lifecycle.





## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
