### PR TITLE
fix: check if segment should be immediately regenerated during ingest SOFIE-2887

### DIFF
--- a/packages/corelib/src/playout/timings.ts
+++ b/packages/corelib/src/playout/timings.ts
@@ -165,8 +165,10 @@ function calculateExpectedDurationWithPreroll(rawDuration: number, timings: Part
 	return Math.max(0, rawDuration + timings.toPartDelay - (timings.fromPartRemaining - timings.toPartDelay))
 }
 
+export type CalculateExpectedDurationPart = Pick<DBPart, 'inTransition' | 'expectedDuration'>
+
 export function calculatePartExpectedDurationWithPreroll(
-	part: DBPart,
+	part: CalculateExpectedDurationPart,
 	pieces: ReadonlyDeep<PieceInstancePiece[]>
 ): number | undefined {
 	if (part.expectedDuration === undefined) return undefined

--- a/packages/job-worker/src/__mocks__/collection.ts
+++ b/packages/job-worker/src/__mocks__/collection.ts
@@ -32,7 +32,7 @@ import {
 } from '@sofie-automation/corelib/dist/mongo'
 import { ProtectedString } from '@sofie-automation/corelib/dist/protectedString'
 import EventEmitter = require('eventemitter3')
-import { AnyBulkWriteOperation, Collection, FindOptions } from 'mongodb'
+import { AnyBulkWriteOperation, Collection, CountOptions, FindOptions } from 'mongodb'
 import { ReadonlyDeep } from 'type-fest'
 import { IChangeStream, IChangeStreamEvents, ICollection, IDirectCollections, MongoModifier, MongoQuery } from '../db'
 import _ = require('underscore')
@@ -154,6 +154,13 @@ export class MockMongoCollection<TDoc extends { _id: ProtectedString<any> }> imp
 		})
 		return docs[0]
 	}
+	async count(selector?: MongoQuery<TDoc> | TDoc['_id'], options?: CountOptions): Promise<number> {
+		this.#ops.push({ type: 'count', args: [selector, options] })
+
+		const docs = await this.findFetchInner(selector, options)
+		return docs.length
+	}
+
 	async insertOne(doc: TDoc | ReadonlyDeep<TDoc>): Promise<TDoc['_id']> {
 		this.#ops.push({ type: 'insertOne', args: [doc._id] })
 

--- a/packages/job-worker/src/blueprints/context/watchedPackages.ts
+++ b/packages/job-worker/src/blueprints/context/watchedPackages.ts
@@ -70,13 +70,10 @@ export class WatchedPackagesHelper {
 			}
 		}
 
-		// Load all the packages and the infos that are watched
-		const watchedPackageInfos = await context.directCollections.PackageInfos.findFetch({
-			studioId: context.studio._id,
-			packageId: { $in: packages.map((p) => p._id) },
-		})
-
-		return new WatchedPackagesHelper(packages, watchedPackageInfos)
+		return this.#createFromPackages(
+			context,
+			packages.filter((pkg) => !!pkg.listenToPackageInfoUpdates)
+		)
 	}
 
 	/**
@@ -101,6 +98,13 @@ export class WatchedPackagesHelper {
 			}
 		}
 
+		return this.#createFromPackages(
+			context,
+			packages.filter((pkg) => !!pkg.listenToPackageInfoUpdates)
+		)
+	}
+
+	static async #createFromPackages(context: JobContext, packages: ReadonlyDeep<ExpectedPackageDB>[]) {
 		// Load all the packages and the infos that are watched
 		const watchedPackageInfos =
 			packages.length > 0

--- a/packages/job-worker/src/blueprints/context/watchedPackages.ts
+++ b/packages/job-worker/src/blueprints/context/watchedPackages.ts
@@ -5,7 +5,7 @@ import {
 } from '@sofie-automation/corelib/dist/dataModel/ExpectedPackages'
 import { PackageInfoDB } from '@sofie-automation/corelib/dist/dataModel/PackageInfos'
 import { JobContext } from '../../jobs'
-import { StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { ExpectedPackageId, StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { Filter as FilterQuery } from 'mongodb'
 import { PackageInfo } from '@sofie-automation/blueprints-integration'
 import { unprotectObjectArray } from '@sofie-automation/corelib/dist/protectedString'
@@ -16,10 +16,16 @@ import { ReadonlyDeep } from 'type-fest'
  * This is a helper class to simplify exposing packageInfo to various places in the blueprints
  */
 export class WatchedPackagesHelper {
+	private readonly packages = new Map<ExpectedPackageId, ReadonlyDeep<ExpectedPackageDB>>()
+
 	private constructor(
-		private readonly packages: ReadonlyDeep<ExpectedPackageDB[]>,
+		packages: ReadonlyDeep<ExpectedPackageDB[]>,
 		private readonly packageInfos: ReadonlyDeep<PackageInfoDB[]>
-	) {}
+	) {
+		for (const pkg of packages) {
+			this.packages.set(pkg._id, pkg)
+		}
+	}
 
 	/**
 	 * Create a helper with no packages. This should be used where the api is in place, but the update flow hasnt been implemented yet so we don't want to expose any data
@@ -80,16 +86,16 @@ export class WatchedPackagesHelper {
 	 * Create a helper, and populate it with data from an IngestModel
 	 * @param studioId The studio this is for
 	 * @param ingestModel Model to fetch data for
-	 * @param segmentExternelIds ExternalId of Segments to be loaded
+	 * @param segmentExternalIds ExternalId of Segments to be loaded
 	 */
