### PR TITLE
fix(core-integration): handle subscription error

### DIFF
--- a/packages/server-core-integration/src/lib/ddpClient.ts
+++ b/packages/server-core-integration/src/lib/ddpClient.ts
@@ -837,7 +837,12 @@ export class DDPClient extends EventEmitter<DDPClientEvents> {
 	}
 
 	// open a subscription on the server, callback should handle on ready and nosub
-	subscribe(subscriptionName: string, data: Array<unknown>, callback: () => void, reuseId?: string): string {
+	subscribe(
+		subscriptionName: string,
+		data: Array<unknown>,
+		callback: (error?: DDPError) => void,
+		reuseId?: string
+	): string {
 		const id = reuseId || this.getNextId()
 
 		if (callback) {

--- a/packages/server-core-integration/src/lib/subscriptions.ts
+++ b/packages/server-core-integration/src/lib/subscriptions.ts
@@ -46,11 +46,17 @@ export class SubscriptionsHelper<PubSubTypes> {
 				const subscriptionId = this.#ddp.ddpClient.subscribe(
 					publicationName, // name of Meteor Publish function to subscribe to
 					params.concat([this.#deviceToken]), // parameters used by the Publish function
-					() => {
-						// TODO - I think this callback has an error parameter?
-
-						// callback when the subscription is complete
-						resolve(protectString(subscriptionId))
+					(error) => {
+						if (error) {
+							reject(
+								new Error(
+									`Error from publication: ${error.errorType} [${error.error}] ${error.reason} ${error.message}`
+								)
+							)
+						} else {
+							// callback when the subscription is complete
+							resolve(protectString(subscriptionId))
+						}
 					},
 					unprotectString(existingSubscriptionId)
 				)


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->

This pull request is posted on behalf of the NRK.

## Type of Contribution

This is a: 
<!-- (pick one) -->
Bug fix


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

When using core-integration (so gateways or other external applications):

```typescript
const coreConnection = new CoreConnection(coreOptions)
await coreConnection.autoSubscribe('rundownPlaylists', myArguments)
```

If there is an error when subscribing (for example: a `Match.test()` throws, due to invalid arguments), the error is swallowed silently.

## New Behavior
<!--
What is the new behavior?
-->

The error is now thrown.


## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
