### PR TITLE
chore: refactor RundownLayoutEditor to avoid MeteorReactComponent SOFIE-2751

### DIFF
--- a/meteor/client/ui/Settings/RundownLayoutEditor.tsx
+++ b/meteor/client/ui/Settings/RundownLayoutEditor.tsx
@@ -1,8 +1,7 @@
-import * as React from 'react'
+import React, { useMemo } from 'react'
 import ClassNames from 'classnames'
 import { EditAttribute } from '../../lib/EditAttribute'
-import { Translated, translateWithTracker } from '../../lib/ReactMeteorData/react-meteor-data'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
+import { Translated, useSubscription, useTracker } from '../../lib/ReactMeteorData/react-meteor-data'
 import { faUpload, faPlus, faCheck, faPencilAlt, faDownload, faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
@@ -38,6 +37,7 @@ import { RundownLayoutId, ShowStyleBaseId } from '@sofie-automation/corelib/dist
 import { OutputLayers, SourceLayers } from '@sofie-automation/corelib/dist/dataModel/ShowStyleBase'
 import { RundownLayouts } from '../../collections'
 import { LabelActual } from '../../lib/Components/LabelAndOverrides'
+import { withTranslation } from 'react-i18next'
 
 export interface IProps {
 	showStyleBaseId: ShowStyleBaseId
@@ -57,20 +57,26 @@ interface ITrackedProps {
 	layoutTypes: RundownLayoutType[]
 }
 
-export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProps) => {
-	const layoutTypes = props.customRegion.layouts.map((l) => l.type)
+export default function RundownLayoutEditor(props: Readonly<IProps>): JSX.Element {
+	useSubscription(MeteorPubSub.rundownLayouts, [props.showStyleBaseId])
 
-	const rundownLayouts = RundownLayouts.find({
-		showStyleBaseId: props.showStyleBaseId,
-		userId: { $exists: false },
-	}).fetch()
+	const layoutTypes = useMemo(() => props.customRegion.layouts.map((l) => l.type), [props.customRegion])
 
-	return {
-		rundownLayouts,
-		layoutTypes,
-	}
-})(
-	class RundownLayoutEditor extends MeteorReactComponent<Translated<IProps & ITrackedProps>, IState> {
+	const rundownLayouts = useTracker(
+		() =>
+			RundownLayouts.find({
+				showStyleBaseId: props.showStyleBaseId,
+				userId: { $exists: false },
+			}).fetch(),
+		[props.showStyleBaseId],
+		[]
+	)
+
+	return <RundownLayoutEditorContent {...props} layoutTypes={layoutTypes} rundownLayouts={rundownLayouts} />
+}
+
+const RundownLayoutEditorContent = withTranslation()(
+	class RundownLayoutEditorContent extends React.Component<Translated<IProps & ITrackedProps>, IState> {
 		constructor(props: Translated<IProps & ITrackedProps>) {
 			super(props)
 
@@ -78,12 +84,6 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 				editedItems: [],
 				uploadFileKey: Date.now(),
 			}
-		}
-
-		componentDidMount(): void {
-			super.componentDidMount && super.componentDidMount()
-
-			this.subscribe(MeteorPubSub.rundownLayouts, null)
 		}
 
 		onAddLayout = () => {


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
This pull request is posted on behalf of the NRK.




## Type of Contribution

This is a bug fix



## New Behavior
The MeteorReactComponent class has been found to be not close subscriptions when rerunning computations.
The simplest and most reliable way to mitigate this is to replace this class with functional components can instead use the native react flow/approach to tracking lifecycle.


## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
