### PR TITLE
chore: refactor TestTools to avoid MeteorReactComponent SOFIE-2751

### DIFF
--- a/meteor/client/ui/TestTools/Mappings.tsx
+++ b/meteor/client/ui/TestTools/Mappings.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react'
-import { Translated, translateWithTracker, withTracker } from '../../lib/ReactMeteorData/react-meteor-data'
+import { useSubscription, useTracker } from '../../lib/ReactMeteorData/react-meteor-data'
 import * as _ from 'underscore'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
-import { omit, Time, unprotectString } from '../../../lib/lib'
+import { omit, unprotectString } from '../../../lib/lib'
 import { MeteorPubSub } from '../../../lib/api/pubsub'
 import { makeTableOfObject } from '../../lib/utilComponents'
 import { StudioSelect } from './StudioSelect'
@@ -10,8 +9,8 @@ import { MappingExt } from '@sofie-automation/corelib/dist/dataModel/Studio'
 import { LookaheadMode, TSR } from '@sofie-automation/blueprints-integration'
 import { createSyncPeripheralDeviceCustomPublicationMongoCollection } from '../../../lib/collections/lib'
 import { StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
-import { RoutedMappings } from '@sofie-automation/shared-lib/dist/core/model/Timeline'
 import { PeripheralDevicePubSubCollectionsNames } from '@sofie-automation/shared-lib/dist/pubsub/peripheralDevice'
+import { useTranslation } from 'react-i18next'
 
 const StudioMappings = createSyncPeripheralDeviceCustomPublicationMongoCollection(
 	PeripheralDevicePubSubCollectionsNames.studioMappings
@@ -24,124 +23,92 @@ interface IMappingsViewProps {
 		}
 	}
 }
-interface IMappingsViewState {}
-const MappingsView = translateWithTracker<IMappingsViewProps, IMappingsViewState, {}>((_props: IMappingsViewProps) => {
-	return {}
-})(
-	class MappingsView extends MeteorReactComponent<Translated<IMappingsViewProps>, IMappingsViewState> {
-		constructor(props: Translated<IMappingsViewProps>) {
-			super(props)
-		}
+function MappingsView(props: Readonly<IMappingsViewProps>): JSX.Element {
+	const { t } = useTranslation()
 
-		render(): JSX.Element {
-			const { t } = this.props
-
-			return (
-				<div className="mtl gutter">
-					<header className="mvs">
-						<h1>{t('Routed Mappings')}</h1>
-					</header>
-					<div className="mod mvl">
-						{this.props.match && this.props.match.params && (
-							<div>
-								<ComponentMappingsTable studioId={this.props.match.params.studioId} />
-							</div>
-						)}
+	return (
+		<div className="mtl gutter">
+			<header className="mvs">
+				<h1>{t('Routed Mappings')}</h1>
+			</header>
+			<div className="mod mvl">
+				{props.match?.params && (
+					<div>
+						<ComponentMappingsTable studioId={props.match.params.studioId} />
 					</div>
-				</div>
-			)
-		}
-	}
-)
+				)}
+			</div>
+		</div>
+	)
+}
 
