### PR TITLE
fix: clear Scratchpad on Rundown activation (SOFIE-2575)

### DIFF
--- a/packages/job-worker/src/__mocks__/context.ts
+++ b/packages/job-worker/src/__mocks__/context.ts
@@ -1,36 +1,4 @@
 import {
-	StudioId,
-	RundownPlaylistId,
-	ShowStyleBaseId,
-	ShowStyleVariantId,
-	RundownId,
-} from '@sofie-automation/corelib/dist/dataModel/Ids'
-import { DBStudio } from '@sofie-automation/corelib/dist/dataModel/Studio'
-import { EventsJobFunc } from '@sofie-automation/corelib/dist/worker/events'
-import { IngestJobFunc } from '@sofie-automation/corelib/dist/worker/ingest'
-import { StudioJobFunc } from '@sofie-automation/corelib/dist/worker/studio'
-import { WrappedStudioBlueprint, WrappedShowStyleBlueprint } from '../blueprints/cache'
-import {
-	ProcessedStudioConfig,
-	ProcessedShowStyleConfig,
-	preprocessStudioConfig,
-	preprocessShowStyleConfig,
-} from '../blueprints/config'
-import { BaseModel } from '../modelBase'
-import { PlaylistLock, RundownLock } from '../jobs/lock'
-import { ReadonlyDeep } from 'type-fest'
-import {
-	ApmSpan,
-	ProcessedShowStyleBase,
-	JobContext,
-	ProcessedShowStyleCompound,
-	ProcessedShowStyleVariant,
-} from '../jobs'
-import { createShowStyleCompound } from '../showStyles'
-import { IMockCollections, getMockCollections } from './collection'
-import { clone } from '@sofie-automation/corelib/dist/lib'
-import { IDirectCollections } from '../db'
-import {
 	BlueprintManifestType,
 	BlueprintResultPart,
 	BlueprintResultRundown,
@@ -42,19 +10,51 @@ import {
 	IBlueprintPiece,
 	IBlueprintRundown,
 	IBlueprintSegment,
-	IngestSegment,
 	ISegmentUserContext,
 	IShowStyleContext,
+	IngestSegment,
 	PlaylistTimingType,
 	ShowStyleBlueprintManifest,
 	StudioBlueprintManifest,
 } from '@sofie-automation/blueprints-integration'
+import {
+	RundownId,
+	RundownPlaylistId,
+	ShowStyleBaseId,
+	ShowStyleVariantId,
+	StudioId,
+} from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { DBStudio } from '@sofie-automation/corelib/dist/dataModel/Studio'
+import { clone } from '@sofie-automation/corelib/dist/lib'
 import { protectString } from '@sofie-automation/corelib/dist/protectedString'
+import { EventsJobFunc } from '@sofie-automation/corelib/dist/worker/events'
+import { IngestJobFunc } from '@sofie-automation/corelib/dist/worker/ingest'
+import { StudioJobFunc } from '@sofie-automation/corelib/dist/worker/studio'
+import { ReadonlyDeep } from 'type-fest'
+import { WrappedShowStyleBlueprint, WrappedStudioBlueprint } from '../blueprints/cache'
+import {
+	ProcessedShowStyleConfig,
+	ProcessedStudioConfig,
+	preprocessShowStyleConfig,
+	preprocessStudioConfig,
+} from '../blueprints/config'
+import { IDirectCollections } from '../db'
+import {
+	ApmSpan,
+	JobContext,
+	ProcessedShowStyleBase,
+	ProcessedShowStyleCompound,
+	ProcessedShowStyleVariant,
+} from '../jobs'
+import { PlaylistLock, RundownLock } from '../jobs/lock'
+import { BaseModel } from '../modelBase'
+import { createShowStyleCompound } from '../showStyles'
+import { IMockCollections, getMockCollections } from './collection'
 // import _ = require('underscore')
-import { defaultStudio } from './defaultCollectionObjects'
 import { TimelineComplete } from '@sofie-automation/corelib/dist/dataModel/Timeline'
-import { processShowStyleBase, processShowStyleVariant } from '../jobs/showStyle'
 import { JSONBlobStringify } from '@sofie-automation/shared-lib/dist/lib/JSONBlob'
+import { processShowStyleBase, processShowStyleVariant } from '../jobs/showStyle'
+import { defaultStudio } from './defaultCollectionObjects'
 
 export function setupDefaultJobEnvironment(studioId?: StudioId): MockJobContext {
 	const { mockCollections, jobCollections } = getMockCollections()

--- a/packages/job-worker/src/__mocks__/defaultCollectionObjects.ts
+++ b/packages/job-worker/src/__mocks__/defaultCollectionObjects.ts
@@ -1,14 +1,15 @@
+import { IBlueprintPieceType, PieceLifespan, PlaylistTimingType } from '@sofie-automation/blueprints-integration'
 import { AdLibPiece } from '@sofie-automation/corelib/dist/dataModel/AdLibPiece'
 import {
-	RundownPlaylistId,
-	StudioId,
+	PartId,
 	PeripheralDeviceId,
+	PieceId,
+	RundownId,
+	RundownPlaylistId,
+	SegmentId,
 	ShowStyleBaseId,
 	ShowStyleVariantId,
-	SegmentId,
-	RundownId,
-	PartId,
-	PieceId,
+	StudioId,
 } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { DBPart } from '@sofie-automation/corelib/dist/dataModel/Part'
 import { EmptyPieceTimelineObjectsBlob, Piece } from '@sofie-automation/corelib/dist/dataModel/Piece'
@@ -17,11 +18,10 @@ import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/Rund
 import { DBSegment } from '@sofie-automation/corelib/dist/dataModel/Segment'
 import { DBStudio } from '@sofie-automation/corelib/dist/dataModel/Studio'
 import { unprotectString } from '@sofie-automation/corelib/dist/protectedString'
-import { getRundownId } from '../ingest/lib'
-import { getCurrentTime } from '../lib'
-import { IBlueprintPieceType, PieceLifespan, PlaylistTimingType } from '@sofie-automation/blueprints-integration'
 import { wrapDefaultObject } from '@sofie-automation/corelib/dist/settings/objectWithOverrides'
 import { DEFAULT_MINIMUM_TAKE_SPAN } from '@sofie-automation/shared-lib/dist/core/constants'
+import { getRundownId } from '../ingest/lib'
+import { getCurrentTime } from '../lib'
 
 export function defaultRundownPlaylist(_id: RundownPlaylistId, studioId: StudioId): DBRundownPlaylist {
 	return {
@@ -100,6 +100,7 @@ export function defaultStudio(_id: StudioId): DBStudio {
 			frameRate: 25,
 			mediaPreviewsUrl: '',
 			minimumTakeSpan: DEFAULT_MINIMUM_TAKE_SPAN,
+			allowScratchpad: true,
 		},
 		routeSets: {},
 		routeSetExclusivityGroups: {},

--- a/packages/job-worker/src/playout/__tests__/actions.test.ts
+++ b/packages/job-worker/src/playout/__tests__/actions.test.ts
@@ -1,14 +1,17 @@
+import { RundownPlaylistId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
+import { SegmentOrphanedReason } from '@sofie-automation/corelib/dist/dataModel/Segment'
 import { protectString } from '@sofie-automation/corelib/dist/protectedString'
 import { MockJobContext, setupDefaultJobEnvironment } from '../../__mocks__/context'
-import { removeRundownFromDb } from '../../rundownPlaylists'
 import { setupDefaultRundownPlaylist, setupMockShowStyleCompound } from '../../__mocks__/presetCollections'
-import { activateRundownPlaylist } from '../activePlaylistActions'
-import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
-import { runJobWithPlayoutModel } from '../lock'
 import { runWithRundownLock } from '../../ingest/lock'
+import { executePeripheralDeviceFunction } from '../../peripheralDevice'
+import { removeRundownFromDb } from '../../rundownPlaylists'
+import { activateRundownPlaylist } from '../activePlaylistActions'
+import { runJobWithPlayoutModel } from '../lock'
+import { handleActivateScratchpad } from '../scratchpad'
 
 jest.mock('../../peripheralDevice')
-import { executePeripheralDeviceFunction } from '../../peripheralDevice'
 type TexecutePeripheralDeviceFunction = jest.MockedFunction<typeof executePeripheralDeviceFunction>
 const executePeripheralDeviceFunctionMock = executePeripheralDeviceFunction as TexecutePeripheralDeviceFunction
 
@@ -84,5 +87,66 @@ describe('Playout Actions', () => {
 		).rejects.toMatchToString(/only one rundown can be active/i)
 
 		expect(executePeripheralDeviceFunctionMock).toHaveBeenCalledTimes(0)
+	})
+	test('scratchpad', async () => {
+		const { playlistId: playlistId0, rundownId: rundownId0 } = await setupDefaultRundownPlaylist(
+			context,
+			undefined,
+			protectString('ro0')
+		)
+		expect(playlistId0).toBeTruthy()
+
+		const getFirstSegment = async () =>
+			await context.directCollections.Segments.findOne(
+				{
+					rundownId: rundownId0,
+				},
+				{
+					sort: {
+						_rank: 1,
+					},
+				}
+			)
+
+		const getCurrentPartInstance = async (playlistId: RundownPlaylistId) => {
+			const playlist = await context.directCollections.RundownPlaylists.findOne(playlistId)
+			if (!playlist) throw new Error(`Playlist "${playlistId} not found`)
+			if (!playlist.currentPartInfo) throw new Error(`Playlist "${playlistId}" doesn't have any currentPartInfo`)
+			return context.directCollections.PartInstances.findOne(playlist.currentPartInfo?.partInstanceId)
+		}
+
+		// Activating a rundown, to rehearsal
+		await runJobWithPlayoutModel(context, { playlistId: playlistId0 }, null, async (playoutModel) =>
+			activateRundownPlaylist(context, playoutModel, true)
+		)
+
+		await expect(getFirstSegment()).resolves.toMatchObject({
+			name: 'Segment 0',
+		})
+
+		await handleActivateScratchpad(context, {
+			playlistId: playlistId0,
+			rundownId: rundownId0,
+		})
+
+		// Scratchpad segment should be at the top
+		const topSegment = await getFirstSegment()
+		expect(topSegment).toMatchObject({
+			orphaned: SegmentOrphanedReason.SCRATCHPAD,
+		})
+
+		await expect(getCurrentPartInstance(playlistId0)).resolves.toMatchObject({
+			segmentId: topSegment?._id,
+		})
+
+		// Activating a rundown
+		await runJobWithPlayoutModel(context, { playlistId: playlistId0 }, null, async (playoutModel) =>
+			activateRundownPlaylist(context, playoutModel, false)
+		)
+
+		// Scratchpad segment should be gone
+		await expect(getFirstSegment()).resolves.toMatchObject({
+			name: 'Segment 0',
+		})
 	})
 })

--- a/packages/job-worker/src/playout/activePlaylistActions.ts
+++ b/packages/job-worker/src/playout/activePlaylistActions.ts
@@ -1,17 +1,18 @@
 import { DBRundown } from '@sofie-automation/corelib/dist/dataModel/Rundown'
+import { SegmentOrphanedReason } from '@sofie-automation/corelib/dist/dataModel/Segment'
 import { stringifyError } from '@sofie-automation/shared-lib/dist/lib/stringifyError'
-import { getActiveRundownPlaylistsInStudioFromDb } from '../studio/lib'
+import { ReadonlyDeep } from 'type-fest'
+import { RundownActivationContext } from '../blueprints/context/RundownActivationContext'
 import { JobContext } from '../jobs'
+import { getCurrentTime } from '../lib'
 import { logger } from '../logging'
-import { PlayoutModel } from './model/PlayoutModel'
+import { getActiveRundownPlaylistsInStudioFromDb } from '../studio/lib'
+import { cleanTimelineDatastore } from './datastore'
 import { resetRundownPlaylist } from './lib'
+import { PlayoutModel } from './model/PlayoutModel'
 import { selectNextPart } from './selectNextPart'
 import { setNextPart } from './setNext'
 import { updateStudioTimeline, updateTimeline } from './timeline/generate'
-import { getCurrentTime } from '../lib'
-import { cleanTimelineDatastore } from './datastore'
-import { RundownActivationContext } from '../blueprints/context/RundownActivationContext'
-import { ReadonlyDeep } from 'type-fest'
 
 export async function activateRundownPlaylist(
 	context: JobContext,
@@ -44,9 +45,21 @@ export async function activateRundownPlaylist(
 
 	const newActivationId = playoutModel.activatePlaylist(rehearsal)
 
+	const currentPartInstance = playoutModel.currentPartInstance
+	if (currentPartInstance && !rehearsal) {
+		const rundownId = currentPartInstance.partInstance.rundownId
+		const rundown = playoutModel.getRundown(rundownId)
+		if (!rundown) throw new Error(`Could not find rundown "${rundownId}"`)
+		const currentSegment = playoutModel.findSegment(currentPartInstance.partInstance.segmentId)
+		if (!currentSegment) throw new Error(`Could not find segment "${currentPartInstance.partInstance.segmentId}"`)
+		if (currentSegment.segment.orphaned === SegmentOrphanedReason.SCRATCHPAD) {
+			currentPartInstance.markAsReset()
+			rundown.removeScratchpadSegment()
+		}
+	}
+
 	let rundown: ReadonlyDeep<DBRundown> | undefined
 
-	const currentPartInstance = playoutModel.currentPartInstance
 	if (!currentPartInstance || currentPartInstance.partInstance.reset) {
 		playoutModel.clearSelectedPartInstances()
 


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This pull request is posted on behalf of the NRK.


## Type of Contribution

This is a:
<!-- (pick one) -->
Bug fix


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->
When activating a Rundown from rehearsal, the Scratchpad Segment is not removed.


## New Behavior
<!--
What is the new behavior?
-->
When activating a Rundown from rehearsal, the Scratchpad Segment is removed and the current-playing PartInstance is reset.


## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->
See above.

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas
<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
* 
-->
* This PR affects the Rundown activation playout logic


## Time Frame
<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->
* Not urgent, but we would like to get this merged into the in-development release.


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
