### PR TITLE
feat: add `node-fetch` as a global to blueprint execution SOFIE-1367

### DIFF
--- a/meteor/yarn.lock
+++ b/meteor/yarn.lock
@@ -2174,6 +2174,7 @@ __metadata:
     elastic-apm-node: ^3.43.0
     eventemitter3: ^4.0.7
     mongodb: ^4.13.0
+    node-fetch: ^2.7.0
     p-lazy: ^3.1.0
     p-timeout: ^4.1.0
     superfly-timeline: ^8.3.1
@@ -9515,6 +9516,20 @@ __metadata:
     encoding:
       optional: true
   checksum: acb04f9ce7224965b2b59e71b33c639794d8991efd73855b0b250921382b38331ffc9d61bce502571f6cc6e11a8905ca9b1b6d4aeb586ab093e2756a1fd190d0
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^2.7.0":
+  version: 2.7.0
+  resolution: "node-fetch@npm:2.7.0"
+  dependencies:
+    whatwg-url: ^5.0.0
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: d76d2f5edb451a3f05b15115ec89fc6be39de37c6089f1b6368df03b91e1633fd379a7e01b7ab05089a25034b2023d959b47e59759cb38d88341b2459e89d6e5
   languageName: node
   linkType: hard
 

--- a/packages/job-worker/package.json
+++ b/packages/job-worker/package.json
@@ -49,6 +49,7 @@
 		"elastic-apm-node": "^3.43.0",
 		"eventemitter3": "^4.0.7",
 		"mongodb": "^4.13.0",
+		"node-fetch": "^2.7.0",
 		"p-lazy": "^3.1.0",
 		"p-timeout": "^4.1.0",
 		"superfly-timeline": "^8.3.1",

--- a/packages/job-worker/src/blueprints/cache.ts
+++ b/packages/job-worker/src/blueprints/cache.ts
@@ -9,6 +9,7 @@ import { VM, VMScript } from 'vm2'
 import { ReadonlyDeep } from 'type-fest'
 import { stringifyError } from '@sofie-automation/shared-lib/dist/lib/stringifyError'
 import { Blueprint } from '@sofie-automation/corelib/dist/dataModel/Blueprint'
+import fetch from 'node-fetch'
 
 export interface WrappedSystemBlueprint {
 	blueprintId: BlueprintId
@@ -54,7 +55,9 @@ export async function parseBlueprintDocument(
 		let manifest: SomeBlueprintManifest
 		try {
 			const vm = new VM({
-				sandbox: {},
+				sandbox: {
+					fetch: fetch, // Future: This should be removed once node18 native fetch is available
+				},
 			})
 
 			const blueprintPath = `db:///blueprint/${blueprint.name || blueprint._id}-bundle.js`

--- a/packages/package.json
+++ b/packages/package.json
@@ -44,6 +44,7 @@
 		"@types/got": "^9.6.12",
 		"@types/jest": "^29.5.0",
 		"@types/node": "^14.18.12",
+		"@types/node-fetch": "^2.6.11",
 		"@types/object-path": "^0.11.1",
 		"@types/underscore": "^1.11.4",
 		"babel-jest": "^29.5.0",

--- a/packages/yarn.lock
+++ b/packages/yarn.lock
@@ -5426,6 +5426,7 @@ __metadata:
     elastic-apm-node: ^3.43.0
     eventemitter3: ^4.0.7
     mongodb: ^4.13.0
+    node-fetch: ^2.7.0
     p-lazy: ^3.1.0
     p-timeout: ^4.1.0
     superfly-timeline: ^8.3.1
@@ -6214,6 +6215,16 @@ __metadata:
   version: 0.7.31
   resolution: "@types/ms@npm:0.7.31"
   checksum: daadd354aedde024cce6f5aa873fefe7b71b22cd0e28632a69e8b677aeb48ae8caa1c60e5919bb781df040d116b01cb4316335167a3fc0ef6a63fa3614c0f6da
+  languageName: node
+  linkType: hard
+
+"@types/node-fetch@npm:^2.6.11":
+  version: 2.6.11
+  resolution: "@types/node-fetch@npm:2.6.11"
+  dependencies:
+    "@types/node": "*"
+    form-data: ^4.0.0
+  checksum: 180e4d44c432839bdf8a25251ef8c47d51e37355ddd78c64695225de8bc5dc2b50b7bb855956d471c026bb84bd7295688a0960085e7158cbbba803053492568b
   languageName: node
   linkType: hard
 
@@ -16666,6 +16677,20 @@ asn1@evs-broadcast/node-asn1:
   languageName: node
   linkType: hard
 
+"node-fetch@npm:^2.7.0":
+  version: 2.7.0
+  resolution: "node-fetch@npm:2.7.0"
+  dependencies:
+    whatwg-url: ^5.0.0
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: d76d2f5edb451a3f05b15115ec89fc6be39de37c6089f1b6368df03b91e1633fd379a7e01b7ab05089a25034b2023d959b47e59759cb38d88341b2459e89d6e5
+  languageName: node
+  linkType: hard
+
 "node-forge@npm:^1":
   version: 1.3.1
   resolution: "node-forge@npm:1.3.1"
@@ -17911,6 +17936,7 @@ asn1@evs-broadcast/node-asn1:
     "@types/got": ^9.6.12
     "@types/jest": ^29.5.0
     "@types/node": ^14.18.12
+    "@types/node-fetch": ^2.6.11
     "@types/object-path": ^0.11.1
     "@types/underscore": ^1.11.4
     babel-jest: ^29.5.0


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
This pull request is posted on behalf of the NRK.


## Type of Contribution

This is a: Feature

## New Behavior

This exposes a `fetch` global into blueprints, using `node-fetch` as the implementation.

While we are using `got` elsewhere, it feels bad to introduce `got` v11 into new usages, given that the current release of got is v14. It does appear to be getting security patches, but for how long?
By using `fetch`, it should provide a more seamless experience once we update to node18, as the builtin `fetch` implementation will be usable instead. `node-fetch` also looks to be better maintained, even though this is using the previous major version.


## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information

This is not necessary for R50, but it makes testing with storybuilder much easier as it allows for developing without needing package-manager to be setup and running.

## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
