### PR TITLE
feat: New Prompter scroll algorithm (SOFIE-3082)

### DIFF
--- a/meteor/client/ui/Prompter/PrompterView.tsx
+++ b/meteor/client/ui/Prompter/PrompterView.tsx
@@ -1,5 +1,5 @@
 import React, { PropsWithChildren } from 'react'
-import _, { filter } from 'underscore'
+import _ from 'underscore'
 import Velocity from 'velocity-animate'
 import ClassNames from 'classnames'
 import { Meteor } from 'meteor/meteor'
@@ -729,7 +729,10 @@ export const Prompter = translateWithTracker<PropsWithChildren<IPrompterProps>, 
 		private restoreScrollAnchor = (scrollAnchors: ScrollAnchor[] | null) => {
 			if (scrollAnchors === null) return
 			if (!scrollAnchors.length) {
-				logger.error(`No read anchors to use after update`)
+				if (this.props.prompterData?.segments.length) {
+					// That's wierd, log the issue:
+					logger.error(`No read anchors to use after update`)
+				}
 				return
 			}
 


### PR DESCRIPTION

<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This pull request is posted on behalf of the NRK

## Type of Contribution

This is a: Bug fix


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

We have reported issues in prod where the prompter "jump" in case of content changes (ie doesn't scroll to the new position correctly).
We also see quite a few `Read anchor could not be found after update` errors in our logs.

I haven't been able to properly reproduce the issue, but I believe it is related to the `getScrollAnchor` method returning an anchor which doesn't exist after the update.


## New Behavior
<!--
What is the new behavior?
-->

I've rewritten the `getScrollAnchor` algorithm to no return a list of anchors instead of a single one, order in falling "order of importance".

When the content changes, if `restoreScrollAnchor` fails to find the first anchor, it can now continue and try the next ones after that.


## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->

* Use the Prompter, scroll to various positions.
* Modify the  rundown content (edit text, add / remove Parts & segments).
* Observe how the Prompter behaves, it should never jump to a strange/unexpected position after an update.



## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
