### PR TITLE
feat: allow blueprints to specify a custom resolution for NORA hover preview SOFIE-2840

### DIFF
--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -2939,12 +2939,24 @@ svg.icon {
 		border: 1px solid #1f1f1f;
 		border-radius: 0px;
 		transform: translate(-100%, -100%);
-		width: 480px;
-		height: 270px;
 		max-width: none;
 
+		// Default values
+		--preview-render-width: 1920;
+		--preview-render-height: 1080;
+		--preview-max-dimension: 480;
+		--preview-scale: calc(
+			var(--preview-max-dimension) / max(var(--preview-render-width), var(--preview-render-height))
+		);
+
+		width: calc(var(--preview-render-width) * var(--preview-scale) * 1px);
+		height: calc(var(--preview-render-height) * var(--preview-scale) * 1px);
+
 		> .preview {
-			transform: translate(-50%, 0rem) scale(0.249479);
+			transform: translate(-50%, 0rem) scale(var(--preview-scale));
+			width: calc(var(--preview-render-width) * 1px);
+			height: calc(var(--preview-render-height) * 1px);
+
 			position: relative;
 			left: 50%;
 			top: 0;
@@ -2953,6 +2965,9 @@ svg.icon {
 			img {
 				object-fit: cover;
 				object-position: center bottom;
+
+				width: calc(var(--preview-render-width) * 1px);
+				height: calc(var(--preview-render-height) * 1px);
 			}
 
 			> iframe {
@@ -2962,6 +2977,9 @@ svg.icon {
 				transform: translate(-50%, -50%);
 				transform-origin: center center;
 				border: 0;
+
+				width: calc(var(--preview-render-width) * 1px);
+				height: calc(var(--preview-render-height) * 1px);
 			}
 		}
 	}

--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -2944,8 +2944,6 @@ svg.icon {
 		max-width: none;
 
 		> .preview {
-			width: 1920px;
-			height: 1080px;
 			transform: translate(-50%, 0rem) scale(0.249479);
 			position: relative;
 			left: 50%;

--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -2950,6 +2950,11 @@ svg.icon {
 			top: 0;
 			transform-origin: center top;
 
+			img {
+				object-fit: cover;
+				object-position: center bottom;
+			}
+
 			> iframe {
 				position: absolute;
 				left: 50%;

--- a/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
@@ -181,9 +181,20 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 		this.rootElement = e
 	}
 
-	private getElStyle() {
+	private getElStyle(width: number, height: number) {
 		const style = { ...this.state.style }
 		style.visibility = this.state.show ? 'visible' : 'hidden'
+		style.width = `${width / 4}px`
+		style.height = `${height / 4}px`
+		return style
+	}
+
+	private getPreviewStyle(width: number, height: number) {
+		const style: React.CSSProperties = {
+			width: `${width}px`,
+			height: `${height}px`,
+		}
+
 		return style
 	}
 
@@ -193,23 +204,30 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 
 		const rendererUrl = this.state.noraContent?.previewRenderer
 
+		const dimensions = this.state.noraContent?.previewRendererDimensions
+		const renderWidth = dimensions?.width ?? 1920
+		const renderHeight = dimensions?.height ?? 1080
+
+		const rootElmStyle = { ...this.state.style }
+		rootElmStyle.visibility = this.state.show ? 'visible' : 'hidden'
+
 		return (
 			<Escape to="document">
 				<div
 					className="segment-timeline__mini-inspector segment-timeline__mini-inspector--graphics segment-timeline__mini-inspector--graphics--preview"
-					style={this.getElStyle()}
+					style={this.getElStyle(renderWidth, renderHeight)}
 					ref={this._setRootElement}
 				>
-					<div className="preview">
-						<img width="100%" src="/images/previewBG.jpg" alt="" />
+					<div className="preview" style={this.getPreviewStyle(renderWidth, renderHeight)}>
+						<img src="/images/previewBG.jpg" alt="" width={renderWidth} height={renderHeight} />
 						{rendererUrl && (
 							<iframe
 								key={rendererUrl} // Use the url as the key, so that the old renderer unloads immediately when changing url
 								sandbox="allow-scripts allow-same-origin"
 								src={rendererUrl}
 								ref={this._setIFrameElement}
-								width="1920"
-								height="1080"
+								width={renderWidth}
+								height={renderHeight}
 							></iframe>
 						)}
 					</div>

--- a/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
@@ -139,9 +139,9 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 	}
 
 	private _hide() {
-		this.setState({
-			show: false,
-		})
+		// this.setState({
+		// 	show: false,
+		// })
 	}
 
 	private _setIFrameElement = (e: HTMLIFrameElement | null) => {
@@ -181,18 +181,13 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 		this.rootElement = e
 	}
 
-	private getElStyle(width: number, height: number) {
+	private getElStyle(dimensions: { width: number; height: number } | undefined) {
 		const style = { ...this.state.style }
 		style.visibility = this.state.show ? 'visible' : 'hidden'
-		style.width = `${width / 4}px`
-		style.height = `${height / 4}px`
-		return style
-	}
 
-	private getPreviewStyle(width: number, height: number) {
-		const style: React.CSSProperties = {
-			width: `${width}px`,
-			height: `${height}px`,
+		if (dimensions) {
+			style['--preview-render-width'] = dimensions.width
+			style['--preview-render-height'] = dimensions.height
 		}
 
 		return style
@@ -205,8 +200,6 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 		const rendererUrl = this.state.noraContent?.previewRenderer
 
 		const dimensions = this.state.noraContent?.previewRendererDimensions
-		const renderWidth = dimensions?.width ?? 1920
-		const renderHeight = dimensions?.height ?? 1080
 
 		const rootElmStyle = { ...this.state.style }
 		rootElmStyle.visibility = this.state.show ? 'visible' : 'hidden'
@@ -215,19 +208,17 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 			<Escape to="document">
 				<div
 					className="segment-timeline__mini-inspector segment-timeline__mini-inspector--graphics segment-timeline__mini-inspector--graphics--preview"
-					style={this.getElStyle(renderWidth, renderHeight)}
+					style={this.getElStyle(dimensions)}
 					ref={this._setRootElement}
 				>
-					<div className="preview" style={this.getPreviewStyle(renderWidth, renderHeight)}>
-						<img src="/images/previewBG.jpg" alt="" width={renderWidth} height={renderHeight} />
+					<div className="preview">
+						<img src="/images/previewBG.jpg" alt="" />
 						{rendererUrl && (
 							<iframe
 								key={rendererUrl} // Use the url as the key, so that the old renderer unloads immediately when changing url
 								sandbox="allow-scripts allow-same-origin"
 								src={rendererUrl}
 								ref={this._setIFrameElement}
-								width={renderWidth}
-								height={renderHeight}
 							></iframe>
 						)}
 					</div>

--- a/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
@@ -198,11 +198,7 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 		const isMultiStep = this.state.noraContent?.payload?.step?.enabled === true
 
 		const rendererUrl = this.state.noraContent?.previewRenderer
-
 		const dimensions = this.state.noraContent?.previewRendererDimensions
-
-		const rootElmStyle = { ...this.state.style }
-		rootElmStyle.visibility = this.state.show ? 'visible' : 'hidden'
 
 		return (
 			<Escape to="document">

--- a/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
@@ -139,9 +139,9 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 	}
 
 	private _hide() {
-		// this.setState({
-		// 	show: false,
-		// })
+		this.setState({
+			show: false,
+		})
 	}
 
 	private _setIFrameElement = (e: HTMLIFrameElement | null) => {

--- a/packages/blueprints-integration/src/content.ts
+++ b/packages/blueprints-integration/src/content.ts
@@ -125,6 +125,7 @@ export interface NoraPayload {
 export interface NoraContent extends BaseContent {
 	payload: NoraPayload
 	previewRenderer: string
+	previewRendererDimensions?: { width: number; height: number }
 }
 
 export interface SplitsContentBoxProperties {

--- a/packages/blueprints-integration/src/content.ts
+++ b/packages/blueprints-integration/src/content.ts
@@ -125,6 +125,7 @@ export interface NoraPayload {
 export interface NoraContent extends BaseContent {
 	payload: NoraPayload
 	previewRenderer: string
+	/** Dimensions of the rendered hover-preview viewport in pixels. Defaults to 1920x1080. */
 	previewRendererDimensions?: { width: number; height: number }
 }
 


### PR DESCRIPTION

## About the Contributor
This pull request is posted on behalf of the NRK.


## Type of Contribution

This is a:  Feature

## Current Behavior
The NORA hover preview is currently fixed at being run at a resolution of 1920x1080.

## New Behavior
The blueprints are able to specify a different resolution for the hover preview window, so that it can more accurately represent the content as it will be shown on video walls with other aspect ratios


## Testing Instructions
This requires custom blueprints which set the properties


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
