### PR TITLE
chore: refactor Status/ExternalMessages to avoid MeteorReactComponent SOFIE-2751

### DIFF
--- a/meteor/client/ui/Status/ExternalMessages.tsx
+++ b/meteor/client/ui/Status/ExternalMessages.tsx
@@ -1,342 +1,277 @@
-import { Meteor } from 'meteor/meteor'
-import * as React from 'react'
-import { Translated, translateWithTracker } from '../../lib/ReactMeteorData/react-meteor-data'
+import React, { useCallback, useState } from 'react'
+import { useSubscription, useTracker } from '../../lib/ReactMeteorData/react-meteor-data'
 import { getCurrentTime, Time, unprotectString } from '../../../lib/lib'
 import { MomentFromNow } from '../../lib/Moment'
 import { getAllowConfigure } from '../../lib/localStorage'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import * as _ from 'underscore'
 import { ExternalMessageQueueObj } from '@sofie-automation/corelib/dist/dataModel/ExternalMessageQueue'
-import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { makeTableOfObject } from '../../lib/utilComponents'
 import ClassNames from 'classnames'
 import { DatePickerFromTo } from '../../lib/datePicker'
 import moment from 'moment'
 import { faTrash, faPause, faPlay, faRedo } from '@fortawesome/free-solid-svg-icons'
-import { MeteorPubSub, meteorSubscribe } from '../../../lib/api/pubsub'
+import { MeteorPubSub } from '../../../lib/api/pubsub'
 import { MeteorCall } from '../../../lib/api/methods'
 import { UIStudios } from '../Collections'
