### PR TITLE
fix: rename 'onPresenterScreen' description in GUI

### DIFF
--- a/meteor/client/ui/Settings/ShowStyle/SourceLayer.tsx
+++ b/meteor/client/ui/Settings/ShowStyle/SourceLayer.tsx
@@ -394,11 +394,12 @@ function SourceLayerEntry({ item, isExpanded, toggleExpanded, overrideHelper }: 
 								)}
 							</LabelAndOverridesForInt>
 							<LabelAndOverridesForCheckbox
-								label={t("Display on Presenter's Screen")}
+								label={t('Treat as Main content')}
 								item={item}
 								itemKey={'onPresenterScreen'}
 								opPrefix={item.id}
 								overrideHelper={overrideHelper}
+								hint="When set, Pieces on this Source Layer will be used to display summaries, thumbnails etc for the Part in GUIs. "
 							>
 								{(value, handleUpdate) => <CheckboxControl value={!!value} handleUpdate={handleUpdate} />}
 							</LabelAndOverridesForCheckbox>

--- a/meteor/i18n/nb.po
+++ b/meteor/i18n/nb.po
@@ -2118,8 +2118,6 @@ msgstr "Er en gjesteinngang"
 msgid "Is hidden"
 msgstr "Er skjult"
 
-msgid "Display on Presenter's Screen"
-msgstr "Vis på presentatørskjerm"
 
 msgid "Pieces on this layer can be cleared"
 msgstr "Elementer på dette laget kan tømmes"

--- a/meteor/i18n/nn.po
+++ b/meteor/i18n/nn.po
@@ -2122,9 +2122,6 @@ msgstr "Er ein gjesteinngang"
 msgid "Is hidden"
 msgstr "Er skjult"
 
-msgid "Display on Presenter's Screen"
-msgstr "Vis på presentatørskjerm"
-
 msgid "Pieces on this layer can be cleared"
 msgstr "Element på dette laget kan tømmas"
 

--- a/meteor/i18n/template.pot
+++ b/meteor/i18n/template.pot
@@ -2113,9 +2113,6 @@ msgstr ""
 msgid "Is hidden"
 msgstr ""
 
-msgid "Display on Presenter's Screen"
-msgstr ""
-
 msgid "Display in a column in List View"
 msgstr ""
 

--- a/meteor/public/locales/nb/translations.json
+++ b/meteor/public/locales/nb/translations.json
@@ -601,7 +601,6 @@
     "Is a Live Remote Input": "Er en RM",
     "Is a Guest Input": "Er en gjesteinngang",
     "Is hidden": "Er skjult",
-    "Display on Presenter's Screen": "Vis på presentatørskjerm",
     "Pieces on this layer can be cleared": "Elementer på dette laget kan tømmes",
     "Pieces on this layer are sticky": "Elementer i dette laget er sticky",
     "Only Pieces present in rundown are sticky": "Kun elementer tilstede i kjøreplanen er sticky",

--- a/meteor/public/locales/nn/translations.json
+++ b/meteor/public/locales/nn/translations.json
@@ -601,7 +601,6 @@
     "Is a Live Remote Input": "Er ein RM",
     "Is a Guest Input": "Er ein gjesteinngang",
     "Is hidden": "Er skjult",
-    "Display on Presenter's Screen": "Vis på presentatørskjerm",
     "Pieces on this layer can be cleared": "Element på dette laget kan tømmas",
     "Pieces on this layer are sticky": "Element på dette laget er sticky",
     "Only Pieces present in rundown are sticky": "Kun element til stades i køyreplanen er sticky",


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This pull request is posted on behalf of the NRK


## Type of Contribution

This is a: GUI label clarification


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

GUI label for `sourceLayer.onPresenterScreen` is "Display on Presenter's Screen"

This is confusing for our Admins, since it doesn't really convey what the setting does.


## New Behavior
<!--
What is the new behavior?
-->

GUI label for `sourceLayer.onPresenterScreen` is "Treat as Main content"
with hint: "When set, Pieces on this Source Layer will be used to display summaries, thumbnails etc for the Part in GUIs."

Our Admins confirms this label is clearer for them.

## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->

No testing needed



## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
