### PR TITLE
fix: hide create playlist drop box when dragging a rundown not in a multi-rundown playlist SOFIE-2462

### DIFF
--- a/meteor/client/ui/RundownList/DragAndDropTypes.ts
+++ b/meteor/client/ui/RundownList/DragAndDropTypes.ts
@@ -10,6 +10,7 @@ enum RundownListDragDropTypes {
 interface IRundownDragObject {
 	id: RundownId
 	rundownLayouts: Array<RundownLayoutBase>
+	isOnlyRundownInPlaylist: boolean
 }
 
 function isRundownDragObject(obj: unknown): obj is IRundownDragObject {

--- a/meteor/client/ui/RundownList/RundownDropZone.tsx
+++ b/meteor/client/ui/RundownList/RundownDropZone.tsx
@@ -17,7 +17,7 @@ export function RundownDropZone(): JSX.Element {
 		accept: RundownListDragDropTypes.RUNDOWN,
 		collect: (monitor) => {
 			return {
-				activated: !!monitor.getItemType(),
+				activated: !!monitor.getItemType() && !monitor.getItem<IRundownDragObject>()?.isOnlyRundownInPlaylist,
 			}
 		},
 		drop: (item) => {

--- a/meteor/client/ui/RundownList/RundownListItem.tsx
+++ b/meteor/client/ui/RundownList/RundownListItem.tsx
@@ -32,7 +32,7 @@ export function RundownListItem({
 	rundownLayouts: Array<RundownLayoutBase>
 	swapRundownOrder: (a: RundownId, b: RundownId) => void
 	playlistId: RundownPlaylistId
-	isOnlyRundownInPlaylist?: boolean
+	isOnlyRundownInPlaylist: boolean
 	action?: IRundownPlaylistUiAction
 }>): JSX.Element | null {
 	const { t } = useTranslation()
@@ -65,6 +65,7 @@ export function RundownListItem({
 			item: {
 				id: rundown._id,
 				rundownLayouts,
+				isOnlyRundownInPlaylist,
 			},
 		},
 		[rundown._id, rundownLayouts]

--- a/meteor/client/ui/RundownList/RundownPlaylistUi.tsx
+++ b/meteor/client/ui/RundownList/RundownPlaylistUi.tsx
@@ -158,6 +158,7 @@ export function RundownPlaylistUi({
 				rundownLayouts={rundownLayouts}
 				swapRundownOrder={handleRundownSwap}
 				playlistId={playlist._id}
+				isOnlyRundownInPlaylist={false}
 			/>
 		) : null
 	})


### PR DESCRIPTION


## About the Contributor
This pull request is posted on behalf of the NRK.


## Type of Contribution

This is a: Bug fix

## Current Behavior
In the rundown list page, when dragging a rundown which is not grouped in a playlist, a dropbox is shown to create it in a new playlist.
This has no visible effect, as the rundown is moved into a non-grouped playlist, giving the same result as before.


## New Behavior
When dragging a rundown which is alone in a flattened playlist, don't show the drop box


## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas
This is a minor ui change



## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
