### PR TITLE
fix(Client): Piece-dependency for expectedDuration calculation causes the Diff to be inconsistent (SOFIE-3004)

### DIFF
--- a/meteor/client/lib/__tests__/rundown.test.ts
+++ b/meteor/client/lib/__tests__/rundown.test.ts
@@ -53,7 +53,6 @@ describe('client/lib/rundown', () => {
 				[],
 				new Map(),
 				parts.map((part) => part._id),
-				new Map(),
 				currentPartInstance,
 				nextPartInstance
 			)
@@ -115,7 +114,6 @@ describe('client/lib/rundown', () => {
 				[],
 				new Map(),
 				parts.map((part) => part._id),
-				new Map(),
 				currentPartInstance,
 				nextPartInstance
 			)
@@ -201,7 +199,6 @@ describe('client/lib/rundown', () => {
 				[],
 				new Map(),
 				parts.map((part) => part._id),
-				new Map(),
 				currentPartInstance,
 				nextPartInstance
 			)
@@ -364,7 +361,6 @@ describe('client/lib/rundown', () => {
 					[],
 					new Map(),
 					parts.map((part) => part._id),
-					new Map(),
 					currentPartInstance,
 					nextPartInstance
 				)

--- a/meteor/client/lib/__tests__/rundownTiming.test.ts
+++ b/meteor/client/lib/__tests__/rundownTiming.test.ts
@@ -5,9 +5,8 @@ import { DBSegment } from '../../../lib/collections/Segments'
 import { DBRundown } from '../../../lib/collections/Rundowns'
 import { literal, protectString } from '../../../lib/lib'
 import { RundownTimingCalculator, RundownTimingContext } from '../rundownTiming'
-import { IBlueprintPieceType, PlaylistTimingType } from '@sofie-automation/blueprints-integration'
+import { PlaylistTimingType } from '@sofie-automation/blueprints-integration'
 import { PartId, RundownId, SegmentId } from '@sofie-automation/corelib/dist/dataModel/Ids'
-import { CalculateTimingsPiece } from '@sofie-automation/corelib/dist/playout/timings'
 
 const DEFAULT_DURATION = 0
 const DEFAULT_NONZERO_DURATION = 4000
@@ -112,7 +111,6 @@ describe('rundown Timing Calculator', () => {
 			undefined,
 			parts,
 			partInstancesMap,
-			new Map(),
 			segmentsMap,
 			DEFAULT_DURATION,
 			[]
@@ -175,7 +173,6 @@ describe('rundown Timing Calculator', () => {
 			undefined,
 			parts,
 			partInstancesMap,
-			new Map(),
 			segmentsMap,
 			DEFAULT_DURATION,
 			[]
@@ -277,7 +274,6 @@ describe('rundown Timing Calculator', () => {
 			undefined,
 			parts,
 			partInstancesMap,
-			new Map(),
 			segmentsMap,
 			DEFAULT_DURATION,
 			[]
@@ -381,7 +377,6 @@ describe('rundown Timing Calculator', () => {
 			undefined,
 			parts,
 			partInstancesMap,
-			new Map(),
 			segmentsMap,
 			DEFAULT_DURATION,
 			[]
@@ -509,7 +504,6 @@ describe('rundown Timing Calculator', () => {
 			undefined,
 			parts,
 			partInstancesMap,
-			new Map(),
 			segmentsMap,
 			DEFAULT_DURATION,
 			[]
@@ -612,7 +606,6 @@ describe('rundown Timing Calculator', () => {
 				undefined,
 				parts,
 				partInstancesMap,
-				new Map(),
 				segmentsMap,
 				DEFAULT_NONZERO_DURATION,
 				[]
@@ -743,7 +736,6 @@ describe('rundown Timing Calculator', () => {
 				undefined,
 				parts,
 				partInstancesMap,
-				new Map(),
 				segmentsMap,
 				DEFAULT_NONZERO_DURATION,
 				[]
@@ -868,7 +860,6 @@ describe('rundown Timing Calculator', () => {
 			undefined,
 			parts,
 			partInstancesMap,
-			new Map(),
 			segmentsMap,
 			DEFAULT_DURATION,
 			[]
@@ -938,127 +929,6 @@ describe('rundown Timing Calculator', () => {
 					[segmentId1]: 5000,
 					[segmentId2]: 3000,
 				},
-				segmentStartedPlayback: {},
-			})
-		)
-	})
-
-	it('Adds Piece preroll to Part durations', () => {
-		const timing = new RundownTimingCalculator()
-		const playlist: RundownPlaylist = makeMockPlaylist()
-		playlist.timing = {
-			type: 'forward-time' as any,
-			expectedStart: 0,
-			expectedDuration: 40000,
-		}
-		const rundownId = 'rundown1'
-		const segmentId1 = 'segment1'
-		const segmentId2 = 'segment2'
-		const segmentsMap: Map<SegmentId, DBSegment> = new Map()
-		segmentsMap.set(protectString<SegmentId>(segmentId1), makeMockSegment(segmentId1, 0, rundownId))
-		segmentsMap.set(protectString<SegmentId>(segmentId2), makeMockSegment(segmentId2, 0, rundownId))
-		const parts: Part[] = []
-		parts.push(makeMockPart('part1', 0, rundownId, segmentId1, { expectedDuration: 1000 }))
-		parts.push(makeMockPart('part2', 0, rundownId, segmentId1, { expectedDuration: 1000 }))
-		parts.push(makeMockPart('part3', 0, rundownId, segmentId2, { expectedDuration: 1000 }))
-		parts.push(makeMockPart('part4', 0, rundownId, segmentId2, { expectedDuration: 1000 }))
-		const piecesMap: Map<PartId, CalculateTimingsPiece[]> = new Map()
-		piecesMap.set(protectString('part1'), [
-			literal<CalculateTimingsPiece>({
-				enable: {
-					start: 0,
-				},
-				prerollDuration: 5000,
-				pieceType: IBlueprintPieceType.Normal,
-			}),
-		])
-		piecesMap.set(protectString('part2'), [
-			literal<CalculateTimingsPiece>({
-				enable: {
-					start: 0,
-				},
-				prerollDuration: 240,
-				pieceType: IBlueprintPieceType.Normal,
-			}),
-		])
-		const partInstancesMap: Map<PartId, PartInstance> = new Map()
-		const rundown = makeMockRundown(rundownId, playlist)
-		const rundowns = [rundown]
-		const result = timing.updateDurations(
-			0,
-			false,
-			playlist,
-			rundowns,
-			undefined,
-			parts,
-			partInstancesMap,
-			piecesMap,
-			segmentsMap,
-			DEFAULT_DURATION,
-			[]
-		)
-		expect(result).toEqual(
-			literal<RundownTimingContext>({
-				isLowResolution: false,
-				asDisplayedPlaylistDuration: 9240,
-				asPlayedPlaylistDuration: 9240,
-				currentPartInstanceId: null,
-				currentPartWillAutoNext: false,
-				currentTime: 0,
-				rundownExpectedDurations: {
-					[rundownId]: 9240,
-				},
-				rundownAsPlayedDurations: {
-					[rundownId]: 9240,
-				},
-				partCountdown: {
-					part1: 0,
-					part2: 6000,
-					part3: 7240,
-					part4: 8240,
-				},
-				partDisplayDurations: {
-					part1: 6000,
-					part2: 1240,
-					part3: 1000,
-					part4: 1000,
-				},
-				partDisplayStartsAt: {
-					part1: 0,
-					part2: 6000,
-					part3: 7240,
-					part4: 8240,
-				},
-				partDurations: {
-					part1: 6000,
-					part2: 1240,
-					part3: 1000,
-					part4: 1000,
-				},
-				partExpectedDurations: {
-					part1: 6000,
-					part2: 1240,
-					part3: 1000,
-					part4: 1000,
-				},
-				partPlayed: {
-					part1: 0,
-					part2: 0,
-					part3: 0,
-					part4: 0,
-				},
-				partStartsAt: {
-					part1: 0,
-					part2: 6000,
-					part3: 7240,
-					part4: 8240,
-				},
-				remainingPlaylistDuration: 9240,
-				totalPlaylistDuration: 9240,
-				breakIsLastRundown: undefined,
-				remainingTimeOnCurrentPart: undefined,
-				rundownsBeforeNextBreak: undefined,
-				segmentBudgetDurations: {},
 				segmentStartedPlayback: {},
 			})
 		)
@@ -1140,7 +1010,6 @@ describe('rundown Timing Calculator', () => {
 			rundown,
 			parts,
 			partInstancesMap,
-			new Map(),
 			segmentsMap,
 			DEFAULT_DURATION,
 			[]
@@ -1289,7 +1158,6 @@ describe('rundown Timing Calculator', () => {
 			rundown,
 			parts,
 			partInstancesMap,
-			new Map(),
 			segmentsMap,
 			DEFAULT_DURATION,
 			[]
@@ -1444,7 +1312,6 @@ describe('rundown Timing Calculator', () => {
 			rundown,
 			parts,
 			partInstancesMap,
-			new Map(),
 			segmentsMap,
 			DEFAULT_DURATION,
 			[]
@@ -1593,7 +1460,6 @@ describe('rundown Timing Calculator', () => {
 			rundown,
 			parts,
 			partInstancesMap,
-			new Map(),
 			segmentsMap,
 			DEFAULT_DURATION,
 			[]
@@ -1742,7 +1608,6 @@ describe('rundown Timing Calculator', () => {
 			rundown,
 			parts,
 			partInstancesMap,
-			new Map(),
 			segmentsMap,
 			DEFAULT_DURATION,
 			[]
@@ -1897,7 +1762,6 @@ describe('rundown Timing Calculator', () => {
 			rundown,
 			parts,
 			partInstancesMap,
-			new Map(),
 			segmentsMap,
 			DEFAULT_DURATION,
 			[]

--- a/meteor/client/lib/rundown.ts
+++ b/meteor/client/lib/rundown.ts
@@ -36,10 +36,7 @@ import { FindOptions } from '../../lib/collections/lib'
 import { getShowHiddenSourceLayers } from './localStorage'
 import { Rundown } from '../../lib/collections/Rundowns'
 import { IStudioSettings } from '@sofie-automation/corelib/dist/dataModel/Studio'
-import {
-	calculatePartInstanceExpectedDurationWithPreroll,
-	CalculateTimingsPiece,
-} from '@sofie-automation/corelib/dist/playout/timings'
+import { calculatePartInstanceExpectedDurationWithPreroll } from '@sofie-automation/corelib/dist/playout/timings'
 import { AdLibPieceUi } from './shelf'
 import { UIShowStyleBase } from '../../lib/api/showStyles'
 import { PartId, PieceId, RundownId, SegmentId, ShowStyleBaseId } from '@sofie-automation/corelib/dist/dataModel/Ids'
@@ -59,17 +56,14 @@ export namespace RundownUtils {
 
 	export function getSegmentDuration(
 		parts: Array<PartUi>,
-		pieces: Map<PartId, CalculateTimingsPiece[]>,
+		// pieces: Map<PartId, CalculateTimingsPiece[]>,
 		display?: boolean
 	): number {
 		return parts.reduce((memo, part) => {
 			return (
 				memo +
 				(part.instance.timings?.duration ||
-					calculatePartInstanceExpectedDurationWithPreroll(
-						part.instance,
-						pieces.get(part.instance.part._id) ?? []
-					) ||
+					calculatePartInstanceExpectedDurationWithPreroll(part.instance) ||
 					part.renderedDuration ||
 					(display ? Settings.defaultDisplayDuration : 0))
 			)
@@ -205,7 +199,6 @@ export namespace RundownUtils {
 		scrollLeft: number,
 		scrollWidth: number,
 		part: PartUi,
-		pieces: CalculateTimingsPiece[],
 		partStartsAt: number | undefined,
 		partDuration: number | undefined,
 		piece?: PieceUi
@@ -225,7 +218,7 @@ export namespace RundownUtils {
 								? part.instance.timings.duration + (part.instance.timings?.playOffset || 0)
 								: (partDuration ||
 										part.renderedDuration ||
-										calculatePartInstanceExpectedDurationWithPreroll(part.instance, pieces) ||
+										calculatePartInstanceExpectedDurationWithPreroll(part.instance) ||
 										0) - (piece.renderedInPoint || 0)))
 					: part.instance.timings?.duration !== undefined
 					? part.instance.timings.duration + (part.instance.timings?.playOffset || 0)
@@ -299,7 +292,6 @@ export namespace RundownUtils {
 		rundownsBeforeThisInPlaylist: RundownId[],
 		rundownsToShowstyles: Map<RundownId, ShowStyleBaseId>,
 		orderedAllPartIds: PartId[],
-		pieces: Map<PartId, CalculateTimingsPiece[]>,
 		currentPartInstance: PartInstance | undefined,
 		nextPartInstance: PartInstance | undefined,
 		pieceInstanceSimulation = false,
@@ -430,10 +422,7 @@ export namespace RundownUtils {
 			partsE = segmentInfo.partInstances.map((partInstance, itIndex) => {
 				const partTimeline: SuperTimeline.TimelineObject[] = []
 
-				const partExpectedDuration = calculatePartInstanceExpectedDurationWithPreroll(
-					partInstance,
-					pieces.get(partInstance.part._id) ?? []
-				)
+				const partExpectedDuration = calculatePartInstanceExpectedDurationWithPreroll(partInstance)
 
 				// extend objects to match the Extended interface
 				const partE = literal<PartExtended>({

--- a/meteor/client/lib/rundownTiming.ts
+++ b/meteor/client/lib/rundownTiming.ts
@@ -14,10 +14,7 @@
 import { PartId, PartInstanceId, SegmentId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { literal } from '@sofie-automation/corelib/dist/lib'
 import { PlaylistTiming } from '@sofie-automation/corelib/dist/playout/rundownTiming'
-import {
-	calculatePartInstanceExpectedDurationWithPreroll,
-	CalculateTimingsPiece,
-} from '@sofie-automation/corelib/dist/playout/timings'
+import { calculatePartInstanceExpectedDurationWithPreroll } from '@sofie-automation/corelib/dist/playout/timings'
 import { protectString, unprotectString } from '@sofie-automation/corelib/dist/protectedString'
 import {
 	findPartInstanceInMapOrWrapToTemporary,
@@ -99,7 +96,6 @@ export class RundownTimingCalculator {
 		currentRundown: Rundown | undefined,
 		parts: Part[],
 		partInstancesMap: Map<PartId, PartInstance>,
-		pieces: Map<PartId, CalculateTimingsPiece[]>,
 		segmentsMap: Map<SegmentId, DBSegment>,
 		/** Fallback duration for Parts that have no as-played duration of their own. */
 		defaultDuration: number = Settings.defaultDisplayDuration,
@@ -173,7 +169,6 @@ export class RundownTimingCalculator {
 
 			parts.forEach((origPart, itIndex) => {
 				const partInstance = this.getPartInstanceOrGetCachedTemp(partInstancesMap, origPart)
-				const piecesForPart = pieces.get(partInstance.part._id) ?? []
 
 				if (partInstance.segmentId !== lastSegmentId) {
 					this.untimedSegments.add(partInstance.segmentId)
@@ -216,8 +211,7 @@ export class RundownTimingCalculator {
 				// if the Part is using budgetDuration, this budget is calculated when going through all the segments
 				// in the Rundown (see further down)
 				if (!segmentUsesBudget && !partIsUntimed) {
-					totalRundownDuration +=
-						calculatePartInstanceExpectedDurationWithPreroll(partInstance, piecesForPart) || 0
+					totalRundownDuration += calculatePartInstanceExpectedDurationWithPreroll(partInstance) || 0
 				}
 
 				const lastStartedPlayback = partInstance.timings?.plannedStartedPlayback
@@ -231,7 +225,7 @@ export class RundownTimingCalculator {
 				let displayDurationFromGroup = 0
 
 				partExpectedDuration =
-					calculatePartInstanceExpectedDurationWithPreroll(partInstance, piecesForPart) ||
+					calculatePartInstanceExpectedDurationWithPreroll(partInstance) ||
 					partInstance.timings?.duration ||
 					0
 
@@ -254,7 +248,7 @@ export class RundownTimingCalculator {
 				) {
 					this.displayDurationGroups[partInstance.part.displayDurationGroup] =
 						(this.displayDurationGroups[partInstance.part.displayDurationGroup] || 0) +
-						(calculatePartInstanceExpectedDurationWithPreroll(partInstance, piecesForPart) || 0)
+						(calculatePartInstanceExpectedDurationWithPreroll(partInstance) || 0)
 					displayDurationFromGroup =
 						partInstance.part.displayDuration ||
 						Math.max(
@@ -278,9 +272,7 @@ export class RundownTimingCalculator {
 							: undefined)
 					partDuration =
 						Math.max(
-							duration ||
-								calculatePartInstanceExpectedDurationWithPreroll(partInstance, piecesForPart) ||
-								0,
+							duration || calculatePartInstanceExpectedDurationWithPreroll(partInstance) || 0,
 							now - lastStartedPlayback
 						) - playOffset
 					// because displayDurationGroups have no actual timing on them, we need to have a copy of the
@@ -290,7 +282,7 @@ export class RundownTimingCalculator {
 						duration ||
 						(memberOfDisplayDurationGroup
 							? displayDurationFromGroup
-							: calculatePartInstanceExpectedDurationWithPreroll(partInstance, piecesForPart)) ||
+							: calculatePartInstanceExpectedDurationWithPreroll(partInstance)) ||
 						defaultDuration
 					partDisplayDuration = Math.max(partDisplayDurationNoPlayback, now - lastStartedPlayback)
 					this.partPlayed[unprotectString(partInstance.part._id)] = now - lastStartedPlayback
@@ -312,7 +304,7 @@ export class RundownTimingCalculator {
 							(duration ||
 								(memberOfDisplayDurationGroup
 									? displayDurationFromGroup
-									: calculatePartInstanceExpectedDurationWithPreroll(partInstance, piecesForPart)) ||
+									: calculatePartInstanceExpectedDurationWithPreroll(partInstance)) ||
 								0) -
 								(now - lastStartedPlayback)
 						)
@@ -320,7 +312,7 @@ export class RundownTimingCalculator {
 				} else {
 					partDuration =
 						(partInstance.timings?.duration ||
-							calculatePartInstanceExpectedDurationWithPreroll(partInstance, piecesForPart) ||
+							calculatePartInstanceExpectedDurationWithPreroll(partInstance) ||
 							0) - playOffset
 					partDisplayDurationNoPlayback = Math.max(
 						0,
@@ -328,7 +320,7 @@ export class RundownTimingCalculator {
 							displayDurationFromGroup ||
 							ensureMinimumDefaultDurationIfNotAuto(
 								partInstance,
-								calculatePartInstanceExpectedDurationWithPreroll(partInstance, piecesForPart),
+								calculatePartInstanceExpectedDurationWithPreroll(partInstance),
 								defaultDuration
 							)
 					)
@@ -352,7 +344,7 @@ export class RundownTimingCalculator {
 							valToAddToAsPlayedDuration = partInstance.timings.duration
 						} else if (partCounts) {
 							valToAddToAsPlayedDuration =
-								calculatePartInstanceExpectedDurationWithPreroll(partInstance, piecesForPart) || 0
+								calculatePartInstanceExpectedDurationWithPreroll(partInstance) || 0
 						}
 
 						asPlayedRundownDuration += valToAddToAsPlayedDuration
@@ -389,15 +381,15 @@ export class RundownTimingCalculator {
 						memberOfDisplayDurationGroup
 							? Math.max(
 									partExpectedDuration,
-									calculatePartInstanceExpectedDurationWithPreroll(partInstance, piecesForPart) || 0
+									calculatePartInstanceExpectedDurationWithPreroll(partInstance) || 0
 							  )
-							: calculatePartInstanceExpectedDurationWithPreroll(partInstance, piecesForPart) || 0,
+							: calculatePartInstanceExpectedDurationWithPreroll(partInstance) || 0,
 						now - lastStartedPlayback
 					)
 				} else {
 					asDisplayedRundownDuration +=
 						partInstance.timings?.duration ||
-						calculatePartInstanceExpectedDurationWithPreroll(partInstance, piecesForPart) ||
+						calculatePartInstanceExpectedDurationWithPreroll(partInstance) ||
 						0
 				}
 
@@ -441,12 +433,12 @@ export class RundownTimingCalculator {
 					waitDuration =
 						partInstance.timings?.duration ||
 						partDisplayDuration ||
-						calculatePartInstanceExpectedDurationWithPreroll(partInstance, piecesForPart) ||
+						calculatePartInstanceExpectedDurationWithPreroll(partInstance) ||
 						0
 				} else {
 					waitDuration =
 						partInstance.timings?.duration ||
-						calculatePartInstanceExpectedDurationWithPreroll(partInstance, piecesForPart) ||
+						calculatePartInstanceExpectedDurationWithPreroll(partInstance) ||
 						0
 				}
 				if (segmentUsesBudget) {
@@ -470,8 +462,7 @@ export class RundownTimingCalculator {
 						// this needs to use partInstance.part.expectedDuration as opposed to partExpectedDuration, because
 						// partExpectedDuration is affected by displayGroups, and if it hasn't played yet then it shouldn't
 						// add any duration to the "remaining" time pool
-						remainingRundownDuration +=
-							calculatePartInstanceExpectedDurationWithPreroll(partInstance, piecesForPart) || 0
+						remainingRundownDuration += calculatePartInstanceExpectedDurationWithPreroll(partInstance) || 0
 						// item is onAir right now, and it's is currently shorter than expectedDuration
 					} else if (
 						lastStartedPlayback &&
@@ -603,13 +594,12 @@ export class RundownTimingCalculator {
 		if (currentAIndex >= 0) {
 			const currentLivePart = parts[currentAIndex]
 			const currentLivePartInstance = findPartInstanceInMapOrWrapToTemporary(partInstancesMap, currentLivePart)
-			const piecesForPart = pieces.get(currentLivePartInstance.part._id) ?? []
 
 			const lastStartedPlayback = currentLivePartInstance.timings?.plannedStartedPlayback
 
 			let onAirPartDuration =
 				currentLivePartInstance.timings?.duration ||
-				calculatePartInstanceExpectedDurationWithPreroll(currentLivePartInstance, piecesForPart) ||
+				calculatePartInstanceExpectedDurationWithPreroll(currentLivePartInstance) ||
 				0
 			if (
 				currentLivePart.displayDurationGroup &&

--- a/meteor/client/ui/ClockView/PresenterScreen.tsx
+++ b/meteor/client/ui/ClockView/PresenterScreen.tsx
@@ -21,7 +21,6 @@ import { PieceCountdownContainer } from '../PieceIcons/PieceCountdown'
 import { PlaylistTiming } from '@sofie-automation/corelib/dist/playout/rundownTiming'
 import { DashboardLayout, RundownLayoutBase, RundownLayoutPresenterView } from '../../../lib/collections/RundownLayouts'
 import {
-	PartId,
 	RundownId,
 	RundownLayoutId,
 	RundownPlaylistId,
@@ -40,7 +39,6 @@ import { UIShowStyleBases, UIStudios } from '../Collections'
 import { UIStudio } from '../../../lib/api/studios'
 import { PieceInstances, RundownLayouts, RundownPlaylists, Rundowns, ShowStyleVariants } from '../../collections'
 import { RundownPlaylistCollectionUtil } from '../../../lib/collections/rundownPlaylistUtil'
-import { Piece } from '@sofie-automation/corelib/dist/dataModel/Piece'
 
 interface SegmentUi extends DBSegment {
 	items: Array<PartUi>
@@ -63,7 +61,6 @@ export interface RundownOverviewTrackedProps {
 	playlist?: RundownPlaylist
 	rundowns: Rundown[]
 	segments: Array<SegmentUi>
-	pieces: Map<PartId, Piece[]>
 	currentSegment: SegmentUi | undefined
 	currentPartInstance: PartUi | undefined
 	nextSegment: SegmentUi | undefined
@@ -86,7 +83,6 @@ function getShowStyleBaseIdSegmentPartUi(
 		segments: Segment[]
 		parts: Part[]
 	},
-	pieces: Map<PartId, Piece[]>,
 	rundownsToShowstyles: Map<RundownId, ShowStyleBaseId>,
 	currentPartInstance: PartInstance | undefined,
 	nextPartInstance: PartInstance | undefined
@@ -137,7 +133,6 @@ function getShowStyleBaseIdSegmentPartUi(
 				rundownOrder.slice(0, rundownIndex),
 				rundownsToShowstyles,
 				orderedSegmentsAndParts.parts.map((part) => part._id),
-				pieces,
 				currentPartInstance,
 				nextPartInstance,
 				true,
@@ -179,7 +174,6 @@ export const getPresenterScreenReactive = (props: RundownOverviewProps): Rundown
 			},
 		})
 	const segments: Array<SegmentUi> = []
-	let pieces: Map<PartId, Piece[]> = new Map()
 	let showStyleBaseIds: ShowStyleBaseId[] = []
 	let rundowns: Rundown[] = []
 	let rundownIds: RundownId[] = []
@@ -201,7 +195,6 @@ export const getPresenterScreenReactive = (props: RundownOverviewProps): Rundown
 	if (playlist) {
 		rundowns = RundownPlaylistCollectionUtil.getRundownsOrdered(playlist)
 		const orderedSegmentsAndParts = RundownPlaylistCollectionUtil.getSegmentsAndPartsSync(playlist)
-		pieces = RundownPlaylistCollectionUtil.getPiecesForParts(orderedSegmentsAndParts.parts.map((p) => p._id))
 		rundownIds = rundowns.map((rundown) => rundown._id)
 		const rundownsToShowstyles: Map<RundownId, ShowStyleBaseId> = new Map()
 		for (const rundown of rundowns) {
@@ -233,7 +226,6 @@ export const getPresenterScreenReactive = (props: RundownOverviewProps): Rundown
 					currentPartInstance,
 					playlist,
 					orderedSegmentsAndParts,
-					pieces,
 					rundownsToShowstyles,
 					currentPartInstance,
 					nextPartInstance
@@ -251,7 +243,6 @@ export const getPresenterScreenReactive = (props: RundownOverviewProps): Rundown
 					nextPartInstance,
 					playlist,
 					orderedSegmentsAndParts,
-					pieces,
 					rundownsToShowstyles,
 					currentPartInstance,
 					nextPartInstance
@@ -265,7 +256,6 @@ export const getPresenterScreenReactive = (props: RundownOverviewProps): Rundown
 	return {
 		studio,
 		segments,
-		pieces,
 		playlist,
 		rundowns,
 		showStyleBaseIds,
@@ -425,7 +415,7 @@ export class PresenterScreenBase extends MeteorReactComponent<
 	}
 
 	private renderDefaultLayout() {
-		const { playlist, segments, pieces, currentShowStyleBaseId, nextShowStyleBaseId, playlistId } = this.props
+		const { playlist, segments, currentShowStyleBaseId, nextShowStyleBaseId, playlistId } = this.props
 
 		if (playlist && playlistId && segments) {
 			const currentPart = this.props.currentPartInstance
@@ -477,10 +467,7 @@ export class PresenterScreenBase extends MeteorReactComponent<
 										showStyleBaseId={currentShowStyleBaseId}
 										rundownIds={this.props.rundownIds}
 										partAutoNext={currentPart.instance.part.autoNext || false}
-										partExpectedDuration={calculatePartInstanceExpectedDurationWithPreroll(
-											currentPart.instance,
-											pieces.get(currentPart.partId) ?? []
-										)}
+										partExpectedDuration={calculatePartInstanceExpectedDurationWithPreroll(currentPart.instance)}
 										partStartedPlayback={currentPart.instance.timings?.plannedStartedPlayback}
 										playlistActivationId={this.props.playlist?.activationId}
 									/>

--- a/meteor/client/ui/RundownView/RundownTiming/RundownTimingProvider.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming/RundownTimingProvider.tsx
@@ -14,8 +14,6 @@ import { RundownTimingCalculator, RundownTimingContext } from '../../../lib/rund
 import { PartId, SegmentId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { PartInstances } from '../../../collections'
 import { RundownPlaylistCollectionUtil } from '../../../../lib/collections/rundownPlaylistUtil'
-import { Piece } from '@sofie-automation/corelib/dist/dataModel/Piece'
-import { CalculateTimingsPiece } from '@sofie-automation/corelib/dist/playout/timings'
 
 const TIMING_DEFAULT_REFRESH_INTERVAL = 1000 / 60 // the interval for high-resolution events (timeupdateHR)
 const LOW_RESOLUTION_TIMING_DECIMATOR = 15
@@ -49,7 +47,6 @@ interface IRundownTimingProviderTrackedProps {
 	currentRundown: Rundown | undefined
 	parts: Array<Part>
 	partInstancesMap: Map<PartId, PartInstance>
-	pieces: Map<PartId, CalculateTimingsPiece[]>
 	segmentEntryPartInstances: PartInstance[]
 	segments: DBSegment[]
 	segmentsMap: Map<SegmentId, DBSegment>
@@ -70,7 +67,6 @@ export const RundownTimingProvider = withTracker<
 	let parts: Array<Part> = []
 	let segments: Array<DBSegment> = []
 	const partInstancesMap = new Map<PartId, PartInstance>()
-	let pieces: Map<PartId, Piece[]> = new Map()
 	let currentRundown: Rundown | undefined
 	const segmentEntryPartInstances: PartInstance[] = []
 	if (props.playlist) {
@@ -151,8 +147,6 @@ export const RundownTimingProvider = withTracker<
 				}
 			}
 		})
-
-		pieces = RundownPlaylistCollectionUtil.getPiecesForParts(parts.map((p) => p._id))
 	}
 
 	const segmentsMap = new Map<SegmentId, DBSegment>(segments.map((segment) => [segment._id, segment]))
@@ -162,7 +156,6 @@ export const RundownTimingProvider = withTracker<
 		currentRundown,
 		parts,
 		partInstancesMap,
-		pieces,
 		segmentEntryPartInstances,
 		segments,
 		segmentsMap,
@@ -299,16 +292,8 @@ export const RundownTimingProvider = withTracker<
 		}
 
 		updateDurations(now: number, isSynced: boolean) {
-			const {
-				playlist,
-				rundowns,
-				currentRundown,
-				parts,
-				partInstancesMap,
-				pieces,
-				segmentsMap,
-				segmentEntryPartInstances,
-			} = this.props
+			const { playlist, rundowns, currentRundown, parts, partInstancesMap, segmentsMap, segmentEntryPartInstances } =
+				this.props
 			const updatedDurations = this.timingCalculator.updateDurations(
 				now,
 				isSynced,
@@ -317,7 +302,6 @@ export const RundownTimingProvider = withTracker<
 				currentRundown,
 				parts,
 				partInstancesMap,
-				pieces,
 				segmentsMap,
 				this.props.defaultDuration,
 				segmentEntryPartInstances

--- a/meteor/client/ui/RundownView/RundownTiming/SegmentDuration.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming/SegmentDuration.tsx
@@ -4,16 +4,12 @@ import { withTiming, WithTiming } from './withTiming'
 import { unprotectString } from '../../../../lib/lib'
 import { RundownUtils } from '../../../lib/rundown'
 import { PartUi } from '../../SegmentTimeline/SegmentTimelineContainer'
-import {
-	calculatePartInstanceExpectedDurationWithPreroll,
-	CalculateTimingsPiece,
-} from '@sofie-automation/corelib/dist/playout/timings'
-import { PartId, SegmentId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { calculatePartInstanceExpectedDurationWithPreroll } from '@sofie-automation/corelib/dist/playout/timings'
+import { SegmentId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 
 interface ISegmentDurationProps {
 	segmentId: SegmentId
 	parts: PartUi[]
-	pieces: Map<PartId, CalculateTimingsPiece[]>
 	label?: ReactNode
 	className?: string
 	/** If set, the timer will display just the played out duration */
@@ -49,7 +45,7 @@ export const SegmentDuration = withTiming<ISegmentDurationProps, {}>()(function 
 				budget +=
 					part.instance.orphaned || part.instance.part.untimed
 						? 0
-						: calculatePartInstanceExpectedDurationWithPreroll(part.instance, props.pieces.get(part.partId) ?? []) || 0
+						: calculatePartInstanceExpectedDurationWithPreroll(part.instance) || 0
 			})
 		}
 		props.parts.forEach((part) => {

--- a/meteor/client/ui/SegmentContainer/withResolvedSegment.ts
+++ b/meteor/client/ui/SegmentContainer/withResolvedSegment.ts
@@ -35,7 +35,6 @@ import {
 } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { PieceInstances, Segments } from '../../collections'
 import { RundownPlaylistCollectionUtil } from '../../../lib/collections/rundownPlaylistUtil'
-import { CalculateTimingsPiece } from '@sofie-automation/corelib/dist/playout/timings'
 import { ReadonlyDeep } from 'type-fest'
 import { PieceContentStatusObj } from '../../../lib/mediaObjects'
 
@@ -107,7 +106,6 @@ export interface SegmentNoteCounts {
 export interface ITrackedProps {
 	segmentui: SegmentUi | undefined
 	parts: Array<PartUi>
-	pieces: Map<PartId, CalculateTimingsPiece[]>
 	segmentNoteCounts: SegmentNoteCounts
 	hasRemoteItems: boolean
 	hasGuestItems: boolean
@@ -208,15 +206,6 @@ export function withResolvedSegment<T extends IProps, IState = {}>(
 			)
 
 			const rundownOrder = RundownPlaylistCollectionUtil.getRundownOrderedIDs(props.playlist)
-			const pieces = memoizedIsolatedAutorun(
-				(orderedParts) => {
-					return RundownPlaylistCollectionUtil.getPiecesForParts(orderedParts, {
-						fields: { enable: 1, prerollDuration: 1, postrollDuration: 1, pieceType: 1 },
-					})
-				},
-				'playlist.getPiecesForParts',
-				orderedAllPartIds
-			)
 			const rundownIndex = rundownOrder.indexOf(segment.rundownId)
 
 			const o = RundownUtils.getResolvedSegment(
@@ -228,7 +217,6 @@ export function withResolvedSegment<T extends IProps, IState = {}>(
 				rundownOrder.slice(0, rundownIndex),
 				props.rundownsToShowstyles,
 				orderedAllPartIds,
-				pieces,
 				currentPartInstance,
 				nextPartInstance,
 				true,
@@ -297,7 +285,6 @@ export function withResolvedSegment<T extends IProps, IState = {}>(
 			return {
 				segmentui: o.segmentExtended,
 				parts: o.parts,
-				pieces,
 				segmentNoteCounts,
 				hasAlreadyPlayed: o.hasAlreadyPlayed,
 				hasRemoteItems: o.hasRemoteItems,

--- a/meteor/client/ui/SegmentList/SegmentList.tsx
+++ b/meteor/client/ui/SegmentList/SegmentList.tsx
@@ -14,11 +14,10 @@ import { SegmentViewMode } from '../SegmentContainer/SegmentViewModes'
 import { SegmentListHeader } from './SegmentListHeader'
 import { useInView } from 'react-intersection-observer'
 import { getHeaderHeight } from '../../lib/viewPort'
-import { PartId, SegmentId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { SegmentId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { NoteSeverity } from '@sofie-automation/blueprints-integration'
 import { UIStudio } from '../../../lib/api/studios'
 import { RundownHoldState } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
-import { CalculateTimingsPiece } from '@sofie-automation/corelib/dist/playout/timings'
 
 interface IProps {
 	id: string
@@ -34,7 +33,6 @@ interface IProps {
 	playlist: RundownPlaylist
 	studio: UIStudio
 	parts: Array<PartUi>
-	pieces: Map<PartId, CalculateTimingsPiece[]>
 	segmentNoteCounts: SegmentNoteCounts
 
 	fixedSegmentDuration: boolean
@@ -224,7 +222,6 @@ const SegmentListInner = React.forwardRef<HTMLDivElement, IProps>(function Segme
 				isDetached={isHeaderDetached}
 				isDetachedStick={isHeaderDetachedStick}
 				parts={props.parts}
-				pieces={props.pieces}
 				segment={props.segment}
 				playlist={props.playlist}
 				studio={props.studio}

--- a/meteor/client/ui/SegmentList/SegmentListContainer.tsx
+++ b/meteor/client/ui/SegmentList/SegmentListContainer.tsx
@@ -223,7 +223,6 @@ export const SegmentListContainer = withResolvedSegment<IProps>(function Segment
 			key={unprotectString(props.segmentui._id)}
 			segment={props.segmentui}
 			parts={props.parts}
-			pieces={props.pieces}
 			playlist={props.playlist}
 			studio={props.studio}
 			currentPartWillAutoNext={currentPartWillAutoNext}

--- a/meteor/client/ui/SegmentList/SegmentListHeader.tsx
+++ b/meteor/client/ui/SegmentList/SegmentListHeader.tsx
@@ -16,7 +16,6 @@ import { IContextMenuContext } from '../RundownView'
 import { NoteSeverity } from '@sofie-automation/blueprints-integration'
 import { CriticalIconSmall, WarningIconSmall } from '../../lib/ui/icons/notifications'
 import { UIStudio } from '../../../lib/api/studios'
-import { CalculateTimingsPiece } from '@sofie-automation/corelib/dist/playout/timings'
 import { SegmentTimeAnchorTime } from '../RundownView/RundownTiming/SegmentTimeAnchorTime'
 
 export function SegmentListHeader({
@@ -24,7 +23,6 @@ export function SegmentListHeader({
 	isDetachedStick,
 	segment,
 	parts,
-	pieces,
 	playlist,
 	studio,
 	highlight,
@@ -47,7 +45,6 @@ export function SegmentListHeader({
 	playlist: RundownPlaylist
 	studio: UIStudio
 	parts: Array<PartUi>
-	pieces: Map<PartId, CalculateTimingsPiece[]>
 	segmentNoteCounts: SegmentNoteCounts
 	highlight: boolean
 	isLiveSegment: boolean
@@ -107,7 +104,6 @@ export function SegmentListHeader({
 						<SegmentDuration
 							segmentId={segment._id}
 							parts={parts}
-							pieces={pieces}
 							label={<span className="segment-timeline__duration__label">{t('Duration')}</span>}
 							fixed={fixedSegmentDuration}
 						/>

--- a/meteor/client/ui/SegmentStoryboard/SegmentStoryboard.tsx
+++ b/meteor/client/ui/SegmentStoryboard/SegmentStoryboard.tsx
@@ -34,7 +34,6 @@ import { SwitchViewModeButton } from '../SegmentContainer/SwitchViewModeButton'
 import { UIStudio } from '../../../lib/api/studios'
 import { PartId, SegmentId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { RundownHoldState } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
-import { CalculateTimingsPiece } from '@sofie-automation/corelib/dist/playout/timings'
 import { SegmentTimeAnchorTime } from '../RundownView/RundownTiming/SegmentTimeAnchorTime'
 import { logger } from '../../../lib/logging'
 
@@ -45,7 +44,6 @@ interface IProps {
 	playlist: RundownPlaylist
 	studio: UIStudio
 	parts: Array<PartUi>
-	pieces: Map<PartId, CalculateTimingsPiece[]>
 	segmentNoteCounts: SegmentNoteCounts
 	// timeScale: number
 	// maxTimeScale: number
@@ -616,7 +614,6 @@ export const SegmentStoryboard = React.memo(
 							<SegmentDuration
 								segmentId={props.segment._id}
 								parts={props.parts}
-								pieces={props.pieces}
 								label={<span className="segment-timeline__duration__label">{t('Duration')}</span>}
 								fixed={props.fixedSegmentDuration}
 							/>

--- a/meteor/client/ui/SegmentStoryboard/SegmentStoryboardContainer.tsx
+++ b/meteor/client/ui/SegmentStoryboard/SegmentStoryboardContainer.tsx
@@ -236,7 +236,6 @@ export const SegmentStoryboardContainer = withResolvedSegment<IProps>(function S
 			segment={props.segmentui}
 			studio={props.studio}
 			parts={props.parts}
-			pieces={props.pieces}
 			segmentNoteCounts={props.segmentNoteCounts}
 			onItemClick={props.onPieceClick}
 			onItemDoubleClick={props.onPieceDoubleClick}

--- a/meteor/client/ui/SegmentTimeline/Parts/FlattenedSourceLayers.tsx
+++ b/meteor/client/ui/SegmentTimeline/Parts/FlattenedSourceLayers.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 import * as _ from 'underscore'
 import { unprotectString } from '../../../../lib/lib'
 import { ISourceLayerUi } from '../SegmentTimelineContainer'
@@ -6,7 +6,6 @@ import { ContextMenuTrigger } from '@jstarpl/react-contextmenu'
 import { SourceLayerItemContainer } from '../SourceLayerItemContainer'
 import { ISourceLayerPropsBase, useMouseContext } from './SourceLayer'
 import { ISourceLayerExtended } from '../../../../lib/Rundown'
-import { PieceInstancePiece } from '@sofie-automation/corelib/dist/dataModel/PieceInstance'
 
 interface IFlattenedSourceLayerProps extends ISourceLayerPropsBase {
 	layers: ISourceLayerUi[]
@@ -15,17 +14,6 @@ interface IFlattenedSourceLayerProps extends ISourceLayerPropsBase {
 
 export function FlattenedSourceLayers(props: IFlattenedSourceLayerProps): JSX.Element {
 	const { getPartContext, onMouseUp } = useMouseContext(props)
-
-	const piecesForLayers = useMemo(() => {
-		const piecesForLayers: Map<string, PieceInstancePiece[]> = new Map()
-		for (const layer of props.layers) {
-			piecesForLayers.set(
-				layer._id,
-				layer.pieces.map((p) => p.instance.piece)
-			)
-		}
-		return piecesForLayers
-	}, [props.layers])
 
 	return (
 		<ContextMenuTrigger
@@ -69,7 +57,6 @@ export function FlattenedSourceLayers(props: IFlattenedSourceLayerProps): JSX.El
 									onClick={props.onPieceClick}
 									onDoubleClick={props.onPieceDoubleClick}
 									piece={piece}
-									pieces={piecesForLayers.get(layer._id) ?? []}
 									layer={layer}
 									outputLayer={props.outputLayer}
 									part={props.part}

--- a/meteor/client/ui/SegmentTimeline/Parts/OutputGroup.tsx
+++ b/meteor/client/ui/SegmentTimeline/Parts/OutputGroup.tsx
@@ -10,7 +10,6 @@ import { DEBUG_MODE } from '../SegmentTimelineDebugMode'
 import { RundownUtils } from '../../../lib/rundown'
 import { ISourceLayer } from '@sofie-automation/blueprints-integration'
 import { UIStudio } from '../../../../lib/api/studios'
-import { CalculateTimingsPiece } from '@sofie-automation/corelib/dist/playout/timings'
 
 interface IOutputGroupProps {
 	layer: IOutputLayerUi
@@ -19,7 +18,6 @@ interface IOutputGroupProps {
 	studio: UIStudio
 	segment: SegmentUi
 	part: PartUi
-	pieces: CalculateTimingsPiece[]
 	startsAt: number
 	duration: number
 	expectedDuration: number
@@ -70,7 +68,6 @@ export function OutputGroup(props: IOutputGroupProps): JSX.Element {
 							outputGroupCollapsed={isOutputGroupCollapsed}
 							segment={props.segment}
 							part={props.part}
-							pieces={props.pieces}
 							startsAt={props.startsAt}
 							duration={props.duration}
 							expectedDuration={props.expectedDuration}
@@ -106,7 +103,6 @@ export function OutputGroup(props: IOutputGroupProps): JSX.Element {
 						outputGroupCollapsed={isOutputGroupCollapsed}
 						segment={props.segment}
 						part={props.part}
-						pieces={props.pieces}
 						startsAt={props.startsAt}
 						duration={props.duration}
 						expectedDuration={props.expectedDuration}

--- a/meteor/client/ui/SegmentTimeline/Parts/SegmentTimelinePart.tsx
+++ b/meteor/client/ui/SegmentTimeline/Parts/SegmentTimelinePart.tsx
@@ -34,7 +34,6 @@ import { OutputGroup } from './OutputGroup'
 import { InvalidPartCover } from './InvalidPartCover'
 import { ISourceLayer } from '@sofie-automation/blueprints-integration'
 import { UIStudio } from '../../../../lib/api/studios'
-import { CalculateTimingsPiece } from '@sofie-automation/corelib/dist/playout/timings'
 
 export const SegmentTimelineLineElementId = 'rundown__segment__line__'
 export const SegmentTimelinePartElementId = 'rundown__segment__part__'
@@ -50,7 +49,6 @@ interface IProps {
 	playlist: RundownPlaylist
 	studio: UIStudio
 	part: PartUi
-	pieces: CalculateTimingsPiece[]
 	timeToPixelRatio: number
 	onCollapseOutputToggle?: (layer: IOutputLayerUi, event: any) => void
 	collapsedOutputs: {
@@ -198,7 +196,6 @@ export class SegmentTimelinePartClass extends React.Component<Translated<WithTim
 				nextProps.scrollLeft,
 				nextProps.scrollWidth,
 				nextProps.part,
-				nextProps.pieces,
 				SegmentTimelinePartClass.getPartStartsAt(nextProps),
 				partDisplayDuration
 			)
@@ -472,7 +469,6 @@ export class SegmentTimelinePartClass extends React.Component<Translated<WithTim
 								sourceLayers={sourceLayers}
 								segment={this.props.segment}
 								part={part}
-								pieces={this.props.pieces}
 								playlist={this.props.playlist}
 								studio={this.props.studio}
 								startsAt={SegmentTimelinePartClass.getPartStartsAt(this.props) || this.props.part.startsAt || 0}

--- a/meteor/client/ui/SegmentTimeline/Parts/SourceLayer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Parts/SourceLayer.tsx
@@ -10,7 +10,6 @@ import { ContextMenuTrigger } from '@jstarpl/react-contextmenu'
 import { SourceLayerItemContainer } from '../SourceLayerItemContainer'
 import { contextMenuHoldToDisplayTime } from '../../../lib/lib'
 import { UIStudio } from '../../../../lib/api/studios'
-import { CalculateTimingsPiece } from '@sofie-automation/corelib/dist/playout/timings'
 
 export interface ISourceLayerPropsBase {
 	key: string
@@ -19,7 +18,6 @@ export interface ISourceLayerPropsBase {
 	studio: UIStudio
 	segment: SegmentUi
 	part: PartUi
-	pieces: CalculateTimingsPiece[]
 	startsAt: number
 	duration: number
 	expectedDuration: number
@@ -119,7 +117,6 @@ export function SourceLayer(props: ISourceLayerProps): JSX.Element {
 									layer={props.layer}
 									outputLayer={props.outputLayer}
 									part={props.part}
-									pieces={props.pieces}
 									partStartsAt={props.startsAt}
 									partDuration={props.duration}
 									partExpectedDuration={props.expectedDuration}

--- a/meteor/client/ui/SegmentTimeline/Renderers/CustomLayerItemRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/CustomLayerItemRenderer.tsx
@@ -7,7 +7,6 @@ import { faCut } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { PieceLifespan, VTContent } from '@sofie-automation/blueprints-integration'
 import { OffsetPosition } from '../../../utils/positions'
-import { CalculateTimingsPiece } from '@sofie-automation/corelib/dist/playout/timings'
 import { IFloatingInspectorPosition } from '../../FloatingInspectors/IFloatingInspectorPosition'
 
 export type SourceDurationLabelAlignment = 'left' | 'right'
@@ -18,7 +17,6 @@ export interface ICustomLayerItemProps {
 	outputLayer: IOutputLayerUi
 	outputGroupCollapsed: boolean
 	part: PartUi
-	pieces: CalculateTimingsPiece[]
 	isLiveLine: boolean
 	partStartsAt: number
 	partDuration: number // 0 if unknown

--- a/meteor/client/ui/SegmentTimeline/Renderers/MicSourceRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/MicSourceRenderer.tsx
@@ -135,15 +135,14 @@ export const MicSourceRenderer = withTranslation()(
 				_forceSizingRecheck = true
 			}
 
+			const expectedDuration = calculatePartInstanceExpectedDurationWithPreroll(this.props.part.instance)
+			const prevExpectedDuration = calculatePartInstanceExpectedDurationWithPreroll(prevProps.part.instance)
+
 			if (
 				!_forceSizingRecheck &&
 				this._lineAtEnd === true &&
-				(calculatePartInstanceExpectedDurationWithPreroll(this.props.part.instance, this.props.pieces) ||
-					this.props.partDuration) *
-					this.props.timeScale !==
-					(calculatePartInstanceExpectedDurationWithPreroll(prevProps.part.instance, this.props.pieces) ||
-						prevProps.partDuration) *
-						prevProps.timeScale
+				(expectedDuration || this.props.partDuration) * this.props.timeScale !==
+					(prevExpectedDuration || prevProps.partDuration) * prevProps.timeScale
 			) {
 				_forceSizingRecheck = true
 			}

--- a/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
@@ -42,7 +42,6 @@ import { UIStudio } from '../../../lib/api/studios'
 import { PartId, PartInstanceId, SegmentId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { RundownHoldState } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { SegmentNoteCounts } from '../SegmentContainer/withResolvedSegment'
-import { CalculateTimingsPiece } from '@sofie-automation/corelib/dist/playout/timings'
 import { PartExtended } from '../../../lib/Rundown'
 import {
 	withTiming,
@@ -61,7 +60,6 @@ interface IProps {
 	followLiveSegments: boolean
 	studio: UIStudio
 	parts: Array<PartUi>
-	pieces: Map<PartId, CalculateTimingsPiece[]>
 	segmentNoteCounts: SegmentNoteCounts
 	timeScale: number
 	maxTimeScale: number
@@ -180,7 +178,7 @@ const SegmentTimelineZoom = class SegmentTimelineZoom extends React.Component<
 				total += duration
 			})
 		} else {
-			total = RundownUtils.getSegmentDuration(this.props.parts, this.props.pieces, true)
+			total = RundownUtils.getSegmentDuration(this.props.parts, true)
 		}
 		return total
 	}
@@ -604,7 +602,7 @@ export class SegmentTimelineClass extends React.Component<Translated<WithTiming<
 	}
 
 	private getSegmentDuration() {
-		return (this.props.parts && RundownUtils.getSegmentDuration(this.props.parts, this.props.pieces)) || 0
+		return (this.props.parts && RundownUtils.getSegmentDuration(this.props.parts)) || 0
 	}
 
 	private isOutputGroupCollapsed(outputGroup: IOutputLayer) {
@@ -734,7 +732,6 @@ export class SegmentTimelineClass extends React.Component<Translated<WithTiming<
 					{emitSmallPartsInFlag && !emitSmallPartsInFlagAtEnd && (
 						<SegmentTimelineSmallPartFlag
 							parts={emitSmallPartsInFlag}
-							pieces={this.props.pieces}
 							followingPart={part}
 							livePosition={this.props.livePosition}
 							firstPartInSegmentId={firstPartInSegment.partId}
@@ -785,7 +782,6 @@ export class SegmentTimelineClass extends React.Component<Translated<WithTiming<
 						}
 						showDurationSourceLayers={this.props.showDurationSourceLayers}
 						part={part}
-						pieces={this.props.pieces.get(part.partId) ?? []}
 						isBudgetGap={false}
 						isLiveSegment={this.props.isLiveSegment}
 						anyPriorPartWasLive={anyPriorPartWasLive}
@@ -796,7 +792,6 @@ export class SegmentTimelineClass extends React.Component<Translated<WithTiming<
 					{emitSmallPartsInFlag && emitSmallPartsInFlagAtEnd && (
 						<SegmentTimelineSmallPartFlag
 							parts={emitSmallPartsInFlag}
-							pieces={this.props.pieces}
 							followingPart={undefined}
 							livePosition={this.props.livePosition}
 							firstPartInSegmentId={firstPartInSegment.partId}
@@ -859,7 +854,6 @@ export class SegmentTimelineClass extends React.Component<Translated<WithTiming<
 				isAfterLastValidInSegmentAndItsLive={false}
 				isBudgetGap={true}
 				part={BUDGET_GAP_PART}
-				pieces={[]}
 				showDurationSourceLayers={this.props.showDurationSourceLayers}
 				isLiveSegment={this.props.isLiveSegment}
 				anyPriorPartWasLive={true}
@@ -1102,7 +1096,6 @@ export class SegmentTimelineClass extends React.Component<Translated<WithTiming<
 							<SegmentDuration
 								segmentId={this.props.segment._id}
 								parts={this.props.parts}
-								pieces={this.props.pieces}
 								label={<span className="segment-timeline__duration__label">{t('Duration')}</span>}
 								fixed={this.props.fixedSegmentDuration}
 							/>
@@ -1155,7 +1148,6 @@ export class SegmentTimelineClass extends React.Component<Translated<WithTiming<
 					frameRate={this.props.studio.settings.frameRate}
 					isLiveSegment={this.props.isLiveSegment}
 					partInstances={this.props.parts}
-					pieces={this.props.pieces}
 					currentPartInstanceId={
 						this.props.isLiveSegment ? this.props.playlist.currentPartInfo?.partInstanceId ?? null : null
 					}

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -738,7 +738,6 @@ export const SegmentTimelineContainer = withResolvedSegment(
 							segment={this.props.segmentui}
 							studio={this.props.studio}
 							parts={this.props.parts}
-							pieces={this.props.pieces}
 							segmentNoteCounts={this.props.segmentNoteCounts}
 							timeScale={this.state.timeScale}
 							maxTimeScale={this.state.maxTimeScale}

--- a/meteor/client/ui/SegmentTimeline/SmallParts/SegmentTimelinePartHoverPreview.tsx
+++ b/meteor/client/ui/SegmentTimeline/SmallParts/SegmentTimelinePartHoverPreview.tsx
@@ -7,13 +7,10 @@ import { PartUi, SegmentUi } from '../SegmentTimelineContainer'
 import { SegmentTimelinePart } from '../Parts/SegmentTimelinePart'
 import { ISourceLayer } from '@sofie-automation/blueprints-integration'
 import { UIStudio } from '../../../../lib/api/studios'
-import { PartId } from '@sofie-automation/corelib/dist/dataModel/Ids'
-import { CalculateTimingsPiece } from '@sofie-automation/corelib/dist/playout/timings'
 
 export const SegmentTimelinePartHoverPreview = ({
 	showMiniInspector,
 	parts,
-	pieces,
 	followingPart,
 	segment,
 	playlist,
@@ -29,7 +26,6 @@ export const SegmentTimelinePartHoverPreview = ({
 }: {
 	showMiniInspector: boolean
 	parts: PartUi[]
-	pieces: Map<PartId, CalculateTimingsPiece[]>
 	followingPart: PartUi | undefined
 
 	segment: SegmentUi
@@ -93,7 +89,6 @@ export const SegmentTimelinePartHoverPreview = ({
 							isLastInSegment={isLastInSegment && !followingPart && parts.length - 1 === index}
 							isAfterLastValidInSegmentAndItsLive={false}
 							part={part}
-							pieces={pieces.get(part.partId) ?? []}
 							isPreview={true}
 							isBudgetGap={false}
 							showDurationSourceLayers={showDurationSourceLayers}
@@ -126,7 +121,6 @@ export const SegmentTimelinePartHoverPreview = ({
 						isLastInSegment={false}
 						isAfterLastValidInSegmentAndItsLive={false}
 						part={followingPart}
-						pieces={pieces.get(followingPart.partId) ?? []}
 						isPreview={true}
 						cropDuration={followingPartPreviewDuration}
 						isBudgetGap={false}

--- a/meteor/client/ui/SegmentTimeline/SmallParts/SegmentTimelineSmallPartFlag.tsx
+++ b/meteor/client/ui/SegmentTimeline/SmallParts/SegmentTimelineSmallPartFlag.tsx
@@ -8,7 +8,6 @@ import { RundownPlaylist } from '../../../../lib/collections/RundownPlaylists'
 import { SegmentTimelinePartHoverPreview } from './SegmentTimelinePartHoverPreview'
 import RundownViewEventBus, { RundownViewEvents } from '../../../../lib/api/triggers/RundownViewEventBus'
 import { UIStudio } from '../../../../lib/api/studios'
-import { CalculateTimingsPiece } from '@sofie-automation/corelib/dist/playout/timings'
 import { PartId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { TimingDataResolution, TimingTickResolution, withTiming } from '../../RundownView/RundownTiming/withTiming'
 import { SegmentTimelinePartClass } from '../Parts/SegmentTimelinePart'
@@ -16,7 +15,6 @@ import { SegmentTimelinePartClass } from '../Parts/SegmentTimelinePart'
 export const SegmentTimelineSmallPartFlag = withTiming<
 	{
 		parts: [PartUi, number, number][]
-		pieces: Map<PartId, CalculateTimingsPiece[]>
 		followingPart: PartUi | undefined
 		firstPartInSegmentId: PartId
 		sourceLayers: {
@@ -54,7 +52,6 @@ export const SegmentTimelineSmallPartFlag = withTiming<
 }))(
 	({
 		parts,
-		pieces,
 		followingPart,
 		sourceLayers,
 		timeToPixelRatio,
@@ -190,7 +187,6 @@ export const SegmentTimelineSmallPartFlag = withTiming<
 					showMiniInspector={isHover}
 					followingPart={followingPart}
 					parts={parts.map(([part]) => part)}
-					pieces={pieces}
 					segment={segment}
 					playlist={playlist}
 					liveLineHistorySize={liveLineHistorySize}

--- a/meteor/client/ui/SegmentTimeline/SourceLayerItem.tsx
+++ b/meteor/client/ui/SegmentTimeline/SourceLayerItem.tsx
@@ -19,7 +19,6 @@ import { pieceUiClassNames } from '../../lib/ui/pieceUiClassNames'
 import { SourceDurationLabelAlignment } from './Renderers/CustomLayerItemRenderer'
 import { TransitionSourceRenderer } from './Renderers/TransitionSourceRenderer'
 import { UIStudio } from '../../../lib/api/studios'
-import { CalculateTimingsPiece } from '@sofie-automation/corelib/dist/playout/timings'
 const LEFT_RIGHT_ANCHOR_SPACER = 15
 const MARGINAL_ANCHORED_WIDTH = 5
 
@@ -38,8 +37,6 @@ export interface ISourceLayerItemProps {
 	partExpectedDuration: number
 	/** The piece being rendered in this layer */
 	piece: PieceUi
-	/** Pieces belonging to the Part */
-	pieces: CalculateTimingsPiece[]
 	/** Scaling factor for this segment */
 	timeScale: number
 	/** Whether this part is live */
@@ -657,7 +654,6 @@ export const SourceLayerItem = withTranslation()(
 				this.props.scrollLeft,
 				this.props.scrollWidth,
 				this.props.part,
-				this.props.pieces,
 				this.props.partStartsAt,
 				this.props.partDuration,
 				this.props.piece

--- a/meteor/client/ui/SegmentTimeline/TimelineGrid.tsx
+++ b/meteor/client/ui/SegmentTimeline/TimelineGrid.tsx
@@ -11,8 +11,7 @@ import { getCurrentTime } from '../../../lib/lib'
 import { RundownTiming } from '../RundownView/RundownTiming/RundownTiming'
 import { SegmentTimelinePartClass } from './Parts/SegmentTimelinePart'
 import { RundownTimingContext } from '../../lib/rundownTiming'
-import { PartId, PartInstanceId } from '@sofie-automation/corelib/dist/dataModel/Ids'
-import { CalculateTimingsPiece } from '@sofie-automation/corelib/dist/playout/timings'
+import { PartInstanceId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 
 // We're cheating a little: Fontface
 declare class FontFace {
@@ -41,7 +40,6 @@ interface ITimelineGridProps {
 	scrollLeft: number
 	isLiveSegment: boolean
 	partInstances: PartUi[]
-	pieces: Map<PartId, CalculateTimingsPiece[]>
 	currentPartInstanceId: PartInstanceId | null
 	onResize: (size: number[]) => void
 }
@@ -332,7 +330,7 @@ export class TimelineGrid extends React.Component<ITimelineGridProps> {
 				total += duration
 			})
 		} else {
-			total = RundownUtils.getSegmentDuration(this.props.partInstances, this.props.pieces, true)
+			total = RundownUtils.getSegmentDuration(this.props.partInstances, true)
 		}
 		return total
 	}

--- a/meteor/client/ui/Shelf/SegmentTimingPanel.tsx
+++ b/meteor/client/ui/Shelf/SegmentTimingPanel.tsx
@@ -23,7 +23,6 @@ import { getIsFilterActive } from '../../lib/rundownLayouts'
 import { UIShowStyleBase } from '../../../lib/api/showStyles'
 import { PartId, RundownPlaylistId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { RundownPlaylistCollectionUtil } from '../../../lib/collections/rundownPlaylistUtil'
-import { CalculateTimingsPiece } from '@sofie-automation/corelib/dist/playout/timings'
 
 interface ISegmentTimingPanelProps {
 	visible?: boolean
@@ -36,7 +35,6 @@ interface ISegmentTimingPanelProps {
 interface ISegmentTimingPanelTrackedProps {
 	liveSegment?: Segment
 	parts?: PartExtended[]
-	pieces?: Map<PartId, CalculateTimingsPiece[]>
 	active: boolean
 }
 
@@ -68,11 +66,10 @@ class SegmentTimingPanelInner extends MeteorReactComponent<
 							{panel.timingType === 'count_down' ? t('Segment Count Down') : t('Segment Count Up')}
 						</span>
 					)}
-					{this.props.active && this.props.liveSegment && this.props.parts && this.props.pieces && (
+					{this.props.active && this.props.liveSegment && this.props.parts && (
 						<SegmentDuration
 							segmentId={this.props.liveSegment._id}
 							parts={this.props.parts}
-							pieces={this.props.pieces}
 							countUp={panel.timingType === 'count_up'}
 							className="segment-duration"
 						/>
@@ -144,7 +141,6 @@ export const SegmentTimingPanel = translateWithTracker<
 			const rundowns = RundownPlaylistCollectionUtil.getRundownsOrdered(props.playlist)
 			const rundown = rundowns.find((r) => r._id === liveSegment.rundownId)
 			const segmentIndex = orderedSegmentsAndParts.segments.findIndex((s) => s._id === liveSegment._id)
-			const pieces = RundownPlaylistCollectionUtil.getPiecesForParts(orderedAllPartIds)
 
 			if (!rundown) return { active }
 
@@ -162,7 +158,6 @@ export const SegmentTimingPanel = translateWithTracker<
 				rundownOrder.slice(0, rundownIndex),
 				rundownsToShowstyles,
 				orderedAllPartIds,
-				pieces,
 				currentPartInstance,
 				nextPartInstance,
 				true,

--- a/packages/corelib/src/playout/timings.ts
+++ b/packages/corelib/src/playout/timings.ts
@@ -176,15 +176,15 @@ export function calculatePartExpectedDurationWithPreroll(
 }
 
 export function calculatePartInstanceExpectedDurationWithPreroll(
-	partInstance: Pick<DBPartInstance, 'part' | 'partPlayoutTimings'>,
-	pieces: CalculateTimingsPiece[]
+	partInstance: Pick<DBPartInstance, 'part' | 'partPlayoutTimings'>
+	// pieces: CalculateTimingsPiece[]
 ): number | undefined {
 	if (partInstance.part.expectedDuration === undefined) return undefined
 
 	if (partInstance.partPlayoutTimings) {
 		return calculateExpectedDurationWithPreroll(partInstance.part.expectedDuration, partInstance.partPlayoutTimings)
 	} else {
-		const timings = calculatePartTimings(undefined, {}, [], partInstance.part, pieces)
+		const timings = calculatePartTimings(undefined, {}, [], partInstance.part, []) // TODO: Piece timings should be taken into account
 
 		return calculateExpectedDurationWithPreroll(
 			partInstance.part.expectedDurationWithPreroll ?? partInstance.part.expectedDuration,


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This PR is posted on behalf of the NRK.


## Type of Contribution

This is a:
<!-- (pick one) -->
Bug fix


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->
Calculating the Diff requires knowing all Part's expectedDurations, that means that in order to calculate the Diff, one needs to have all the Pieces for a Playlist loaded. The GUI trims down the amount of data it needs in local cache ("minimongo") in order to maximize performance, and as such, will only have some Pieces loaded at any given time. The Presenters' screen for example will only have the Pieces for the current and next Part loaded. This causes the Diff to be different on the Presenters' screen and in the Rundown View. The Diff in the Rundown View changes as the user scrolls around the page.


## New Behavior
<!--
What is the new behavior?
-->
The expectedDuration calculation does not consider Pieces prerolls. This will introduce minimal (in real-life scenarios) innacuracies in the calculation, but at least will make the Diff counter consistent.


## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->
* Open Rundown View
* Open Presenter screen
* Make sure if the Diff is consistent


## Time Frame
<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->
* This Bug Fix is critical for us, please review and merge it as soon as possible. 


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
