### PR TITLE
fix(live-status-gw): adLibs having invalid layers before the first take

### DIFF
--- a/packages/live-status-gateway/src/collections/rundownHandler.ts
+++ b/packages/live-status-gateway/src/collections/rundownHandler.ts
@@ -50,7 +50,7 @@ export class RundownHandler
 				break
 			case PartInstancesHandler.name:
 				this._logger.info(`${this._name} received partInstances update from ${source}`)
-				this._currentRundownId = partInstances.current?.rundownId
+				this._currentRundownId = partInstances.current?.rundownId ?? partInstances.next?.rundownId
 				break
 			default:
 				throw new Error(`${this._name} received unsupported update from ${source}}`)


### PR DESCRIPTION

<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This PR is being opened on behalf of TV 2 Norge.


## Type of Contribution

This is a: 
<!-- (pick one) -->
Bug fix


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->
In the Live Status Gateway, Adlibs that before the first take are sourced from the Rundown where the Next part is, have their layers reported as invalid until the first Take.

## New Behavior
<!--
What is the new behavior?
-->
Adlib layers are reported correctly even before the first Take.

## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->
Start the LSG and connect to it. Subscribe to the `activePlaylist` topic. Activate a Rundown Playlist. Observe the adlibs returned by the LSG.

## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
