### PR TITLE
chore: refactor RundownView to avoid MeteorReactComponent SOFIE-2751

### DIFF
--- a/meteor/client/lib/ReactMeteorData/ReactMeteorData.tsx
+++ b/meteor/client/lib/ReactMeteorData/ReactMeteorData.tsx
@@ -359,6 +359,43 @@ export function useSubscription<K extends keyof AllPubSubTypes>(
 
 	return ready
 }
+
+/**
+ * A Meteor Subscription hook that allows using React Functional Components and the Hooks API with Meteor subscriptions.
+ * Subscriptions will be torn down 1000ms after unmounting the component.
+ *
+ * @export
+ * @param {PubSub} sub The subscription to be subscribed to
+ * @param {boolean} enable Whether the subscription is enabled
+ * @param {...any[]} args A list of arugments for the subscription. This is used for optimizing the subscription across
+ * 		renders so that it isn't torn down and created for every render.
+ */
+export function useSubscriptionIfEnabled<K extends keyof AllPubSubTypes>(
+	sub: K,
+	enable: boolean,
+	...args: Parameters<AllPubSubTypes[K]>
+): boolean {
+	const [ready, setReady] = useState<boolean>(false)
+
+	useEffect(() => {
+		if (!enable) {
+			setReady(false)
+			return
+		}
+
+		const subscription = Tracker.nonreactive(() => meteorSubscribe(sub, ...args))
+		const isReadyComp = Tracker.nonreactive(() => Tracker.autorun(() => setReady(subscription.ready())))
+		return () => {
+			isReadyComp.stop()
+			setTimeout(() => {
+				subscription.stop()
+			}, 1000)
+		}
+	}, [sub, enable, stringifyObjects(args)])
+
+	return ready
+}
+
 /**
  * Sets up multiple subscriptions of the same type, but with different arguments
  */


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
This pull request is posted on behalf of the NRK.




## Type of Contribution
This is a bug fix



## New Behavior
The MeteorReactComponent class has been found to be not close subscriptions when rerunning computations.
The simplest and most reliable way to mitigate this is to replace this class with functional components can instead use the native react flow/approach to tracking lifecycle.




## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
