### PR TITLE
feat: Include Part ID with AdLibs

### DIFF
--- a/packages/live-status-gateway/api/schemas/adLibs.yaml
+++ b/packages/live-status-gateway/api/schemas/adLibs.yaml
@@ -31,14 +31,11 @@ $defs:
           $ref: '#/$defs/adLib/examples'
         globalAdLibs:
           $ref: '#/$defs/adLib/examples'
-  adLib:
+  baseAdLib:
     type: object
     properties:
       id:
         description: Unique id of the AdLib
-        type: string
-      partId:
-        description: Unique id of the part which owns this AdLib
         type: string
       name:
         description: The user defined AdLib name
@@ -63,17 +60,64 @@ $defs:
               type: string
           required: [name, label]
           additionalProperties: false
-      tags:
-        description: Tags attached to this AdLib
-        type: array
-        items:
-          type: string
       publicData:
         description: Optional arbitrary data
     required: [id, name, sourceLayer, actionType]
     additionalProperties: false
+  adLib:
+    allOf:
+      - $ref: '#/$defs/baseAdLib'
+      - type: object
+        properties:
+          partId:
+            description: Unique id of the part which owns this AdLib
+            type: string
     examples:
       - id: 'C6K_yIMuGFUk8X_L9A9_jRT6aq4_'
+        partId: 'H5CBGYjThrMSmaYvRaa5FVKJIzk_'
+        name: Music video clip
+        sourceLayer: Video Clip
+        actionType:
+          - name: pvw
+            label: Preview
+        publicData:
+          fileName: MV000123.mxf
+  globalAdLib:
+    allOf:
+      - $ref: '#/$defs/baseAdLib'
+      - type: object
+        properties:
+          tags:
+            description: Tags attached to this AdLib
+            type: array
+            items:
+              type: string
+    examples:
+      - id: 'C6K_yIMuGFUk8X_L9A9_jRT6aq4_'
+        name: Music video clip
+        sourceLayer: Video Clip
+        actionType:
+          - name: pvw
+            label: Preview
+        tags: ['music_video']
+        publicData:
+          fileName: MV000123.mxf
+  adLibAction:
+    allOf:
+      - $ref: '#/$defs/baseAdLib'
+      - type: object
+        properties:
+          partId:
+            description: Unique id of the part which owns this AdLib
+            type: string
+          tags:
+            description: Tags attached to this AdLib
+            type: array
+            items:
+              type: string
+    examples:
+      - id: 'C6K_yIMuGFUk8X_L9A9_jRT6aq4_'
+        partId: 'H5CBGYjThrMSmaYvRaa5FVKJIzk_'
         name: Music video clip
         sourceLayer: Video Clip
         actionType:

--- a/packages/live-status-gateway/api/schemas/adLibs.yaml
+++ b/packages/live-status-gateway/api/schemas/adLibs.yaml
@@ -37,6 +37,9 @@ $defs:
       id:
         description: Unique id of the AdLib
         type: string
+      partId:
+        description: Unique id of the part which owns this AdLib
+        type: string
       name:
         description: The user defined AdLib name
         type: string

