### PR TITLE
fix: remove adlib action's publicData from userLog SOFIE-2939

### DIFF
--- a/meteor/server/api/rest/v1/playlists.ts
+++ b/meteor/server/api/rest/v1/playlists.ts
@@ -109,10 +109,10 @@ class PlaylistsServerAPI implements PlaylistsRestAPI {
 				segmentAdLibPiece,
 				bucketAdLibPiece,
 				AdLibActions.findOneAsync(adLibId as AdLibActionId, {
-					projection: { _id: 1, actionId: 1, userData: 1, privateData: 1 },
+					projection: { _id: 1, actionId: 1, userData: 1 },
 				}),
 				RundownBaselineAdLibActions.findOneAsync(adLibId as RundownBaselineAdLibActionId, {
-					projection: { _id: 1, actionId: 1, userData: 1, privateData: 1 },
+					projection: { _id: 1, actionId: 1, userData: 1 },
 				}),
 			]
 		)
@@ -204,7 +204,6 @@ class PlaylistsServerAPI implements PlaylistsRestAPI {
 					actionId: adLibActionDoc.actionId,
 					userData: adLibActionDoc.userData,
 					triggerMode: triggerMode ?? undefined,
-					privateData: adLibActionDoc.privateData,
 				}
 			)
 		} else {

--- a/meteor/server/api/userActions.ts
+++ b/meteor/server/api/userActions.ts
@@ -415,7 +415,6 @@ class ServerUserActionAPI
 				actionId,
 				userData,
 				triggerMode: triggerMode ?? undefined,
-				privateData: null,
 			}
 		)
 	}

--- a/packages/corelib/src/worker/studio.ts
+++ b/packages/corelib/src/worker/studio.ts
@@ -242,7 +242,6 @@ export interface ExecuteActionProps extends RundownPlayoutPropsBase {
 	actionId: string
 	userData: any
 	triggerMode?: string
-	privateData?: unknown | undefined | null
 }
 export interface ExecuteBucketAdLibOrActionProps extends RundownPlayoutPropsBase {
 	bucketId: BucketId

--- a/packages/job-worker/src/playout/__tests__/playout-executeAction.test.ts
+++ b/packages/job-worker/src/playout/__tests__/playout-executeAction.test.ts
@@ -57,7 +57,6 @@ describe('Playout API', () => {
 					actionDocId: actionDocId,
 					actionId: actionId,
 					userData: userData,
-					privateData: undefined,
 				})
 			).rejects.toMatchUserError(UserErrorMessage.ActionsNotSupported)
 
@@ -73,7 +72,6 @@ describe('Playout API', () => {
 					actionDocId,
 					actionId,
 					userData,
-					privateData: undefined,
 				})
 			).rejects.toMatchUserError(UserErrorMessage.InternalError)
 
@@ -99,7 +97,6 @@ describe('Playout API', () => {
 				actionDocId,
 				actionId,
 				userData,
-				privateData: undefined,
 			})
 
 			expect(syncPlayheadInfinitesForNextPartInstanceMock).toHaveBeenCalledTimes(0)
@@ -127,7 +124,6 @@ describe('Playout API', () => {
 				actionDocId,
 				actionId,
 				userData,
-				privateData: undefined,
 			})
 
 			expect(syncPlayheadInfinitesForNextPartInstanceMock).toHaveBeenCalledTimes(1)
@@ -155,7 +151,6 @@ describe('Playout API', () => {
 				actionDocId,
 				actionId,
 				userData,
-				privateData: undefined,
 			})
 
 			expect(syncPlayheadInfinitesForNextPartInstanceMock).toHaveBeenCalledTimes(1)
@@ -179,7 +174,6 @@ describe('Playout API', () => {
 				actionDocId,
 				actionId,
 				userData,
-				privateData: undefined,
 			})
 
 			expect(takeNextPartMock).toHaveBeenCalledTimes(1)
@@ -202,7 +196,6 @@ describe('Playout API', () => {
 				actionDocId,
 				actionId,
 				userData,
-				privateData: undefined,
 			})
 
 			expect(takeNextPartMock).toHaveBeenCalledTimes(0)

--- a/packages/job-worker/src/playout/adlibAction.ts
+++ b/packages/job-worker/src/playout/adlibAction.ts
@@ -81,30 +81,27 @@ export async function executeAdlibActionAndSaveModel(
 		},
 	})
 
-	if (data.privateData === null) {
-		const [adLibAction, baselineAdLibAction, bucketAdLibAction] = await Promise.all([
-			context.directCollections.AdLibActions.findOne(data.actionDocId as AdLibActionId, {
+	const [adLibAction, baselineAdLibAction, bucketAdLibAction] = await Promise.all([
+		context.directCollections.AdLibActions.findOne(data.actionDocId as AdLibActionId, {
+			projection: { _id: 1, privateData: 1 },
+		}),
+		context.directCollections.RundownBaselineAdLibActions.findOne(
+			data.actionDocId as RundownBaselineAdLibActionId,
+			{
 				projection: { _id: 1, privateData: 1 },
-			}),
-			context.directCollections.RundownBaselineAdLibActions.findOne(
-				data.actionDocId as RundownBaselineAdLibActionId,
-				{
-					projection: { _id: 1, privateData: 1 },
-				}
-			),
-			context.directCollections.BucketAdLibActions.findOne(data.actionDocId as BucketAdLibActionId, {
-				projection: { _id: 1, privateData: 1 },
-			}),
-		])
-		const adLibActionDoc = adLibAction ?? baselineAdLibAction ?? bucketAdLibAction
-		data.privateData = adLibActionDoc?.privateData
-	}
+			}
+		),
+		context.directCollections.BucketAdLibActions.findOne(data.actionDocId as BucketAdLibActionId, {
+			projection: { _id: 1, privateData: 1 },
+		}),
+	])
+	const adLibActionDoc = adLibAction ?? baselineAdLibAction ?? bucketAdLibAction
 
 	const actionParameters: ExecuteActionParameters = {
 		actionId: data.actionId,
 		userData: data.userData,
 		triggerMode: data.triggerMode,
-		privateData: data.privateData,
+		privateData: adLibActionDoc?.privateData,
 	}
 
 	try {


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This PR is being opened on behalf of TV 2 Norge.

## Type of Contribution

This is a: 
<!-- (pick one) -->
Bug fix


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->
Since around https://github.com/nrkno/sofie-core/pull/1077, `privateData` of Adlib Actions appears in the User Action Log when executing an adlib through the HTTP API. This is undesired as its confusing (privateData does not originate from the request) and it adds noise to the logs (in our case it contains entire Parts and Pieces generated ahead of time).

## New Behavior
<!--
What is the new behavior?
-->
`privateData` of Adlib Actions no longer appears in the User Action Log. It is fetched later, in the worker, just like when executing an adlib through Meteor API.

## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
