### PR TITLE
chore: refactor SystemStatus and SnapshotsView to avoid MeteorReactComponent SOFIE-2751

### DIFF
--- a/meteor/client/ui/Settings/SnapshotsView.tsx
+++ b/meteor/client/ui/Settings/SnapshotsView.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
-import { Translated, translateWithTracker } from '../../lib/ReactMeteorData/react-meteor-data'
+import { Translated, useSubscription, useTracker } from '../../lib/ReactMeteorData/react-meteor-data'
 import { doModalDialog } from '../../lib/ModalDialog'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { SnapshotItem } from '../../../lib/collections/Snapshots'
 import { unprotectString } from '../../../lib/lib'
 import * as _ from 'underscore'
@@ -20,6 +19,7 @@ import { Snapshots, Studios } from '../../collections'
 import { ClientAPI } from '../../../lib/api/client'
 import { hashSingleUseToken } from '../../../lib/api/userActions'
 import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
+import { withTranslation } from 'react-i18next'
 
 interface IProps {
 	match: {
@@ -37,20 +37,32 @@ interface ITrackedProps {
 	snapshots: Array<SnapshotItem>
 	studios: Array<DBStudio>
 }
-export default translateWithTracker<IProps, IState, ITrackedProps>(() => {
-	return {
-		snapshots: Snapshots.find(
-			{},
-			{
-				sort: {
-					created: -1,
-				},
-			}
-		).fetch(),
-		studios: Studios.find({}, {}).fetch(),
-	}
-})(
-	class SnapshotsView extends MeteorReactComponent<Translated<IProps & ITrackedProps>, IState> {
+
+export default function SnapshotsView(props: Readonly<IProps>): JSX.Element {
+	// // Subscribe to data:
+	useSubscription(MeteorPubSub.snapshots)
+	useSubscription(CorelibPubSub.studios, null)
+
+	const snapshots = useTracker(
+		() =>
+			Snapshots.find(
+				{},
+				{
+					sort: {
+						created: -1,
+					},
+				}
+			).fetch(),
+		[],
+		[]
+	)
+	const studios = useTracker(() => Studios.find({}, {}).fetch(), [], [])
+
+	return <SnapshotsViewContent {...props} snapshots={snapshots} studios={studios} />
+}
+
+const SnapshotsViewContent = withTranslation()(
+	class SnapshotsViewContent extends React.Component<Translated<IProps & ITrackedProps>, IState> {
 		constructor(props: Translated<IProps & ITrackedProps>) {
 			super(props)
 			this.state = {
@@ -58,10 +70,6 @@ export default translateWithTracker<IProps, IState, ITrackedProps>(() => {
 				editSnapshotId: null,
 				removeSnapshots: false,
 			}
-		}
-		componentDidMount(): void {
-			this.subscribe(MeteorPubSub.snapshots)
-			this.subscribe(CorelibPubSub.studios, null)
 		}
 
 		onUploadFile(e: React.ChangeEvent<HTMLInputElement>) {


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
This pull request is posted on behalf of the NRK.




## Type of Contribution
This is a bug fix



## New Behavior
The MeteorReactComponent class has been found to be not close subscriptions when rerunning computations.
The simplest and most reliable way to mitigate this is to replace this class with functional components can instead use the native react flow/approach to tracking lifecycle.




## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