-interface IMappingsTableProps {
+interface ComponentMappingsTableProps {
 	studioId: StudioId
 }
-interface IMappingsTableTrackedProps {
-	mappings: RoutedMappings | null
-}
-interface IMappingsTableState {
-	time: Time | null
-}
-export const ComponentMappingsTable = withTracker<IMappingsTableProps, IMappingsTableState, IMappingsTableTrackedProps>(
-	(props: IMappingsTableProps) => {
-		try {
-			// These properties will be exposed under this.props
-			// Note that these properties are reactively recalculated
-			const mappings = StudioMappings.findOne(props.studioId)
-			return {
-				mappings: mappings || null,
-			}
-		} catch (e) {
-			return {
-				mappings: null,
-			}
-		}
-	}
-)(
-	class ComponentMappingsTable extends MeteorReactComponent<
-		IMappingsTableProps & IMappingsTableTrackedProps,
-		IMappingsTableState
-	> {
-		constructor(props: IMappingsTableProps & IMappingsTableTrackedProps) {
-			super(props)
+function ComponentMappingsTable({ studioId }: Readonly<ComponentMappingsTableProps>): JSX.Element {
+	useSubscription(MeteorPubSub.mappingsForStudio, studioId)
 
-			this.state = {
-				time: null,
-			}
-		}
-		componentDidMount(): void {
-			this.subscribe(MeteorPubSub.mappingsForStudio, this.props.studioId)
-		}
-		renderMappingsState(state: RoutedMappings) {
-			const rows = _.sortBy(Object.entries<MappingExt>(state.mappings), (o) => o[0])
-			return rows.map(([id, obj]) => (
-				<tr key={id}>
-					<td>{id}</td>
-					<td>{unprotectString(obj.deviceId)}</td>
-					<td>{TSR.DeviceType[obj.device]}</td>
-					<td>{obj.layerName}</td>
-					<td>
-						Mode: {LookaheadMode[obj.lookahead]}
-						<br />
-						Distance: {obj.lookaheadMaxSearchDistance}
-						<br />
-						Depth: {obj.lookaheadDepth}
-					</td>
-					<td>
-						{makeTableOfObject(
-							omit(obj, 'deviceId', 'device', 'lookahead', 'lookaheadDepth', 'lookaheadMaxSearchDistance', 'layerName')
-						)}
-					</td>
-				</tr>
-			))
-		}
-		render(): JSX.Element {
-			const { mappings } = this.props
-			return (
+	const mappingsObj = useTracker(
+		() => {
+			return StudioMappings.findOne(studioId)
+		},
+		[studioId],
+		null
+	)
+
+	const mappingsItems = mappingsObj ? _.sortBy(Object.entries<MappingExt>(mappingsObj.mappings), (o) => o[0]) : []
+
+	return (
+		<div>
+			<div>
 				<div>
-					<div>
-						<div>
-							<table className="testtools-timelinetable">
-								<tbody>
-									<tr>
-										<th>Mapping</th>
-										<th>DeviceId</th>
-										<th>Type</th>
-										<th>Name</th>
-										<th>Lookahead</th>
-										<th>Data</th>
-									</tr>
-									{mappings ? this.renderMappingsState(mappings) : ''}
-								</tbody>
-							</table>
-						</div>
-					</div>
+					<table className="testtools-timelinetable">
+						<tbody>
+							<tr>
+								<th>Mapping</th>
+								<th>DeviceId</th>
+								<th>Type</th>
+								<th>Name</th>
+								<th>Lookahead</th>
+								<th>Data</th>
+							</tr>
+							{mappingsItems.map(([id, obj]) => (
+								<ComponentMappingsTableRow key={id} id={id} obj={obj} />
+							))}
+						</tbody>
+					</table>
 				</div>
-			)
-		}
-	}
-)
+			</div>
+		</div>
+	)
+}
+
+interface ComponentMappingsTableRowProps {
+	id: string
+	obj: MappingExt<TSR.TSRMappingOptions>
+}
+function ComponentMappingsTableRow({ id, obj }: Readonly<ComponentMappingsTableRowProps>) {
+	return (
+		<tr>
+			<td>{id}</td>
+			<td>{unprotectString(obj.deviceId)}</td>
+			<td>{TSR.DeviceType[obj.device]}</td>
+			<td>{obj.layerName}</td>
+			<td>
+				Mode: {LookaheadMode[obj.lookahead]}
+				<br />
+				Distance: {obj.lookaheadMaxSearchDistance}
+				<br />
+				Depth: {obj.lookaheadDepth}
+			</td>
+			<td>
+				{makeTableOfObject(
+					omit(obj, 'deviceId', 'device', 'lookahead', 'lookaheadDepth', 'lookaheadMaxSearchDistance', 'layerName')
+				)}
+			</td>
+		</tr>
+	)
+}
 
 function MappingsStudioSelect(): JSX.Element {
 	return <StudioSelect path="mappings" title="Mappings" />

--- a/meteor/client/ui/TestTools/Mappings.tsx
+++ b/meteor/client/ui/TestTools/Mappings.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { withTracker } from '../../lib/ReactMeteorData/react-meteor-data'
+import { useSubscription, useTracker } from '../../lib/ReactMeteorData/react-meteor-data'
 import * as _ from 'underscore'
 import { omit, unprotectString } from '../../../lib/lib'
 import { MeteorPubSub } from '../../../lib/api/pubsub'

--- a/meteor/client/ui/TestTools/index.tsx
+++ b/meteor/client/ui/TestTools/index.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react'
-import { withTranslation } from 'react-i18next'
-import { Translated } from '../../lib/ReactMeteorData/react-meteor-data'
+import { useTranslation } from 'react-i18next'
+import { useSubscription } from '../../lib/ReactMeteorData/react-meteor-data'
 import { Route, Switch, NavLink, Redirect } from 'react-router-dom'
-
 import { TimelineView, TimelineStudioSelect } from './Timeline'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { MeteorPubSub } from '../../../lib/api/pubsub'
 import { MappingsStudioSelect, MappingsView } from './Mappings'
 import { TimelineDatastoreStudioSelect, TimelineDatastoreView } from './TimelineDatastore'
@@ -14,93 +12,82 @@ import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 interface IStatusMenuProps {
 	match?: any
 }
-type IStatusMenuState = {}
-const StatusMenu = withTranslation()(
-	class StatusMenu extends React.Component<Translated<IStatusMenuProps>, IStatusMenuState> {
-		render(): JSX.Element {
-			const { t } = this.props
+function StatusMenu(_props: Readonly<IStatusMenuProps>) {
+	const { t } = useTranslation()
 
-			return (
-				<div className="tight-xs htight-xs text-s">
-					<NavLink
-						activeClassName="selectable-selected"
-						className="testTools-menu__testTools-menu-item selectable clickable"
-						to={'/testTools/timeline'}
-					>
-						<h3>{t('Timeline')}</h3>
-					</NavLink>
-					<NavLink
-						activeClassName="selectable-selected"
-						className="testTools-menu__testTools-menu-item selectable clickable"
-						to={'/testTools/timelinedatastore'}
-					>
-						<h3>{t('Timeline Datastore')}</h3>
-					</NavLink>
-					<NavLink
-						activeClassName="selectable-selected"
-						className="testTools-menu__testTools-menu-item selectable clickable"
-						to={'/testTools/mappings'}
-					>
-						<h3>{t('Mappings')}</h3>
-					</NavLink>
-					<NavLink
-						activeClassName="selectable-selected"
-						className="testTools-menu__testTools-menu-item selectable clickable"
-						to={'/testTools/devicetriggers'}
-					>
-						<h3>{t('Device Triggers')}</h3>
-					</NavLink>
-				</div>
-			)
-		}
-	}
-)
+	return (
+		<div className="tight-xs htight-xs text-s">
+			<NavLink
+				activeClassName="selectable-selected"
+				className="testTools-menu__testTools-menu-item selectable clickable"
+				to={'/testTools/timeline'}
+			>
+				<h3>{t('Timeline')}</h3>
+			</NavLink>
+			<NavLink
+				activeClassName="selectable-selected"
+				className="testTools-menu__testTools-menu-item selectable clickable"
+				to={'/testTools/timelinedatastore'}
+			>
+				<h3>{t('Timeline Datastore')}</h3>
+			</NavLink>
+			<NavLink
+				activeClassName="selectable-selected"
+				className="testTools-menu__testTools-menu-item selectable clickable"
+				to={'/testTools/mappings'}
+			>
+				<h3>{t('Mappings')}</h3>
+			</NavLink>
+			<NavLink
+				activeClassName="selectable-selected"
+				className="testTools-menu__testTools-menu-item selectable clickable"
+				to={'/testTools/devicetriggers'}
+			>
+				<h3>{t('Device Triggers')}</h3>
+			</NavLink>
+		</div>
+	)
+}
 
 interface IStatusProps {
 	match?: any
 }
-class Status extends MeteorReactComponent<Translated<IStatusProps>> {
-	componentDidMount(): void {
-		// Subscribe to data:
+export default function Status(props: Readonly<IStatusProps>): JSX.Element {
+	// Subscribe to data:
+	useSubscription(MeteorPubSub.uiStudio, null)
+	useSubscription(CorelibPubSub.showStyleBases, null)
+	useSubscription(CorelibPubSub.showStyleVariants, null, null)
 
-		this.subscribe(MeteorPubSub.uiStudio, null)
-		this.subscribe(CorelibPubSub.showStyleBases, null)
-		this.subscribe(CorelibPubSub.showStyleVariants, null, null)
-	}
-	render(): JSX.Element {
-		return (
-			<div className="mtl gutter has-statusbar">
-				{/* <header className='mvs'>
+	return (
+		<div className="mtl gutter has-statusbar">
+			{/* <header className='mvs'>
 					<h1>{t('Status')}</h1>
 				</header> */}
-				<div className="mod mvl mhs">
-					<div className="flex-row hide-m-up">
-						<div className="flex-col c12 rm-c1 status-menu">
-							<StatusMenu match={this.props.match} />
-						</div>
+			<div className="mod mvl mhs">
+				<div className="flex-row hide-m-up">
+					<div className="flex-col c12 rm-c1 status-menu">
+						<StatusMenu match={props.match} />
 					</div>
-					<div className="flex-row">
-						<div className="flex-col c12 rm-c1 show-m-up status-menu">
-							<StatusMenu match={this.props.match} />
-						</div>
-						<div className="flex-col c12 rm-c11 status-dialog">
-							<Switch>
-								<Route path="/testTools/timeline/:studioId" component={TimelineView} />
-								<Route path="/testTools/timeline" component={TimelineStudioSelect} />
-								<Route path="/testTools/mappings/:studioId" component={MappingsView} />
-								<Route path="/testTools/mappings" component={MappingsStudioSelect} />
-								<Route path="/testTools/timelinedatastore/:studioId" component={TimelineDatastoreView} />
-								<Route path="/testTools/timelinedatastore" component={TimelineDatastoreStudioSelect} />
-								<Route path="/testTools/devicetriggers/:peripheralDeviceId" component={DeviceTriggersView} />
-								<Route path="/testTools/devicetriggers" component={DeviceTriggersDeviceSelect} />
-								<Redirect to="/testTools/timeline" />
-							</Switch>
-						</div>
+				</div>
+				<div className="flex-row">
+					<div className="flex-col c12 rm-c1 show-m-up status-menu">
+						<StatusMenu match={props.match} />
+					</div>
+					<div className="flex-col c12 rm-c11 status-dialog">
+						<Switch>
+							<Route path="/testTools/timeline/:studioId" component={TimelineView} />
+							<Route path="/testTools/timeline" component={TimelineStudioSelect} />
+							<Route path="/testTools/mappings/:studioId" component={MappingsView} />
+							<Route path="/testTools/mappings" component={MappingsStudioSelect} />
+							<Route path="/testTools/timelinedatastore/:studioId" component={TimelineDatastoreView} />
+							<Route path="/testTools/timelinedatastore" component={TimelineDatastoreStudioSelect} />
+							<Route path="/testTools/devicetriggers/:peripheralDeviceId" component={DeviceTriggersView} />
+							<Route path="/testTools/devicetriggers" component={DeviceTriggersDeviceSelect} />
+							<Redirect to="/testTools/timeline" />
+						</Switch>
 					</div>
 				</div>
 			</div>
-		)
-	}
+		</div>
+	)
 }
-
-export default withTranslation()(Status)


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
This pull request is posted on behalf of the NRK.




## Type of Contribution
This is a bug fix



## New Behavior
The MeteorReactComponent class has been found to be not close subscriptions when rerunning computations.
The simplest and most reliable way to mitigate this is to replace this class with functional components can instead use the native react flow/approach to tracking lifecycle.




## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
