### PR TITLE
Fix: MeteorApply as alternative to Meteor.apply, to log delayed sent method calls (SOFIE-3236)

### DIFF
--- a/meteor/lib/MeteorApply.ts
+++ b/meteor/lib/MeteorApply.ts
@@ -1,0 +1,150 @@
+import { Meteor } from 'meteor/meteor'
+import { logger } from './logging'
+
+/*
+ * MeteorApply is a wrapper around Meteor.apply(), and logs a warning if the method is sent late.
+ *
+ * Because Meteor methods are generally executed in order, it might be useful to know if a method is sent late.
+ * ref: https://guide.meteor.com/methods#methods-vs-rest
+ *
+ * This only works if all method-calls on the client are done through this function,
+ * as separate calls to Meteor.apply() or Meteor.call() will bypass the queueing, and cause the
+ * time-measurements and logged warnings to be incorrect or omitted.
+ */
+
+/**
+ * Synonym for Meteor.apply.
+ * Logs a warning if the method is sent late
+ */
+export async function MeteorApply(
+	callName: Parameters<typeof Meteor.apply>[0],
+	args: Parameters<typeof Meteor.apply>[1],
+	options?: Parameters<typeof Meteor.apply>[2],
+	sendOptions?: SendOptions
+): Promise<any> {
+	if (!Meteor.isClient) throw new Error('MeteorApply should only be called client side!')
+
+	return new Promise((resolve, reject) => {
+		const queuedMethod: QueuedMeteorMethod = {
+			queueTime: Date.now(),
+			running: false,
+			callName,
+			args,
+			options,
+			sendOptions,
+			reject,
+			resolve,
+		}
+		meteorMethodQueue.push(queuedMethod)
+		checkMethodQueue()
+	})
+}
+const meteorMethodQueue: QueuedMeteorMethod[] = []
+
+function checkMethodQueue() {
+	const nextMethod = meteorMethodQueue[0]
+	if (!nextMethod) return
+	if (!nextMethod.running) {
+		// Time to send the method
+		nextMethod.running = true
+
+		const sendTime = Date.now()
+		const timeBetweenTriggerAndSend = sendTime - nextMethod.queueTime
+		if (timeBetweenTriggerAndSend > (nextMethod.sendOptions?.warnSendTime ?? 1000)) {
+			logWarning(
+				`Method "${
+					nextMethod.callName
+				}" was sent ${timeBetweenTriggerAndSend}ms after it was triggered (at ${new Date().toISOString()})`
+			)
+		}
+
+		Meteor.apply(nextMethod.callName, nextMethod.args, nextMethod.options, (err, res) => {
+			meteorMethodQueue.shift()
+			setTimeout(() => {
+				checkMethodQueue()
+			}, 0)
+
+			const completeTime = Date.now()
+			const timeBetweenSendAndComplete = completeTime - sendTime
+			if (timeBetweenSendAndComplete > (nextMethod.sendOptions?.warnCompleteTime ?? 1000)) {
+				logWarning(
+					`Method "${
+						nextMethod.callName
+					}" was completed ${timeBetweenSendAndComplete}ms after it was sent (at ${new Date().toISOString()})`
+				)
+			}
+
+			if (err) {
+				nextMethod.reject(err)
+			} else {
+				nextMethod.resolve(res)
+			}
+		})
+	}
+}
+
+let loggedWarningCount = 0
+let tooManyWarnings = false
+let skippedWarningCount = 0
+const MAX_LOG_COUNT = 10
+const SKIP_WARNING_COOL_DOWN = 60 * 5 // seconds
+function logWarning(message: string) {
+	if (!tooManyWarnings) {
+		loggedWarningCount++
+
+		if (loggedWarningCount > MAX_LOG_COUNT) {
+			// To avoid a flood of warnings (which, when sent to server via a method call, can cause slowness itself),
+			// we will only log the first {MAX_LOG_COUNT} warnings, and then ignore further warnings for a while.
+
+			logger.warn(
+				`Has logged too many warnings (${loggedWarningCount}) about late Meteor methods. Will ignore further warnings for ${SKIP_WARNING_COOL_DOWN} seconds.`
+			)
+			tooManyWarnings = true
+			setTimeout(() => {
+				if (skippedWarningCount > 0) {
+					logger.warn(
+						`Will start logging warnings about late Meteor methods again. (Ignored ${skippedWarningCount} warnings.)`
+					)
+				}
+				tooManyWarnings = false
+				skippedWarningCount = 0
+				loggedWarningCount = 0
+			}, SKIP_WARNING_COOL_DOWN * 1000)
+		} else {
+			logger.warn(message)
+		}
+	} else {
+		// Ignore the warning
+		skippedWarningCount++
+	}
+}
+// Clear the warning count every hour, just to avoid
+setInterval(() => {
+	if (!tooManyWarnings) {
+		loggedWarningCount = 0
+	}
+}, 3600 * 1000)
+
+interface QueuedMeteorMethod {
+	callName: Parameters<typeof Meteor.apply>[0]
+	args: Parameters<typeof Meteor.apply>[1]
+	options?: Parameters<typeof Meteor.apply>[2]
+
+	reject: (reason: any) => void
+	resolve: (value: unknown) => void
+
+	sendOptions?: SendOptions
+
+	queueTime: number
+	running: boolean
+}
+export interface SendOptions {
+	/** Log a warning if the method was sent later than this time. Defaults to 1000. [milliseconds] */
+	warnSendTime?: number
+	/** Log a warning if the method was completed later than this time. Defaults to 1000. [milliseconds] */
+	warnCompleteTime?: number
+}
+if (Meteor.isClient) {
+	// @ts-expect-error hack for dev
+	window.MeteorApply = MeteorApply
+}

