### PR TITLE
fix: stop old observers when re-creating nested observers SOFIE-3016

### DIFF
--- a/meteor/server/api/deviceTriggers/RundownsObserver.ts
+++ b/meteor/server/api/deviceTriggers/RundownsObserver.ts
@@ -51,6 +51,8 @@ export class RundownsObserver {
 
 	private innerUpdateRundownContent = () => {
 		if (!this.#changed) return
+		this.#cleanup?.()
+
 		const changed = this.#changed
 		this.#cleanup = changed(this.rundownIds)
 	}

--- a/meteor/server/publications/lib/__tests__/rundownsObserver.test.ts
+++ b/meteor/server/publications/lib/__tests__/rundownsObserver.test.ts
@@ -101,7 +101,7 @@ describe('RundownsObserver', () => {
 			// After debounce
 			await runAllTimers()
 			expect(onChanged).toHaveBeenCalledTimes(2)
-			expect(onChangedCleanup).toHaveBeenCalledTimes(0)
+			expect(onChangedCleanup).toHaveBeenCalledTimes(1)
 			expect(onChanged).toHaveBeenLastCalledWith([mockId0])
 		} finally {
 			// Make sure to cleanup
@@ -147,7 +147,7 @@ describe('RundownsObserver', () => {
 			// After debounce
 			await runAllTimers()
 			expect(onChanged).toHaveBeenCalledTimes(2)
-			expect(onChangedCleanup).toHaveBeenCalledTimes(0)
+			expect(onChangedCleanup).toHaveBeenCalledTimes(1)
 			expect(onChanged).toHaveBeenLastCalledWith([mockId0])
 		} finally {
 			// Make sure to cleanup
@@ -199,7 +199,7 @@ describe('RundownsObserver', () => {
 			// After debounce
 			await runAllTimers()
 			expect(onChanged).toHaveBeenCalledTimes(2)
-			expect(onChangedCleanup).toHaveBeenCalledTimes(0)
+			expect(onChangedCleanup).toHaveBeenCalledTimes(1)
 			expect(onChanged).toHaveBeenLastCalledWith([mockId0, mockId1, mockId2, mockId3])
 
 			// more documents changing
@@ -218,12 +218,12 @@ describe('RundownsObserver', () => {
 
 			// no debounced call yet
 			expect(onChanged).toHaveBeenCalledTimes(2)
-			expect(onChangedCleanup).toHaveBeenCalledTimes(0)
+			expect(onChangedCleanup).toHaveBeenCalledTimes(1)
 
 			// After debounce
 			await runAllTimers()
 			expect(onChanged).toHaveBeenCalledTimes(3)
-			expect(onChangedCleanup).toHaveBeenCalledTimes(0)
+			expect(onChangedCleanup).toHaveBeenCalledTimes(2)
 			expect(onChanged).toHaveBeenLastCalledWith([mockId0, mockId1, mockId3, mockId4])
 		} finally {
 			// Make sure to cleanup

--- a/meteor/server/publications/lib/rundownsObserver.ts
+++ b/meteor/server/publications/lib/rundownsObserver.ts
@@ -53,6 +53,8 @@ export class RundownsObserver implements Meteor.LiveQueryHandle {
 
 	private innerUpdateRundownContent = () => {
 		if (!this.#changed) return
+		this.#cleanup?.()
+
 		const changed = this.#changed
 		this.#cleanup = changed(this.rundownIds)
 	}

--- a/meteor/server/publications/pieceContentStatusUI/rundownContentObserver.ts
+++ b/meteor/server/publications/pieceContentStatusUI/rundownContentObserver.ts
@@ -125,7 +125,7 @@ export class RundownContentObserver {
 
 	private updateShowStyleBaseIds = _.debounce(
 		Meteor.bindEnvironment(() => {
-			const newShowStyleBaseIds = this.#cache.Rundowns.find({}).map((rd) => rd.showStyleBaseId)
+			const newShowStyleBaseIds = _.uniq(this.#cache.Rundowns.find({}).map((rd) => rd.showStyleBaseId))
 
 			if (!equivalentArrays(newShowStyleBaseIds, this.#showStyleBaseIds)) {
 				logger.silly(


### PR DESCRIPTION
## About the Contributor
This pull request is posted on behalf of the NRK.


## Type of Contribution

This is a: Bug fix 

## Current Behavior
We have identified that there is a memory leak in Sofie that gets worse each day.

Through some local testing, I identified a scenario where this happens and verified it with some debug logging.
To reproduce:
1. Add two or more rundowns into a playlist
2. In the ui, manually remove one of those rundowns from the playlist.
  At this point, the debug logging will show that the observers have been re-created to just consider the rundowns which remain in the playlist 
4. In the ui, manually delete the rundown which is no longer in the playlist
  The debug logging will show that the publication was invalidated from deleting of this rundown.

The issue was that whenever we re-created this RundownsObserver, we would not call the `cleanup` function before re-initialising the child observers. This would result in them being leaked, preserving some memory and continuing their watching of the mongo and in-memory collections.


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
