### PR TITLE
fix: object table showing defaults when pure overrides

### DIFF
--- a/meteor/client/lib/Components/Base64ImageInput.tsx
+++ b/meteor/client/lib/Components/Base64ImageInput.tsx
@@ -1,0 +1,69 @@
+import React, { useCallback, useState } from 'react'
+import { UploadButton } from '../uploadButton'
+import { faUpload } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { useTranslation } from 'react-i18next'
+
+interface IBase64ImageInputControlProps {
+	classNames?: string
+	disabled?: boolean
+	placeholder?: string
+
+	/** Call handleUpdate on every change, before focus is lost */
+	updateOnKey?: boolean
+
+	value: string
+	handleUpdate: (value: string) => void
+}
+export function Base64ImageInputControl({
+	classNames,
+	value,
+	disabled,
+	placeholder,
+	handleUpdate,
+	updateOnKey,
+}: Readonly<IBase64ImageInputControlProps>): JSX.Element {
+	const { t } = useTranslation()
+
+	const [uploadFileKey, setUploadFileKey] = useState(() => Date.now())
+
+	const handleSelectFile = useCallback(
+		(event: React.ChangeEvent<HTMLInputElement>) => {
+			// Clear the field
+			setUploadFileKey(Date.now())
+
+			const file = event.target.files?.[0]
+			if (!file) return
+
+			const reader = new FileReader()
+			reader.onload = (readEvent) => {
+				// On file upload
+
+				const uploadResult = readEvent.target?.result
+				if (typeof uploadResult !== 'string' || !uploadResult) return
+
+				console.log('selected', readEvent.target?.result)
+
+				handleUpdate(uploadResult.toString())
+			}
+			reader.readAsDataURL(file)
+		},
+		[handleUpdate, updateOnKey]
+	)
+
+	return (
+		<div className={classNames}>
+			<UploadButton
+				className="btn btn-primary"
+				accept="image/*"
+				onChange={handleSelectFile}
+				key={uploadFileKey}
+				disabled={disabled}
+			>
+				<FontAwesomeIcon icon={faUpload} />
+				<span>{t('Select image')}</span>
+			</UploadButton>
+			{value ? <img src={value} /> : null}
+		</div>
+	)
+}

--- a/meteor/client/lib/Components/LabelAndOverrides.tsx
+++ b/meteor/client/lib/Components/LabelAndOverrides.tsx
@@ -16,7 +16,7 @@ export interface LabelAndOverridesProps<T extends object, TValue> {
 	opPrefix: string
 	overrideHelper: OverrideOpHelperForItemContents
 
-	formatDefaultValue?: (value: any) => string
+	formatDefaultValue?: (value: any) => JSX.Element | string | null
 
 	children: (value: TValue, setValue: (value: TValue) => void) => React.ReactNode
 }