--- a/meteor/lib/lib.ts
+++ b/meteor/lib/lib.ts
@@ -35,7 +35,16 @@ export async function MeteorPromiseApply(
 	args: Parameters<typeof Meteor.apply>[1],
 	options?: Parameters<typeof Meteor.apply>[2]
 ): Promise<any> {
-	return MeteorApply(callName, args, options)
+	if (Meteor.isServer) {
+		return new Promise((resolve, reject) => {
+			Meteor.apply(callName, args, options, (err, res) => {
+				if (err) reject(err)
+				else resolve(res)
+			})
+		})
+	} else {
+		return MeteorApply(callName, args, options)
+	}
 }
 
 // The diff is currently only used client-side

--- a/meteor/lib/lib.ts
+++ b/meteor/lib/lib.ts
@@ -9,6 +9,7 @@ import { MongoQuery as CoreLibMongoQuery } from '@sofie-automation/corelib/dist/
 import { Time, TimeDuration } from '@sofie-automation/shared-lib/dist/lib/lib'
 import { stringifyError } from '@sofie-automation/shared-lib/dist/lib/stringifyError'
 import { ReactiveVar } from 'meteor/reactive-var'
+import { MeteorApply } from './MeteorApply'
 export { Time, TimeDuration }
 
 // Legacy compatability
@@ -34,12 +35,7 @@ export async function MeteorPromiseApply(
 	args: Parameters<typeof Meteor.apply>[1],
 	options?: Parameters<typeof Meteor.apply>[2]
 ): Promise<any> {
-	return new Promise((resolve, reject) => {
-		Meteor.apply(callName, args, options, (err, res) => {
-			if (err) reject(err)
-			else resolve(res)
-		})
-	})
+	return MeteorApply(callName, args, options)
 }
 
 // The diff is currently only used client-side

--- a/meteor/lib/logging.ts
+++ b/meteor/lib/logging.ts
@@ -1,5 +1,6 @@
 import { Meteor } from 'meteor/meteor'
 import { stringifyError } from '@sofie-automation/shared-lib/dist/lib/stringifyError'
+import { MeteorApply } from './MeteorApply'
 
 export const LOGGER_METHOD_NAME = 'logger'
 
@@ -35,7 +36,9 @@ if (Meteor.isServer) {
 			const stringifiedArgs: string[] = args.map((arg) => {
 				return stringifyError(arg)
 			})
-			return Meteor.call(LOGGER_METHOD_NAME, type, ...stringifiedArgs)
+
+			Meteor.call(LOGGER_METHOD_NAME, type, ...stringifiedArgs)
+			return logger
 		}
 	}
 
@@ -67,7 +70,8 @@ if (Meteor.isServer) {
 				const stringifiedArgs: string[] = args.map((arg) => {
 					return stringifyError(arg)
 				})
-				Meteor.call(LOGGER_METHOD_NAME, type, `Client ${type}`, ...stringifiedArgs)
+				MeteorApply(LOGGER_METHOD_NAME, [type, `Client ${type}`, ...stringifiedArgs]).catch(console.error)
+				return logger
 			}
 			return logger
 		}

--- a/packages/job-worker/src/workers/parent-base.ts
+++ b/packages/job-worker/src/workers/parent-base.ts
@@ -305,7 +305,7 @@ export abstract class WorkerParentBase {
 										result.result
 									)
 
-									logger.debug(`Completed work ${job.id} in ${endTime - startTime}ms`)
+									logger.verbose(`Completed work ${job.id} in ${endTime - startTime}ms`)
 								} catch (e: unknown) {
 									let error: Error
 									if (e instanceof Error) {


### PR DESCRIPTION
…1190)<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->

This pull request is posted on behalf of the NRK.

## Type of Contribution

This is a: Code improvement 


## New behaviour

It is in [Meteor's nature ](https://guide.meteor.com/methods#methods-vs-rest) to only send a single method call at a time, so if a previous method call takes a long time to finish executing (or the response was delayed due to network issues), the next method call will be delayed.
When this happens, we currently don't have a way to detect that this has happened, and have no way of knowing which method was delayed, and why.

This PR attempts to help troubleshooting this by adding logging for when a client method is sent late, due to being blocked by other method calls from that client.


## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas


This PR affects how the web client sends data to the server.


## Time Frame

Fairly high priority, we'll likely look into merging this withing the week.



## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