-import { UIStudio } from '../../../lib/api/studios'
 import { StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { ExternalMessageQueue } from '../../collections'
 import { catchError } from '../../lib/lib'
 import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
+import { useTranslation } from 'react-i18next'
 
-interface IExternalMessagesProps {}
-interface IExternalMessagesState {
-	studioId: StudioId | undefined
+function ExternalMessages(): JSX.Element {
+	const { t } = useTranslation()
+
+	useSubscription(MeteorPubSub.uiStudio, null)
+
+	const studios = useTracker(() => UIStudios.find({}).fetch(), [], [])
+
+	const [selectedStudioId, setSelectedStudioId] = useState<StudioId | null>(null)
+
+	return (
+		<div className="mhl gutter external-message-status">
+			<header className="mbs">
+				<h1>{t('Message Queue')}</h1>
+			</header>
+			<div className="mod mvl">
+				<strong>Studio</strong>
+				<ul>
+					{studios.map((studio) => {
+						return (
+							<li key={unprotectString(studio._id)}>
+								<a href="#" onClick={() => setSelectedStudioId(studio._id)}>
+									{studio.name}
+								</a>
+							</li>
+						)
+					})}
+				</ul>
+			</div>
+			<div>{selectedStudioId ? <ExternalMessagesInStudio studioId={selectedStudioId} /> : null}</div>
+		</div>
+	)
 }
-interface IExternalMessagesTrackedProps {
-	studios: Array<UIStudio>
-}
-
-const ExternalMessages = translateWithTracker<
-	IExternalMessagesProps,
-	IExternalMessagesState,
-	IExternalMessagesTrackedProps
->((_props: IExternalMessagesProps) => {
-	return {
-		studios: UIStudios.find({}).fetch(),
-	}
-})(
-	class ExternalMessages extends MeteorReactComponent<
-		Translated<IExternalMessagesProps & IExternalMessagesTrackedProps>,
-		IExternalMessagesState
-	> {
-		constructor(props: Translated<IExternalMessagesProps & IExternalMessagesTrackedProps>) {
-			super(props)
-			this.state = {
-				studioId: undefined,
-			}
-		}
-		componentDidMount(): void {
-			this.subscribe(MeteorPubSub.uiStudio, null)
-		}
-		onClickStudio = (studio: UIStudio) => {
-			this.setState({
-				studioId: studio._id,
-			})
-		}
-		render(): JSX.Element {
-			const { t } = this.props
-
-			return (
-				<div className="mhl gutter external-message-status">
-					<header className="mbs">
-						<h1>{t('Message Queue')}</h1>
-					</header>
-					<div className="mod mvl">
-						<strong>Studio</strong>
-						<ul>
-							{_.map(this.props.studios, (studio) => {
-								return (
-									<li key={unprotectString(studio._id)}>
-										<a href="#" onClick={() => this.onClickStudio(studio)}>
-											{studio.name}
-										</a>
-									</li>
-								)
-							})}
-						</ul>
-					</div>
-					<div>{this.state.studioId ? <ExternalMessagesInStudio studioId={this.state.studioId} /> : null}</div>
-				</div>
-			)
-		}
-	}
-)
 
 interface IExternalMessagesInStudioProps {
 	studioId: StudioId
 }
-interface IExternalMessagesInStudioState {
-	dateFrom: Time
-	dateTo: Time
+function ExternalMessagesInStudio({ studioId }: Readonly<IExternalMessagesInStudioProps>) {
+	const [dateFrom, setDateFrom] = useState(() => moment().startOf('day').valueOf())
+	const [dateTo, setDateTo] = useState(() => moment().add(1, 'days').startOf('day').valueOf())
+
+	useSubscription(CorelibPubSub.externalMessageQueue, {
+		studioId: studioId,
+		created: {
+			$gte: dateFrom,
+			$lt: dateTo,
+		},
+	})
+
+	const handleChangeDate = useCallback((from: Time, to: Time) => {
+		setDateFrom(from)
+		setDateTo(to)
+	}, [])
+
+	return (
+		<div className="mhl gutter external-message-status">
+			<div className="paging alc">
+				<DatePickerFromTo from={dateFrom} to={dateTo} onChange={handleChangeDate} />
+			</div>
+			<div className="mod mvl">
+				<ExternalMessagesQueuedMessages studioId={studioId} />
+				<ExternalMessagesSentMessages studioId={studioId} />
+			</div>
+		</div>
+	)
 }
-interface IExternalMessagesInStudioTrackedProps {
-	queuedMessages: Array<ExternalMessageQueueObj>
-	sentMessages: Array<ExternalMessageQueueObj>
+
+interface ExternalMessagesQueuedMessagesProps {
+	studioId: StudioId
 }
+function ExternalMessagesQueuedMessages({ studioId }: Readonly<ExternalMessagesQueuedMessagesProps>) {
+	const { t } = useTranslation()
 
-const ExternalMessagesInStudio = translateWithTracker<
-	IExternalMessagesInStudioProps,
-	IExternalMessagesInStudioState,
-	IExternalMessagesInStudioTrackedProps
->((props: IExternalMessagesInStudioProps) => {
-	return {
-		queuedMessages: ExternalMessageQueue.find(
-			{
-				studioId: props.studioId,
-				sent: { $not: { $gt: 0 } },
-			},
-			{
-				sort: {
-					created: -1,
-					lastTry: -1,
+	const queuedMessages = useTracker(
+		() =>
+			ExternalMessageQueue.find(
+				{
+					studioId: studioId,
+					sent: { $gt: 0 },
 				},
-			}
-		).fetch(),
-		sentMessages: ExternalMessageQueue.find(
-			{
-				studioId: props.studioId,
-				sent: { $gt: 0 },
-			},
-			{
-				sort: {
-					sent: -1,
-					lastTry: -1,
-				},
-			}
-		).fetch(),
-	}
-})(
-	class ExternalMessagesInStudio extends MeteorReactComponent<
-		Translated<IExternalMessagesInStudioProps & IExternalMessagesInStudioTrackedProps>,
-		IExternalMessagesInStudioState
-	> {
-		private _currentsub = ''
-		private _sub?: Meteor.SubscriptionHandle
-
-		constructor(props: Translated<IExternalMessagesInStudioProps & IExternalMessagesInStudioTrackedProps>) {
-			super(props)
-
-			this.state = {
-				dateFrom: moment().startOf('day').valueOf(),
-				dateTo: moment().add(1, 'days').startOf('day').valueOf(),
-			}
-		}
-
-		componentDidMount(): void {
-			// Subscribe to data:
-			this.updateSubscription()
-		}
-		componentDidUpdate(): void {
-			this.updateSubscription()
-		}
-		updateSubscription() {
-			const h = this.state.dateFrom + '_' + this.state.dateTo
-			if (h !== this._currentsub) {
-				this._currentsub = h
-				if (this._sub) {
-					this._sub.stop()
-				}
-				this._sub = meteorSubscribe(CorelibPubSub.externalMessageQueue, {
-					studioId: this.props.studioId,
-					created: {
-						$gte: this.state.dateFrom,
-						$lt: this.state.dateTo,
+				{
+					sort: {
+						sent: -1,
+						lastTry: -1,
 					},
-				})
-			}
-		}
-		componentWillUnmount(): void {
-			if (this._sub) {
-				this._sub.stop()
-			}
-			this._cleanUp()
-		}
-		removeMessage(msg: ExternalMessageQueueObj) {
-			MeteorCall.externalMessages.remove(msg._id).catch(catchError('externalMessages.remove'))
-		}
-		toggleHoldMessage(msg: ExternalMessageQueueObj) {
-			MeteorCall.externalMessages.toggleHold(msg._id).catch(catchError('externalMessages.toggleHold'))
-		}
-		retryMessage(msg: ExternalMessageQueueObj) {
-			MeteorCall.externalMessages.retry(msg._id).catch(catchError('externalMessages.retry'))
-		}
-		renderMessageRow(msg: ExternalMessageQueueObj) {
-			const classes: string[] = ['message-row']
-			let info: JSX.Element | null = null
-			if (msg.sent) {
-				classes.push('sent')
-				info = (
-					<div>
-						<b>Sent: </b>
-						<MomentFromNow unit="seconds">{msg.sent}</MomentFromNow>
-					</div>
-				)
-			} else if (
-				getCurrentTime() - (msg.lastTry || 0) < 10 * 1000 &&
-				(msg.lastTry || 0) > (msg.errorMessageTime || 0)
-			) {
-				classes.push('sending')
-				info = (
-					<div>
-						<b>Sending...</b>
-					</div>
-				)
-			} else if (msg.errorFatal) {
-				classes.push('fatal')
-				info = (
-					<div>
-						<b>Fatal error: </b>
-						<span className="text-s vsubtle">{msg.errorMessage}</span>
-					</div>
-				)
-			} else if (msg.errorMessage) {
-				classes.push('error')
-				info = (
-					<div>
-						<b>Error: </b>
-						<span className="text-s vsubtle">{msg.errorMessage}</span>
-						<div>
-							<MomentFromNow>{msg.errorMessageTime}</MomentFromNow>
-						</div>
-					</div>
-				)
-			} else {
-				classes.push('waiting')
-				if (msg.tryCount) {
-					info = (
-						<div>
-							<b>Tried {msg.tryCount} times</b>
-						</div>
-					)
 				}
-				if (msg.lastTry) {
-					info = (
-						<div>
-							<b>Last try: </b>
-							<MomentFromNow unit="seconds">{msg.lastTry}</MomentFromNow>
-						</div>
-					)
-				}
-			}
-			return (
-				<tr key={unprotectString(msg._id)} className={ClassNames(classes)}>
-					<td className="c2">
-						{getAllowConfigure() ? (
-							<React.Fragment>
-								<button className="action-btn" onClick={() => this.removeMessage(msg)}>
-									<FontAwesomeIcon icon={faTrash} />
-								</button>
-								<button className="action-btn" onClick={() => this.toggleHoldMessage(msg)}>
-									{msg.hold ? <FontAwesomeIcon icon={faPlay} /> : <FontAwesomeIcon icon={faPause} />}
-								</button>
-								<button className="action-btn" onClick={() => this.retryMessage(msg)}>
-									<FontAwesomeIcon icon={faRedo} />
-								</button>
-								<br />
-							</React.Fragment>
-						) : null}
-						ID: {unprotectString(msg._id)}
-						<br />
-						Created: <MomentFromNow unit="seconds">{msg.created}</MomentFromNow>
-						{msg.queueForLaterReason !== undefined ? (
-							<div>
-								<b>Queued for later due to: {msg.queueForLaterReason || 'Unknown reason'}</b>
-							</div>
-						) : null}
-					</td>
-					<td className="c7 small">
-						<div>{info}</div>
-						<div>
-							<div>
-								<strong>Receiver</strong>
-								<br />
-								{makeTableOfObject(msg.receiver)}
-							</div>
-							<div>
-								<strong>Message</strong>
-								<br />
-								{makeTableOfObject(msg.message)}
-							</div>
-						</div>
-					</td>
-				</tr>
-			)
-		}
+			).fetch(),
+		[studioId],
+		[]
+	)
 
-		renderQueuedMessages() {
-			const { t } = this.props
-			return (
+	return (
+		<div>
+			<h2>{t('Queued Messages')}</h2>
+			<table className="table system-status-table">
+				<tbody>
+					{queuedMessages.map((msg) => (
+						<ExternalMessagesRow key={unprotectString(msg._id)} msg={msg} />
+					))}
+				</tbody>
+			</table>
+		</div>
+	)
+}
+
+interface ExternalMessagesSentMessagesProps {
+	studioId: StudioId
+}
+function ExternalMessagesSentMessages({ studioId }: Readonly<ExternalMessagesSentMessagesProps>) {
+	const { t } = useTranslation()
+
+	const sentMessages = useTracker(
+		() =>
+			ExternalMessageQueue.find(
+				{
+					studioId: studioId,
+					sent: { $gt: 0 },
+				},
+				{
+					sort: {
+						sent: -1,
+						lastTry: -1,
+					},
+				}
+			).fetch(),
+		[studioId],
+		[]
+	)
+
+	return (
+		<div>
+			<h2>{t('Sent Messages')}</h2>
+			<table className="table system-status-table">
+				<tbody>
+					{sentMessages.map((msg) => (
+						<ExternalMessagesRow key={unprotectString(msg._id)} msg={msg} />
+					))}
+				</tbody>
+			</table>
+		</div>
+	)
+}
+
+interface ExternalMessagesRowProps {
+	msg: ExternalMessageQueueObj
+}
+function ExternalMessagesRow({ msg }: Readonly<ExternalMessagesRowProps>) {
+	const removeMessage = useCallback(() => {
+		MeteorCall.externalMessages.remove(msg._id).catch(catchError('externalMessages.remove'))
+	}, [msg._id])
+	const toggleHoldMessage = useCallback(() => {
+		MeteorCall.externalMessages.toggleHold(msg._id).catch(catchError('externalMessages.toggleHold'))
+	}, [msg._id])
+	const retryMessage = useCallback(() => {
+		MeteorCall.externalMessages.retry(msg._id).catch(catchError('externalMessages.retry'))
+	}, [msg._id])
+
+	const classes: string[] = ['message-row']
+	let info: JSX.Element | null = null
+	if (msg.sent) {
+		classes.push('sent')
+		info = (
+			<div>
+				<b>Sent: </b>
+				<MomentFromNow unit="seconds">{msg.sent}</MomentFromNow>
+			</div>
+		)
+	} else if (getCurrentTime() - (msg.lastTry || 0) < 10 * 1000 && (msg.lastTry || 0) > (msg.errorMessageTime || 0)) {
+		classes.push('sending')
+		info = (
+			<div>
+				<b>Sending...</b>
+			</div>
+		)
+	} else if (msg.errorFatal) {
+		classes.push('fatal')
+		info = (
+			<div>
+				<b>Fatal error: </b>
+				<span className="text-s vsubtle">{msg.errorMessage}</span>
+			</div>
+		)
+	} else if (msg.errorMessage) {
+		classes.push('error')
+		info = (
+			<div>
+				<b>Error: </b>
+				<span className="text-s vsubtle">{msg.errorMessage}</span>
 				<div>
-					<h2>{t('Queued Messages')}</h2>
-					<table className="table system-status-table">
-						<tbody>
-							{_.map(this.props.queuedMessages, (msg) => {
-								return this.renderMessageRow(msg)
-							})}
-						</tbody>
-					</table>
+					<MomentFromNow>{msg.errorMessageTime}</MomentFromNow>
+				</div>
+			</div>
+		)
+	} else {
+		classes.push('waiting')
+		if (msg.tryCount) {
+			info = (
+				<div>
+					<b>Tried {msg.tryCount} times</b>
 				</div>
 			)
 		}
-		renderSentMessages() {
-			const { t } = this.props
-			return (
+		if (msg.lastTry) {
+			info = (
 				<div>
-					<h2>{t('Sent Messages')}</h2>
-					<table className="table system-status-table">
-						<tbody>
-							{_.map(this.props.sentMessages, (msg) => {
-								return this.renderMessageRow(msg)
-							})}
-						</tbody>
-					</table>
-				</div>
-			)
-		}
-		handleChangeDate = (from: Time, to: Time) => {
-			this.setState({
-				dateFrom: from,
-				dateTo: to,
-			})
-		}
-
-		render(): JSX.Element {
-			return (
-				<div className="mhl gutter external-message-status">
-					<div className="paging alc">
-						<DatePickerFromTo from={this.state.dateFrom} to={this.state.dateTo} onChange={this.handleChangeDate} />
-					</div>
-					<div className="mod mvl">
-						{this.renderQueuedMessages()}
-						{this.renderSentMessages()}
-					</div>
+					<b>Last try: </b>
+					<MomentFromNow unit="seconds">{msg.lastTry}</MomentFromNow>
 				</div>
 			)
 		}
 	}
-)
+	return (
+		<tr key={unprotectString(msg._id)} className={ClassNames(classes)}>
+			<td className="c2">
+				{getAllowConfigure() ? (
+					<React.Fragment>
+						<button className="action-btn" onClick={removeMessage}>
+							<FontAwesomeIcon icon={faTrash} />
+						</button>
+						<button className="action-btn" onClick={toggleHoldMessage}>
+							{msg.hold ? <FontAwesomeIcon icon={faPlay} /> : <FontAwesomeIcon icon={faPause} />}
+						</button>
+						<button className="action-btn" onClick={retryMessage}>
+							<FontAwesomeIcon icon={faRedo} />
+						</button>
+						<br />
+					</React.Fragment>
+				) : null}
+				ID: {unprotectString(msg._id)}
+				<br />
+				Created: <MomentFromNow unit="seconds">{msg.created}</MomentFromNow>
+				{msg.queueForLaterReason !== undefined ? (
+					<div>
+						<b>Queued for later due to: {msg.queueForLaterReason || 'Unknown reason'}</b>
+					</div>
+				) : null}
+			</td>
+			<td className="c7 small">
+				<div>{info}</div>
+				<div>
+					<div>
+						<strong>Receiver</strong>
+						<br />
+						{makeTableOfObject(msg.receiver)}
+					</div>
+					<div>
+						<strong>Message</strong>
+						<br />
+						{makeTableOfObject(msg.message)}
+					</div>
+				</div>
+			</td>
+		</tr>
+	)
+}
+
 export { ExternalMessages }


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
This pull request is posted on behalf of the NRK.




## Type of Contribution
This is a bug fix



## New Behavior
The MeteorReactComponent class has been found to be not close subscriptions when rerunning computations.
The simplest and most reliable way to mitigate this is to replace this class with functional components can instead use the native react flow/approach to tracking lifecycle.




## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