@@ -49,7 +49,7 @@ export function LabelAndOverrides<T extends object, TValue = any>({
 
 	const isOverridden = hasOpWithPath(item.overrideOps, opPrefix, String(itemKey))
 
-	let displayValue = '""'
+	let displayValue: JSX.Element | string | null = '""'
 	if (item.defaults) {
 		const defaultValue: any = item.defaults[itemKey]
 		// Special cases for formatting of the default
@@ -173,4 +173,18 @@ export function LabelAndOverridesForInt<T extends object>(
 
 export function LabelActual(props: LabelActualProps): JSX.Element {
 	return <div className="label-actual">{props.label}</div>
+}
+
+export function LabelAndOverridesForBase64Image<T extends object>(
+	props: Readonly<Omit<LabelAndOverridesProps<T, string>, 'formatDefaultValue'>>
+): JSX.Element {
+	const formatter = useCallback((defaultValue: any) => {
+		if (defaultValue && defaultValue.startsWith('data:image/')) {
+			return <img className="form-image-preview" src={defaultValue} />
+		} else {
+			return '-'
+		}
+	}, [])
+
+	return <LabelAndOverrides<T, string> {...props} formatDefaultValue={formatter} />
 }

--- a/meteor/client/lib/forms/SchemaFormTable/ObjectTable.scss
+++ b/meteor/client/lib/forms/SchemaFormTable/ObjectTable.scss
@@ -27,3 +27,9 @@
 		background-color: white;
 	}
 }
+
+.settings-config-table img.table-image-preview {
+	// Match the line height of the text
+	max-height: 1.5rem;
+	max-width: 3rem;
+}

--- a/meteor/client/lib/forms/SchemaFormTable/ObjectTable.tsx
+++ b/meteor/client/lib/forms/SchemaFormTable/ObjectTable.tsx
@@ -113,7 +113,9 @@ export const SchemaFormObjectTable = ({
 	const rowSchema = schema.patternProperties?.['']
 
 	const addNewItem = useCallback(() => {
-		overrideHelper.setItemValue(item.id, `${attr}.${getRandomString()}`, getSchemaDefaultValues(rowSchema))
+		const newRowId = getRandomString()
+		overrideHelper.setItemValue(item.id, `${attr}.${newRowId}`, getSchemaDefaultValues(rowSchema))
+		toggleExpanded(newRowId, true)
 	}, [rowSchema, overrideHelper, item.id, attr])
 
 	const doUndeleteRow = useCallback(
@@ -124,7 +126,7 @@ export const SchemaFormObjectTable = ({
 	)
 
 	const tableOverrideHelper = useMemo(
-		() => new OverrideOpHelperObjectTable(overrideHelper, item.id, wrappedRows, attr),
+		() => new OverrideOpHelperObjectTable(overrideHelper, item, wrappedRows, attr),
 		[overrideHelper, item.id, wrappedRows, attr]
 	)
 

--- a/meteor/client/lib/forms/SchemaFormTable/ObjectTable.tsx
+++ b/meteor/client/lib/forms/SchemaFormTable/ObjectTable.tsx
@@ -1,6 +1,6 @@
 import { faPlus } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { getRandomString, joinObjectPathFragments, objectPathGet } from '@sofie-automation/corelib/dist/lib'
+import { getRandomString, joinObjectPathFragments, literal, objectPathGet } from '@sofie-automation/corelib/dist/lib'
 import React, { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
@@ -55,31 +55,59 @@ export const SchemaFormObjectTable = ({
 	const { t } = useTranslation()
 
 	const wrappedRows = useMemo(() => {
-		const itemValue = item.defaults ?? item.computed // If this is sourced from an override, there are no defaults so we need to use the computed instead
-		const rawRows = (attr ? objectPathGet(itemValue, attr) : itemValue) || {}
+		if (item.defaults) {
+			// Table can be overriden with granularity
 
-		const prefix = joinObjectPathFragments(item.id, attr) + '.'
+			const rawRows = (attr ? objectPathGet(item.defaults, attr) : item.defaults) || {}
 
-		// Filter and strip the ops to be local to the row object
-		const ops: SomeObjectOverrideOp[] = []
-		for (const op of item.overrideOps) {
-			if (op.path.startsWith(prefix)) {
-				ops.push({
-					...op,
-					path: op.path.slice(prefix.length),
-				})
+			const prefix = joinObjectPathFragments(item.id, attr) + '.'
+
+			// Filter and strip the ops to be local to the row object
+			const ops: SomeObjectOverrideOp[] = []
+			for (const op of item.overrideOps) {
+				if (op.path.startsWith(prefix)) {
+					ops.push({
+						...op,
+						path: op.path.slice(prefix.length),
+					})
+				}
 			}
+
+			const wrappedRows = getAllCurrentAndDeletedItemsFromOverrides(
+				{
+					defaults: rawRows,
+					overrides: ops,
+				},
+				(a, b) => a[0].localeCompare(b[0]) // TODO - better comparitor?
+			)
+
+			console.log('obj', item, rawRows, ops, wrappedRows)
+
+			return wrappedRows
+		} else {
+			// Table is formed of purely of an override, so ignore any defaults
+
+			const rawRows = (attr ? objectPathGet(item.computed, attr) : item.computed) || {}
+
+			// Convert the items into an array
+			const validItems: Array<[id: string, obj: object]> = []
+			for (const [id, obj] of Object.entries<object | undefined>(rawRows)) {
+				if (obj) validItems.push([id, obj])
+			}
+
+			validItems.sort((a, b) => a[0].localeCompare(b[0])) // TODO - better comparitor?
+
+			// Sort and wrap in the return type
+			return validItems.map(([id, obj]) =>
+				literal<WrappedOverridableItemNormal<object>>({
+					type: 'normal',
+					id: id,
+					computed: obj,
+					defaults: undefined,
+					overrideOps: [],
+				})
+			)
 		}
-
-		const wrappedRows = getAllCurrentAndDeletedItemsFromOverrides(
-			{
-				defaults: rawRows,
-				overrides: ops,
-			},
-			(a, b) => a[0].localeCompare(b[0]) // TODO - better comparitor?
-		)
-
-		return wrappedRows
 	}, [attr, item])
 
 	const rowSchema = schema.patternProperties?.['']

--- a/meteor/client/lib/forms/SchemaFormTable/ObjectTableOpHelper.tsx
+++ b/meteor/client/lib/forms/SchemaFormTable/ObjectTableOpHelper.tsx
@@ -7,34 +7,36 @@ import { OverrideOpHelperForItemContents, WrappedOverridableItem } from '../../.
  */
 export class OverrideOpHelperObjectTable implements OverrideOpHelperForItemContents {
 	readonly #baseHelper: OverrideOpHelperForItemContents
-	readonly #itemId: string
+	readonly #parentItem: WrappedOverridableItem<object>
 	readonly #currentRows: WrappedOverridableItem<object>[]
 	readonly #path: string
 
 	constructor(
 		baseHelper: OverrideOpHelperForItemContents,
-		itemId: string,
+		parentItem: WrappedOverridableItem<object>,
 		currentRows: WrappedOverridableItem<object>[],
 		path: string
 	) {
 		this.#baseHelper = baseHelper
-		this.#itemId = itemId
+		this.#parentItem = parentItem
 		this.#currentRows = currentRows
 		this.#path = path
 	}
 
 	clearItemOverrides(rowId: string, subPath: string): void {
-		this.#baseHelper.clearItemOverrides(this.#itemId, joinObjectPathFragments(this.#path, rowId, subPath))
+		this.#baseHelper.clearItemOverrides(this.#parentItem.id, joinObjectPathFragments(this.#path, rowId, subPath))
 	}
 	deleteRow(rowId: string): void {
-		// Clear any existing overrides
-		this.#baseHelper.clearItemOverrides(this.#itemId, joinObjectPathFragments(this.#path, rowId))
+		const rowPath = joinObjectPathFragments(this.#path, rowId)
 
 		// If row was not user created (it has defaults), then don't store `undefined`
-		const row = this.#currentRows.find((r) => r.id === rowId)
-		if (row && row.defaults) {
-			// This is a bit of a hack, but it isn't possible to create a delete op from here
-			this.#baseHelper.setItemValue(this.#itemId, joinObjectPathFragments(this.#path, rowId), undefined)
+		const currentRow = this.#currentRows.find((r) => r.id === rowId)
+		if (!this.#parentItem.defaults || currentRow?.defaults) {
+			// Mark the row as undefined. This ensures it gets deleted even if the parent is an override
+			this.#baseHelper.setItemValue(this.#parentItem.id, rowPath, undefined)
+		} else {
+			// Clear any existing overrides
+			this.#baseHelper.clearItemOverrides(this.#parentItem.id, rowPath)
 		}
 	}
 	setItemValue(rowId: string, subPath: string, value: unknown): void {
@@ -43,16 +45,14 @@ export class OverrideOpHelperObjectTable implements OverrideOpHelperForItemConte
 
 		if (currentRow.defaults) {
 			// has defaults, so override the single value
-			this.#baseHelper.setItemValue(this.#itemId, joinObjectPathFragments(this.#path, rowId, subPath), value)
+			this.#baseHelper.setItemValue(this.#parentItem.id, joinObjectPathFragments(this.#path, rowId, subPath), value)
 		} else {
 			// no defaults, replace the whole object
-			// Ensure there arent existing overrides
-			this.#baseHelper.clearItemOverrides(this.#itemId, joinObjectPathFragments(this.#path, rowId))
 
 			// replace with a new override
 			const newObj = clone(currentRow.computed)
 			objectPathSet(newObj, subPath, value)
-			this.#baseHelper.setItemValue(this.#itemId, joinObjectPathFragments(this.#path, rowId), newObj)
+			this.#baseHelper.setItemValue(this.#parentItem.id, joinObjectPathFragments(this.#path, rowId), newObj)
 		}
 	}
 }

--- a/meteor/client/lib/forms/SchemaFormWithOverrides.tsx
+++ b/meteor/client/lib/forms/SchemaFormWithOverrides.tsx
@@ -9,6 +9,7 @@ import { IntInputControl } from '../Components/IntInput'
 import { JsonTextInputControl } from '../Components/JsonTextInput'
 import {
 	LabelAndOverrides,
+	LabelAndOverridesForBase64Image,
 	LabelAndOverridesForCheckbox,
 	LabelAndOverridesForDropdown,
 	LabelAndOverridesForInt,
@@ -22,6 +23,7 @@ import { MultiSelectInputControl } from '../Components/MultiSelectInput'
 import { SchemaFormObjectTable } from './SchemaFormTable/ObjectTable'
 import { SchemaFormUIField } from '@sofie-automation/blueprints-integration'
 import { SchemaFormSectionHeader } from './SchemaFormSectionHeader'
+import { Base64ImageInputControl } from '../Components/Base64ImageInput'
 
 interface SchemaFormWithOverridesProps extends SchemaFormCommonProps {
 	/** Base path of the schema within the document */
@@ -102,7 +104,9 @@ export function SchemaFormWithOverrides(props: SchemaFormWithOverridesProps): JS
 		case TypeName.Boolean:
 			return <BooleanFormWithOverrides {...childProps} />
 		case TypeName.String:
-			if (props.schema[SchemaFormUIField.SofieEnum]) {
+			if (props.schema[SchemaFormUIField.DisplayType] === 'base64-image') {
+				return <Base64ImagePickerWithOverrides {...childProps} />
+			} else if (props.schema[SchemaFormUIField.SofieEnum]) {
 				return (
 					<SofieEnumFormWithOverrides
 						{...childProps}
@@ -387,5 +391,20 @@ const JsonFormWithOverrides = ({ schema, commonAttrs }: FormComponentProps) => {
 				)}
 			</LabelAndOverrides>
 		</>
+	)
+}
+
+const Base64ImagePickerWithOverrides = ({ schema, commonAttrs }: FormComponentProps) => {
+	return (
+		<LabelAndOverridesForBase64Image {...commonAttrs}>
+			{(value, handleUpdate) => (
+				<Base64ImageInputControl
+					classNames="input text-input input-l"
+					placeholder={schema.default}
+					value={value}
+					handleUpdate={handleUpdate}
+				/>
+			)}
+		</LabelAndOverridesForBase64Image>
 	)
 }

--- a/meteor/client/lib/forms/schemaFormUtil.tsx
+++ b/meteor/client/lib/forms/schemaFormUtil.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { translateMessage } from '@sofie-automation/corelib/dist/TranslatableMessage'
 import { i18nTranslator } from '../../ui/i18n'
 import { JSONSchema, TypeName } from '@sofie-automation/shared-lib/dist/lib/JSONSchemaTypes'
@@ -38,7 +39,7 @@ export function translateStringIfHasNamespaces(str: string, translationNamespace
 export interface SchemaSummaryField {
 	attr: string
 	name: string
-	transform?: (val: any) => string
+	transform?: (val: any) => string | JSX.Element
 }
 
 export function getSchemaSummaryFieldsForObject(
@@ -95,6 +96,14 @@ export function getSchemaSummaryFields(schema: JSONSchema, prefix?: string): Sch
 							return `${Number(val) + 1}`
 						} else {
 							return val
+						}
+					}
+				} else if (schema.type === 'string' && schema[SchemaFormUIField.DisplayType] === 'base64-image') {
+					transform = (val) => {
+						if (val && val.startsWith('data:image/')) {
+							return <img className="table-image-preview" src={val} />
+						} else {
+							return '-'
 						}
 					}
 				}

--- a/meteor/client/lib/uploadButton.tsx
+++ b/meteor/client/lib/uploadButton.tsx
@@ -5,6 +5,7 @@ interface IProps {
 	accept?: string
 	onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
 	children?: React.ReactNode
+	disabled?: boolean
 }
 
 export const UploadButton: React.FunctionComponent<IProps> = function (props: IProps) {
@@ -22,6 +23,7 @@ export const UploadButton: React.FunctionComponent<IProps> = function (props: IP
 					display: 'inline',
 					position: 'absolute',
 				}}
+				disabled={props.disabled}
 			/>
 		</label>
 	)

--- a/meteor/client/ui/Settings/util/OverrideOpHelper.tsx
+++ b/meteor/client/ui/Settings/util/OverrideOpHelper.tsx
@@ -84,13 +84,13 @@ export function getAllCurrentAndDeletedItemsFromOverrides<T extends object>(
 		})
 	)
 
-	const removedOutputLayers: WrappedOverridableItemDeleted<T>[] = []
+	const removedItems: WrappedOverridableItemDeleted<T>[] = []
 
 	// Find the items which have been deleted with an override
 	const computedOutputLayerIds = new Set(sortedItems.map((l) => l.id))
 	for (const [id, output] of Object.entries<ReadonlyDeep<T | undefined>>(rawObject.defaults)) {
 		if (!computedOutputLayerIds.has(id) && output) {
-			removedOutputLayers.push(
+			removedItems.push(
 				literal<WrappedOverridableItemDeleted<T>>({
 					type: 'deleted',
 					id: id,
@@ -102,9 +102,9 @@ export function getAllCurrentAndDeletedItemsFromOverrides<T extends object>(
 		}
 	}
 
-	if (comparitor) removedOutputLayers.sort((a, b) => comparitor([a.id, a.defaults], [b.id, b.defaults]))
+	if (comparitor) removedItems.sort((a, b) => comparitor([a.id, a.defaults], [b.id, b.defaults]))
 
-	return [...sortedItems, ...removedOutputLayers]
+	return [...sortedItems, ...removedItems]
 }
 
 type SaveOverridesFunction = (newOps: SomeObjectOverrideOp[]) => void

--- a/packages/shared-lib/src/lib/JSONSchemaUtil.ts
+++ b/packages/shared-lib/src/lib/JSONSchemaUtil.ts
@@ -26,7 +26,9 @@ export enum SchemaFormUIField {
 	ZeroBased = 'ui:zeroBased',
 	/**
 	 * Override the presentation with a special mode.
-	 * Currently only valid for string properties. Valid values are 'json'.
+	 * Currently only valid for:
+	 * - object properties. Valid values are 'json'.
+	 * - string properties. Valid values are 'base64-image'.
 	 */
 	DisplayType = 'ui:displayType',
 	/**


### PR DESCRIPTION

## About the Contributor
This pull request is posted on behalf of the NRK.


## Type of Contribution

This is a: Feature / Bug fix


## New Behavior
This adds a new `Base64ImageInputControl` control type with support for it in the json schema forms we utilise.

This control produces a base64 data url (`data:image/png,base64:......`).

The styling needs a bit of refinement, currently looking like:
![image](https://github.com/nrkno/sofie-core/assets/1327476/2a3f553c-7078-4cd8-b6ff-e06ff1817415)

Additionally, this fixes some issues encountered with the object-table portion of json schema forms. When the parent of the table was an override, it was getting confused and was unable to delete rows.

## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
* 
-->


## Time Frame
<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [ ] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