--- a/packages/live-status-gateway/src/topics/__tests__/adLibs.spec.ts
+++ b/packages/live-status-gateway/src/topics/__tests__/adLibs.spec.ts
@@ -79,11 +79,11 @@ describe('ActivePlaylistTopic', () => {
 			adLibs: [
 				{
 					actionType: [],
+					partId: 'part0',
 					id: 'ACTION_0',
 					name: 'An Action',
 					outputLayer: 'PGM',
 					sourceLayer: 'Layer 0',
-					tags: ['adlib_tag'],
 					publicData: { a: 'b' },
 				},
 			],

--- a/packages/live-status-gateway/src/topics/adLibsTopic.ts
+++ b/packages/live-status-gateway/src/topics/adLibsTopic.ts
@@ -24,7 +24,7 @@ export interface AdLibsStatus {
 	event: 'adLibs'
 	rundownPlaylistId: string | null
 	adLibs: AdLibStatus[]
-	globalAdLibs: AdLibStatus[]
+	globalAdLibs: GlobalAdLibStatus[]
 }
 
 interface AdLibActionType {
@@ -32,15 +32,26 @@ interface AdLibActionType {
 	label: string
 }
 
-interface AdLibStatus {
+interface BaseAdLibStatus {
 	id: string
-	partId?: string
 	name: string
 	sourceLayer: string
 	outputLayer: string
 	actionType: AdLibActionType[]
-	tags?: string[]
 	publicData: unknown
+}
+
+interface AdLibStatus extends BaseAdLibStatus {
+	partId: string | undefined
+}
+
+interface AdLibActionStatus extends BaseAdLibStatus {
+	partId: string
+	tags?: string[]
+}
+
+interface GlobalAdLibStatus extends BaseAdLibStatus {
+	tags?: string[]
 }
 
 export class AdLibsTopic
@@ -77,7 +88,7 @@ export class AdLibsTopic
 
 	sendStatus(subscribers: Iterable<WebSocket>): void {
 		const adLibs: AdLibStatus[] = []
-		const globalAdLibs: AdLibStatus[] = []
+		const globalAdLibs: GlobalAdLibStatus[] = []
 
 		if (this._adLibActions) {
 			adLibs.push(
@@ -96,7 +107,7 @@ export class AdLibsTopic
 								})
 						  )
 						: []
-					return literal<AdLibStatus>({
+					return literal<AdLibActionStatus>({
 						id: unprotectString(action._id),
 						partId: unprotectString(action.partId),
 						name: interpollateTranslation(action.display.label.key, action.display.label.args),
@@ -122,7 +133,6 @@ export class AdLibsTopic
 						sourceLayer: sourceLayerName ?? 'invalid',
 						outputLayer: outputLayerName ?? 'invalid',
 						actionType: [],
-						tags: adLib.tags,
 						publicData: adLib.publicData,
 					})
 				})
@@ -146,7 +156,7 @@ export class AdLibsTopic
 								})
 						  )
 						: []
-					return literal<AdLibStatus>({
+					return literal<GlobalAdLibStatus>({
 						id: unprotectString(action._id),
 						name: interpollateTranslation(action.display.label.key, action.display.label.args),
 						sourceLayer: sourceLayerName ?? 'invalid',
@@ -164,7 +174,7 @@ export class AdLibsTopic
 				...this._globalAdLibs.map((adLib) => {
 					const sourceLayerName = this._sourceLayersMap.get(adLib.sourceLayerId)
 					const outputLayerName = this._outputLayersMap.get(adLib.outputLayerId)
-					return literal<AdLibStatus>({
+					return literal<GlobalAdLibStatus>({
 						id: unprotectString(adLib._id),
 						name: adLib.name,
 						sourceLayer: sourceLayerName ?? 'invalid',

--- a/packages/live-status-gateway/src/topics/adLibsTopic.ts
+++ b/packages/live-status-gateway/src/topics/adLibsTopic.ts
@@ -34,6 +34,7 @@ interface AdLibActionType {
 
 interface AdLibStatus {
 	id: string
+	partId?: string
 	name: string
 	sourceLayer: string
 	outputLayer: string
@@ -97,6 +98,7 @@ export class AdLibsTopic
 						: []
 					return literal<AdLibStatus>({
 						id: unprotectString(action._id),
+						partId: unprotectString(action.partId),
 						name: interpollateTranslation(action.display.label.key, action.display.label.args),
 						sourceLayer: sourceLayerName ?? 'invalid',
 						outputLayer: outputLayerName ?? 'invalid',
@@ -115,6 +117,7 @@ export class AdLibsTopic
 					const outputLayerName = this._outputLayersMap.get(adLib.outputLayerId)
 					return literal<AdLibStatus>({
 						id: unprotectString(adLib._id),
+						partId: unprotectString(adLib.partId),
 						name: adLib.name,
 						sourceLayer: sourceLayerName ?? 'invalid',
 						outputLayer: outputLayerName ?? 'invalid',

--- a/packages/live-status-gateway/src/topics/segmentsTopic.ts
+++ b/packages/live-status-gateway/src/topics/segmentsTopic.ts
@@ -20,6 +20,7 @@ interface SegmentStatus {
 	identifier?: string
 	rundownId: string
 	name: string
+	partIds: string[]
 	timing: SegmentTiming
 	publicData: unknown
 }
@@ -68,6 +69,7 @@ export class SegmentsTopic
 					id: segmentId,
 					rundownId: unprotectString(segment.rundownId),
 					name: segment.name,
+					partIds: this._partsBySegment[segmentId].map((p) => unprotectString(p._id)),
 					timing: calculateSegmentTiming(this._partsBySegment[segmentId] ?? []),
 					identifier: segment.identifier,
 					publicData: segment.publicData,


### PR DESCRIPTION
## About the Contributor
This pull request is posted on behalf of the BBC.

## Type of Contribution

This is a:
Feature


## Current Behavior
It is not possible to filter AdLibs based on part in the Live Status Gateway


## New Behavior
PartId is included with the AdLib to allow basic filtering


## Testing Instructions


## Time Frame
Not urgent, but we would like to get this merged into the in-development release.


## Other Information

## Status
- [X] PR is ready to be reviewed.
- [X] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [X] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
