### PR TITLE
fix: cleanup for deviceTriggers RundownContentObserver failing SOFIE-2834

### DIFF
--- a/meteor/server/api/deviceTriggers/RundownContentObserver.ts
+++ b/meteor/server/api/deviceTriggers/RundownContentObserver.ts
@@ -37,7 +37,8 @@ export class RundownContentObserver {
 	#observers: Meteor.LiveQueryHandle[] = []
 	#cache: ContentCache
 	#cancelCache: () => void
-	#cleanup: () => void
+	#cleanup: (() => void) | undefined
+	#disposed = false
 
 	constructor(
 		rundownPlaylistId: RundownPlaylistId,
@@ -49,6 +50,7 @@ export class RundownContentObserver {
 		logger.silly(`Creating RundownContentObserver for playlist "${rundownPlaylistId}" activation "${activationId}"`)
 		const { cache, cancel: cancelCache } = createReactiveContentCache(() => {
 			this.#cleanup = onChanged(cache)
+			if (this.#disposed) this.#cleanup()
 		}, REACTIVITY_DEBOUNCE)
 
 		this.#cache = cache
@@ -143,8 +145,9 @@ export class RundownContentObserver {
 	}
 
 	public stop = (): void => {
+		this.#disposed = true
 		this.#cancelCache()
 		this.#observers.forEach((observer) => observer.stop())
-		this.#cleanup()
+		this.#cleanup?.()
 	}
 }


### PR DESCRIPTION

<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
This pull request is posted on behalf of the NRK.


## Type of Contribution

This is a: Bug fix 

## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->


## New Behavior
<!--
What is the new behavior?
-->


## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
