### PR TITLE
fix: looks for the correct property itemSlug on ncsItems

### DIFF
--- a/meteor/client/ui/Shelf/ExternalFramePanel.tsx
+++ b/meteor/client/ui/Shelf/ExternalFramePanel.tsx
@@ -221,6 +221,12 @@ export const ExternalFramePanel = withTranslation()(
 
 			const mosTypes = getMosTypes(MOS_DATA_IS_STRICT)
 
+			const name = mosItem.Slug
+				? mosTypes.mosString128.stringify(mosItem.Slug)
+				: mosItem.ObjectSlug
+				? mosTypes.mosString128.stringify(mosItem.ObjectSlug)
+				: ''
+
 			doUserAction(t, e, UserAction.INGEST_BUCKET_ADLIB, (e, ts) =>
 				MeteorCall.userAction.bucketAdlibImport(
 					e,
@@ -229,7 +235,7 @@ export const ExternalFramePanel = withTranslation()(
 					showStyleBaseId,
 					literal<IngestAdlib>({
 						externalId: mosItem.ObjectID ? mosTypes.mosString128.stringify(mosItem.ObjectID) : '',
-						name: mosItem.ObjectSlug ? mosTypes.mosString128.stringify(mosItem.ObjectSlug) : '',
+						name,
 						payloadType: 'MOS',
 						payload: stringifyMosObject(mosItem, MOS_DATA_IS_STRICT),
 					})


### PR DESCRIPTION
## About the Contributor
This pull request is posted on behalf of the NRK.

## Type of Contribution
This is a: Bug fix


## Current Behavior
When dropping an item from a mos plugin into Sofie, the item should be an `ncsItem`. The main slug-property of an ncsItem is called `itemSlug`. However, Sofie is expecting to read a property called `objSlug`, which pr. definition doesn’t exist on ncsItems.

If a mos plugin provides an on-spec ncsItem, Sofie will fail to read its slug.


## New Behavior
Sofie will try to correctly look for a property of itemSlug, then fall back to the old behaviour of wrongly looking for objSlug. Meaning this change is backwards compatible/non-breaking.


## Testing Instructions
Dropping this snippet into a Bucket will prior to this fix lead to `bucketAdlibImport` running with an empty string as the name property. After this fix, the string "ExampleClip" should appear as the name property.

```
<mos>
  <ncsItem>
    <item>
      <itemID>0</itemID>
      <itemSlug>ExampleClip</itemSlug>
      <objID>0000-1111-2222-3333</objID>
      <mosID>TEST.NRK.MOS</mosID>
      <mosPluginID>PLUGIN.TEST.NRK.MOS</mosPluginID>
      <mosAbstract>ExampleClip</mosAbstract>
      <objPaths>
        <objPath techDescription="VIDEO">\\path\to\clip.ext</objPath>
      </objPaths>
      <itemEdStart>0</itemEdStart>
      <itemEdDur>742</itemEdDur>
      <mosExternalMetadata>
        <mosScope>STORY</mosScope>
        <mosSchema>UNKNOWN</mosSchema>
        <mosPayload>
          <isPlaceHolder>false</isPlaceHolder>
        </mosPayload>
      </mosExternalMetadata>
    </item>
  </ncsItem>
</mos>
```


## Other Information


## Status

- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