-	static async createForIngestSegment(
+	static async createForIngestSegments(
 		context: JobContext,
 		ingestModel: IngestModelReadonly,
-		segmentExternelIds: string[]
+		segmentExternalIds: string[]
 	): Promise<WatchedPackagesHelper> {
 		const packages: ReadonlyDeep<ExpectedPackageFromRundown>[] = []
 
-		for (const externalId of segmentExternelIds) {
+		for (const externalId of segmentExternalIds) {
 			const segment = ingestModel.getSegmentByExternalId(externalId)
 			if (!segment) continue // First ingest of the Segment
 
@@ -123,7 +129,10 @@ export class WatchedPackagesHelper {
 	 * @param func A filter to check if each package should be included
 	 */
 	filter(_context: JobContext, func: (pkg: ReadonlyDeep<ExpectedPackageDB>) => boolean): WatchedPackagesHelper {
-		const watchedPackages = this.packages.filter(func)
+		const watchedPackages: ReadonlyDeep<ExpectedPackageDB>[] = []
+		for (const pkg of this.packages.values()) {
+			if (func(pkg)) watchedPackages.push(pkg)
+		}
 
 		const newPackageIds = new Set(watchedPackages.map((p) => p._id))
 		const watchedPackageInfos = this.packageInfos.filter((info) => newPackageIds.has(info.packageId))
@@ -131,13 +140,18 @@ export class WatchedPackagesHelper {
 		return new WatchedPackagesHelper(watchedPackages, watchedPackageInfos)
 	}
 
+	getPackage(packageId: ExpectedPackageId): ReadonlyDeep<ExpectedPackageDB> | undefined {
+		return this.packages.get(packageId)
+	}
+
 	getPackageInfo(packageId: string): Readonly<Array<PackageInfo.Any>> {
-		const pkg = this.packages.find((pkg) => pkg.blueprintPackageId === packageId)
-		if (pkg) {
-			const info = this.packageInfos.filter((p) => p.packageId === pkg._id)
-			return unprotectObjectArray(info)
-		} else {
-			return []
+		for (const pkg of this.packages.values()) {
+			if (pkg.blueprintPackageId === packageId) {
+				const info = this.packageInfos.filter((p) => p.packageId === pkg._id)
+				return unprotectObjectArray(info)
+			}
 		}
+
+		return []
 	}
 }

--- a/packages/job-worker/src/db/collection.ts
+++ b/packages/job-worker/src/db/collection.ts
@@ -1,6 +1,6 @@
 import { ProtectedString, unprotectString } from '@sofie-automation/corelib/dist/protectedString'
 import { EventEmitter } from 'eventemitter3'
-import { AnyBulkWriteOperation, ChangeStream, Collection as MongoCollection, FindOptions } from 'mongodb'
+import { AnyBulkWriteOperation, ChangeStream, Collection as MongoCollection, FindOptions, CountOptions } from 'mongodb'
 import { IChangeStreamEvents } from '.'
 import { startSpanManual } from '../profiler'
 import { IChangeStream, ICollection, MongoModifier, MongoQuery } from './collections'
@@ -56,6 +56,19 @@ class WrappedCollection<TDoc extends { _id: ProtectedString<any> }> implements I
 		const res = await this.#collection.findOne(selector, options)
 		if (span) span.end()
 		return res ?? undefined
+	}
+
+	async count(selector: MongoQuery<TDoc> | TDoc['_id'], options?: CountOptions): Promise<number> {
+		const span = startSpanManual('WrappedCollection.count')
+		if (span) {
+			span.addLabels({
+				collection: this.name,
+				query: JSON.stringify(selector),
+			})
+		}
+		const res = await this.#collection.countDocuments(selector as any, options)
+		if (span) span.end()
+		return res
 	}
 
 	async insertOne(doc: TDoc): Promise<TDoc['_id']> {

--- a/packages/job-worker/src/db/collections.ts
+++ b/packages/job-worker/src/db/collections.ts
@@ -7,6 +7,7 @@ import {
 	UpdateFilter,
 	Collection as MongoCollection,
 	ChangeStreamDocument,
+	CountOptions,
 } from 'mongodb'
 import { wrapMongoCollection } from './collection'
 import { AdLibAction } from '@sofie-automation/corelib/dist/dataModel/AdlibAction'
@@ -53,6 +54,7 @@ export interface IReadOnlyCollection<TDoc extends { _id: ProtectedString<any> }>
 
 	findFetch(selector?: MongoQuery<TDoc>, options?: FindOptions<TDoc>): Promise<Array<TDoc>>
 	findOne(selector?: MongoQuery<TDoc> | TDoc['_id'], options?: FindOptions<TDoc>): Promise<TDoc | undefined>
+	count(selector?: MongoQuery<TDoc> | TDoc['_id'], options?: CountOptions): Promise<number>
 
 	/**
 	 * Watch the collection for changes

--- a/packages/job-worker/src/ingest/model/IngestModel.ts
+++ b/packages/job-worker/src/ingest/model/IngestModel.ts
@@ -99,6 +99,12 @@ export interface IngestModelReadonly {
 	getSegmentByExternalId(externalId: string): IngestSegmentModelReadonly | undefined
 
 	/**
+	 * Get the internal `_id` of a segment from the `externalId`
+	 * @param externalId External id of the Segment
+	 */
+	getSegmentIdFromExternalId(externalId: string): SegmentId
+
+	/**
 	 * Get a Segment from the Rundown
 	 * @param id Id of the Segment
 	 */
@@ -156,12 +162,6 @@ export interface IngestModel extends IngestModelReadonly, BaseModel {
 	getSegmentByExternalId(externalId: string): IngestSegmentModel | undefined
 
 	/**
-	 * Get the internal `_id` of a segment from the `externalId`
-	 * @param externalId External id of the Segment
-	 */
-	getSegmentIdFromExternalId(externalId: string): SegmentId
-
-	/**
 	 * Get a Segment from the Rundown
 	 * @param id Id of the Segment
 	 */
@@ -191,7 +191,7 @@ export interface IngestModel extends IngestModelReadonly, BaseModel {
 	 * Replace or insert a Segment in this Rundown
 	 * @param segment New Segment data
 	 */
-	replaceSegment(segment: Omit<DBSegment, '_id' | 'rundownId'>): IngestSegmentModel
+	replaceSegment(segment: IngestReplaceSegmentType): IngestSegmentModel
 
 	/**
 	 * Change the id of a Segment in this Rundown.
@@ -277,3 +277,5 @@ export interface IngestModel extends IngestModelReadonly, BaseModel {
 	 */
 	appendRundownNotes(...notes: RundownNote[]): void
 }
+
+export type IngestReplaceSegmentType = Omit<DBSegment, '_id' | 'rundownId'>

--- a/packages/job-worker/src/ingest/model/IngestModel.ts
+++ b/packages/job-worker/src/ingest/model/IngestModel.ts
@@ -156,6 +156,12 @@ export interface IngestModel extends IngestModelReadonly, BaseModel {
 	getSegmentByExternalId(externalId: string): IngestSegmentModel | undefined
 
 	/**
+	 * Get the internal `_id` of a segment from the `externalId`
+	 * @param externalId External id of the Segment
+	 */
+	getSegmentIdFromExternalId(externalId: string): SegmentId
+
+	/**
 	 * Get a Segment from the Rundown
 	 * @param id Id of the Segment
 	 */
@@ -185,7 +191,7 @@ export interface IngestModel extends IngestModelReadonly, BaseModel {
 	 * Replace or insert a Segment in this Rundown
 	 * @param segment New Segment data
 	 */
-	replaceSegment(segment: DBSegment): IngestSegmentModel
+	replaceSegment(segment: Omit<DBSegment, '_id' | 'rundownId'>): IngestSegmentModel
 
 	/**
 	 * Change the id of a Segment in this Rundown.

--- a/packages/job-worker/src/ingest/model/IngestSegmentModel.ts
+++ b/packages/job-worker/src/ingest/model/IngestSegmentModel.ts
@@ -20,6 +20,12 @@ export interface IngestSegmentModelReadonly {
 	readonly parts: IngestPartModelReadonly[]
 
 	/**
+	 * Get the internal `_id` of a Part from the `externalId`
+	 * @param externalId External id of the Part
+	 */
+	getPartIdFromExternalId(externalId: string): PartId
+
+	/**
 	 * Get a Part which belongs to this Segment
 	 * @param id Id of the Part
 	 */
@@ -78,5 +84,12 @@ export interface IngestSegmentModel extends IngestSegmentModelReadonly {
 	 * @param adLibPiece AdLib Pieces to add to the Part
 	 * @param adLibActions AdLib Actions to add to the Part
 	 */
-	replacePart(part: DBPart, pieces: Piece[], adLibPiece: AdLibPiece[], adLibActions: AdLibAction[]): IngestPartModel
+	replacePart(
+		part: IngestReplacePartType,
+		pieces: Piece[],
+		adLibPiece: AdLibPiece[],
+		adLibActions: AdLibAction[]
+	): IngestPartModel
 }
+
+export type IngestReplacePartType = Omit<DBPart, '_id' | 'rundownId' | 'segmentId' | 'expectedDurationWithPreroll'>

--- a/packages/job-worker/src/ingest/model/implementation/IngestModelImpl.ts
+++ b/packages/job-worker/src/ingest/model/implementation/IngestModelImpl.ts
@@ -270,6 +270,14 @@ export class IngestModelImpl implements IngestModel, DatabasePersistedModel {
 	}
 
 	/**
+	 * Get the internal `_id` of a segment from the `externalId`
+	 * @param externalId External id of the Segment
+	 */
+	getSegmentIdFromExternalId(externalId: string): SegmentId {
+		return getSegmentId(this.rundownId, externalId)
+	}
+
+	/**
 	 * Get a Segment from the Rundown
 	 * @param id Id of the Segment
 	 */
@@ -355,7 +363,12 @@ export class IngestModelImpl implements IngestModel, DatabasePersistedModel {
 		}
 	}
 
-	replaceSegment(segment: DBSegment): IngestSegmentModel {
+	replaceSegment(rawSegment: Omit<DBSegment, '_id' | 'rundownId'>): IngestSegmentModel {
+		const segment: DBSegment = {
+			...rawSegment,
+			_id: this.getSegmentIdFromExternalId(rawSegment.externalId),
+			rundownId: this.rundownId,
+		}
 		const oldSegment = this.segmentsImpl.get(segment._id)
 
 		const newSegment = new IngestSegmentModelImpl(true, segment, [], oldSegment?.segmentModel)

--- a/packages/job-worker/src/ingest/model/implementation/IngestModelImpl.ts
+++ b/packages/job-worker/src/ingest/model/implementation/IngestModelImpl.ts
@@ -43,7 +43,12 @@ import { IngestPartModelImpl } from './IngestPartModelImpl'
 import { DatabasePersistedModel } from '../../../modelBase'
 import { ExpectedPackagesStore } from './ExpectedPackagesStore'
 import { ReadonlyDeep } from 'type-fest'
-import { ExpectedPackageForIngestModel, ExpectedPackageForIngestModelBaseline, IngestModel } from '../IngestModel'
+import {
+	ExpectedPackageForIngestModel,
+	ExpectedPackageForIngestModelBaseline,
+	IngestModel,
+	IngestReplaceSegmentType,
+} from '../IngestModel'
 import { RundownNote } from '@sofie-automation/corelib/dist/dataModel/Notes'
 import { diffAndReturnLatestObjects } from './utils'
 import _ = require('underscore')
@@ -363,7 +368,7 @@ export class IngestModelImpl implements IngestModel, DatabasePersistedModel {
 		}
 	}
 
-	replaceSegment(rawSegment: Omit<DBSegment, '_id' | 'rundownId'>): IngestSegmentModel {
+	replaceSegment(rawSegment: IngestReplaceSegmentType): IngestSegmentModel {
 		const segment: DBSegment = {
 			...rawSegment,
 			_id: this.getSegmentIdFromExternalId(rawSegment.externalId),

--- a/packages/job-worker/src/ingest/model/implementation/IngestPartModelImpl.ts
+++ b/packages/job-worker/src/ingest/model/implementation/IngestPartModelImpl.ts
@@ -10,7 +10,13 @@ import { ExpectedPlayoutItemRundown } from '@sofie-automation/corelib/dist/dataM
 import { ExpectedPackageFromRundown } from '@sofie-automation/corelib/dist/dataModel/ExpectedPackages'
 import { Piece } from '@sofie-automation/corelib/dist/dataModel/Piece'
 import { ExpectedPackagesStore } from './ExpectedPackagesStore'
-import { diffAndReturnLatestObjects, DocumentChanges, getDocumentChanges, setValuesAndTrackChanges } from './utils'
+import {
+	addManyToSet,
+	diffAndReturnLatestObjects,
+	DocumentChanges,
+	getDocumentChanges,
+	setValuesAndTrackChanges,
+} from './utils'
 
 export class IngestPartModelImpl implements IngestPartModel {
 	readonly partImpl: DBPart
@@ -185,6 +191,11 @@ export class IngestPartModelImpl implements IngestPartModel {
 		) {
 			this.#partHasChanges = true
 		}
+
+		// Anything already marked as changed should still be marked as changed
+		addManyToSet(this.#piecesWithChanges, previousModel.#piecesWithChanges)
+		addManyToSet(this.#adLibPiecesWithChanges, previousModel.#adLibPiecesWithChanges)
+		addManyToSet(this.#adLibActionsWithChanges, previousModel.#adLibActionsWithChanges)
 
 		// Diff the objects, but don't update the stored copies
 		diffAndReturnLatestObjects(this.#piecesWithChanges, previousModel.#pieces, this.#pieces)

--- a/packages/job-worker/src/ingest/model/implementation/utils.ts
+++ b/packages/job-worker/src/ingest/model/implementation/utils.ts
@@ -67,6 +67,12 @@ export function setValuesAndTrackChanges<T extends { _id: ProtectedString<any> }
 	}
 }
 
+export function addManyToSet<T>(set: Set<T>, iter: Iterable<T>): void {
+	for (const val of iter) {
+		set.add(val)
+	}
+}
+
 export interface DocumentChanges<T extends { _id: ProtectedString<any> }> {
 	currentIds: T['_id'][]
 	deletedIds: T['_id'][]


### PR DESCRIPTION


## About the Contributor
This pull request is posted on behalf of the NRK.


## Type of Contribution

This is a: Bug fix / Feature

## New Behavior

Blueprints can mark ExpectedPackages as ones they are listening to. When PackageInfos are updated which belong to these packages, sofie will re-run the ingest for those segments automatically.

During ingest, after calling `getSegment`, if any packages returned were not known of before the `getSegment` call, then we check if the listening behaviour should be triggered immediately.  
It now performs a quick check to see if there are any `PackageInfos` which would have been returned to the blueprints when they asked, and if so it will re-run `getSegment` with a fresh copy of the `PackageInfos`

This is to catch cases where the blueprints define a dependency on a 'new' expectedPackage A, which already exists in the database so can be immediately fulfilled.


## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->

This is best reviewed a commit at a time, some large refactoring of the changed code was performed prior to any functional changes, to allow the change to be made more easily.

## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
