### PR TITLE
fix: nora hoverscrub not showing content on first load SOFIE-2819 (r50)

### DIFF
--- a/meteor/client/ui/FloatingInspectors/L3rdFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/L3rdFloatingInspector.tsx
@@ -83,7 +83,7 @@ export const L3rdFloatingInspector: React.FunctionComponent<IProps> = ({
 
 	return noraContent && noraContent.payload && noraContent.previewRenderer ? (
 		showMiniInspector ? (
-			<NoraFloatingInspector ref={ref} noraContent={noraContent} style={floatingInspectorStyle ?? {}} />
+			<NoraFloatingInspector ref={ref} noraContent={noraContent} style={floatingInspectorStyle} />
 		) : null
 	) : (
 		<FloatingInspector shown={showMiniInspector} displayOn="viewport">

--- a/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
@@ -158,16 +158,19 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 	}
 
 	private _onNoraMessage = (msg: MessageEvent): void => {
+		if (!this.state.noraContent) return
+
+		const rendererUrl = new URL(this.state.noraContent.previewRenderer)
+		if (rendererUrl.origin !== msg.origin) return
+
 		if (msg.source !== this.iframeElement?.contentWindow) return
 		if (msg.data.event === 'nora-render') {
-			console.log('nora-render', msg)
-
 			if (msg.data.data.loaded) {
 				// Nora has loaded, dispatch the initial content
 
 				// Future: this may want to be done via `onload` on the iframe in the future to allow for non-nora renderers to work
 
-				if (this.state.noraContent && this.iframeElement?.contentWindow) {
+				if (this.iframeElement?.contentWindow) {
 					this.postNoraEvent(this.iframeElement.contentWindow, this.state.noraContent)
 				}
 			}

--- a/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useImperativeHandle } from 'react'
 import { NoraContent } from '@sofie-automation/blueprints-integration'
 import Escape from './../../lib/Escape'
+import _ from 'underscore'
 
 interface IPropsHeader {
 	noraContent: NoraContent | undefined
-	style: React.CSSProperties
+	style: React.CSSProperties | undefined
 }
 
 interface IStateHeader extends IPropsHeader {
@@ -45,10 +46,10 @@ export const NoraFloatingInspector = React.forwardRef<HTMLDivElement, IPropsHead
 export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 	static _singletonRef: NoraPreviewRenderer
 
-	iframeElement: HTMLIFrameElement
+	iframeElement: HTMLIFrameElement | null = null
 	rootElement: HTMLDivElement
 
-	static update(noraContent: NoraContent, style: React.CSSProperties): void {
+	static update(noraContent: NoraContent, style: React.CSSProperties | undefined): void {
 		NoraPreviewRenderer._singletonRef._update(noraContent, style)
 	}
 
@@ -69,6 +70,18 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 			style: {},
 		}
 		NoraPreviewRenderer._singletonRef = this
+	}
+
+	componentDidMount(): void {
+		window.addEventListener('message', this._onNoraMessage)
+	}
+
+	componentWillUnmount(): void {
+		window.removeEventListener('message', this._onNoraMessage)
+	}
+
+	shouldComponentUpdate(_nextProps: {}, nextState: IStateHeader, _nextContext: unknown): boolean {
+		return !_.isEqual(nextState, this.state)
 	}
 
 	private postNoraEvent(contentWindow: Window, noraContent: NoraContent) {
@@ -107,17 +120,22 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 		})
 	}
 
-	private _update(noraContent: NoraContent, style: React.CSSProperties) {
+	private _update(noraContent: NoraContent, style: React.CSSProperties | undefined) {
+		const stateUpdate: Partial<IStateHeader> = {}
+
 		if (JSON.stringify(this.state.noraContent) !== JSON.stringify(noraContent)) {
-			if (this.iframeElement && this.iframeElement.contentWindow) {
+			if (this.iframeElement?.contentWindow) {
 				this.postNoraEvent(this.iframeElement.contentWindow, noraContent)
 			}
+
+			stateUpdate.noraContent = noraContent
 		}
 
-		this.setState({
-			noraContent,
-			style,
-		})
+		if (JSON.stringify(this.state.style) !== JSON.stringify(style)) {
+			stateUpdate.style = style
+		}
+
+		this.setState(stateUpdate as Pick<IStateHeader, 'noraContent'>)
 	}
 
 	private _hide() {
@@ -126,18 +144,9 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 		})
 	}
 
-	private _setPreview = (e: HTMLIFrameElement) => {
+	private _setIFrameElement = (e: HTMLIFrameElement | null) => {
 		if (!e) return
 		this.iframeElement = e
-		const noraContent = this.state.noraContent
-		window.onmessage = (msg) => {
-			if (msg.data.source === 'nora-render') console.log(msg)
-		}
-		setTimeout(() => {
-			if (e.contentWindow && noraContent) {
-				this.postNoraEvent(e.contentWindow, noraContent)
-			}
-		}, 1000)
 
 		// set up IntersectionObserver to keep the preview inside the viewport
 		const options = {
@@ -145,6 +154,23 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 		}
 		for (let i = 0; i < 50; i++) {
 			options.threshold.push(i / 50)
+		}
+	}
+
+	private _onNoraMessage = (msg: MessageEvent): void => {
+		if (msg.source !== this.iframeElement?.contentWindow) return
+		if (msg.data.event === 'nora-render') {
+			console.log('nora-render', msg)
+
+			if (msg.data.data.loaded) {
+				// Nora has loaded, dispatch the initial content
+
+				// Future: this may want to be done via `onload` on the iframe in the future to allow for non-nora renderers to work
+
+				if (this.state.noraContent && this.iframeElement?.contentWindow) {
+					this.postNoraEvent(this.iframeElement.contentWindow, this.state.noraContent)
+				}
+			}
 		}
 	}
 
@@ -162,37 +188,40 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 		const stepContent = this.state.noraContent?.payload?.step
 		const isMultiStep = this.state.noraContent?.payload?.step?.enabled === true
 
+		const rendererUrl = this.state.noraContent?.previewRenderer
+
 		return (
-			<React.Fragment>
-				<Escape to="document">
-					<div
-						className="segment-timeline__mini-inspector segment-timeline__mini-inspector--graphics segment-timeline__mini-inspector--graphics--preview"
-						style={this.getElStyle()}
-						ref={this._setRootElement}
-					>
-						<div className="preview">
-							<img width="100%" src="/images/previewBG.jpg" alt="" />
+			<Escape to="document">
+				<div
+					className="segment-timeline__mini-inspector segment-timeline__mini-inspector--graphics segment-timeline__mini-inspector--graphics--preview"
+					style={this.getElStyle()}
+					ref={this._setRootElement}
+				>
+					<div className="preview">
+						<img width="100%" src="/images/previewBG.jpg" alt="" />
+						{rendererUrl && (
 							<iframe
+								key={rendererUrl} // Use the url as the key, so that the old renderer unloads immediately when changing url
 								sandbox="allow-scripts allow-same-origin"
-								src={this.state.noraContent?.previewRenderer}
-								ref={this._setPreview}
+								src={rendererUrl}
+								ref={this._setIFrameElement}
 								width="1920"
 								height="1080"
 							></iframe>
-						</div>
-						{isMultiStep && stepContent ? (
-							<div className="segment-timeline__mini-inspector--graphics--preview__step-chevron">
-								{stepContent.to === 'next' ? (stepContent.from || 0) + 1 : stepContent.to || 1}
-								{typeof stepContent.total === 'number' && stepContent.total > 0 ? (
-									<span className="segment-timeline__mini-inspector--graphics--preview__step-chevron__total">
-										/{stepContent.total}
-									</span>
-								) : null}
-							</div>
-						) : null}
+						)}
 					</div>
-				</Escape>
-			</React.Fragment>
+					{isMultiStep && stepContent ? (
+						<div className="segment-timeline__mini-inspector--graphics--preview__step-chevron">
+							{stepContent.to === 'next' ? (stepContent.from || 0) + 1 : stepContent.to || 1}
+							{typeof stepContent.total === 'number' && stepContent.total > 0 ? (
+								<span className="segment-timeline__mini-inspector--graphics--preview__step-chevron__total">
+									/{stepContent.total}
+								</span>
+							) : null}
+						</div>
+					) : null}
+				</div>
+			</Escape>
 		)
 	}
 }


### PR DESCRIPTION
This is a R50 version of https://github.com/nrkno/sofie-core/pull/1119, as there are merge conflicts

## About the Contributor
This pull request is posted on behalf of the NRK.


## Type of Contribution

This is a: Bug fix 

## Current Behavior
When hovering over a nora piece, the preview doesn't show once the renderer loads. It will load for the second piece you hover over.
This gets worse if there are multiple renderers used on the page, as it is the first piece each time the renderer url changes that doesnt display.


## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
