### PR TITLE
fix: input gateway devices lose rundown actions on reset SOFIE-3134

### DIFF
--- a/meteor/server/api/deviceTriggers/RundownContentObserver.ts
+++ b/meteor/server/api/deviceTriggers/RundownContentObserver.ts
@@ -1,10 +1,5 @@
 import { Meteor } from 'meteor/meteor'
-import {
-	RundownId,
-	RundownPlaylistActivationId,
-	RundownPlaylistId,
-	ShowStyleBaseId,
-} from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { RundownId, RundownPlaylistId, ShowStyleBaseId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import {
 	PartInstances,
 	Parts,
@@ -44,10 +39,9 @@ export class RundownContentObserver {
 		rundownPlaylistId: RundownPlaylistId,
 		showStyleBaseId: ShowStyleBaseId,
 		rundownIds: RundownId[],
-		activationId: RundownPlaylistActivationId,
 		onChanged: ChangedHandler
 	) {
-		logger.silly(`Creating RundownContentObserver for playlist "${rundownPlaylistId}" activation "${activationId}"`)
+		logger.silly(`Creating RundownContentObserver for playlist "${rundownPlaylistId}"`)
 		const { cache, cancel: cancelCache } = createReactiveContentCache(() => {
 			this.#cleanup = onChanged(cache)
 			if (this.#disposed) this.#cleanup()
@@ -93,7 +87,9 @@ export class RundownContentObserver {
 			),
 			PartInstances.observe(
 				{
-					playlistActivationId: activationId,
+					rundownId: {
+						$in: rundownIds,
+					},
 					reset: {
 						$ne: true,
 					},

--- a/meteor/server/api/deviceTriggers/StudioObserver.ts
+++ b/meteor/server/api/deviceTriggers/StudioObserver.ts
@@ -183,26 +183,19 @@ export class StudioObserver extends EventEmitter {
 				this.#rundownsLiveQuery = undefined
 
 				const activePlaylistId = this.activePlaylistId
-				const activationId = this.activationId
 				this.showStyleBaseId = showStyleBaseId
 
 				let cleanupChanges: (() => void) | undefined = undefined
 
 				this.#rundownsLiveQuery = new RundownsObserver(activePlaylistId, (rundownIds) => {
 					logger.silly(`Creating new RundownContentObserver`)
-					const obs1 = new RundownContentObserver(
-						activePlaylistId,
-						showStyleBaseId,
-						rundownIds,
-						activationId,
-						(cache) => {
-							cleanupChanges = this.#changed(showStyleBaseId, cache)
+					const obs1 = new RundownContentObserver(activePlaylistId, showStyleBaseId, rundownIds, (cache) => {
+						cleanupChanges = this.#changed(showStyleBaseId, cache)
 
-							return () => {
-								void 0
-							}
+						return () => {
+							void 0
 						}
-					)
+					})
 
 					return () => {
 						obs1.stop()


### PR DESCRIPTION

## About the Contributor
This pull request is posted on behalf of the NRK.


## Type of Contribution

This is a: Bug fix 

## Current Behavior
When using a streamdeck through the input gateway, when resetting the rundown any rundown based actions on the streamdeck will go blank and will no longer work.

They would return upon deactivating and reactivating the rundown, or restarting sofie.

This was due to a value being used non-reactively, causing incorrect invalidations when resetting the rundown.


## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

This PR affects the input gateway

## Time Frame
<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
