### PR TITLE
fix: make stringifyError handle UserError better (SOFIE-3337)

### DIFF
--- a/packages/corelib/src/__tests__/error.spec.ts
+++ b/packages/corelib/src/__tests__/error.spec.ts
@@ -1,0 +1,29 @@
+import { stringifyError } from '@sofie-automation/shared-lib/dist/lib/stringifyError'
+import { UserError, UserErrorMessage } from '../error'
+
+describe('UserError', () => {
+	test('stringifyError', () => {
+		const rawError = new Error('raw')
+		rawError.stack = 'mock stack'
+		const userError = UserError.from(rawError, UserErrorMessage.PartNotFound, { key: 'translatable message' })
+
+		expect(stringifyError(userError)).toEqual(
+			'UserError: ' +
+				JSON.stringify({
+					rawError: 'Error: raw, mock stack',
+					message: {
+						key: 'The selected part does not exist',
+						args: {
+							key: 'translatable message',
+						},
+					},
+					key: 25,
+					errorCode: 500,
+				})
+		)
+
+		// serialized and restored
+		const restored = JSON.parse(userError.toString())
+		expect(stringifyError(restored)).toEqual('raw, mock stack')
+	})
+})

--- a/packages/shared-lib/src/lib/stringifyError.ts
+++ b/packages/shared-lib/src/lib/stringifyError.ts
@@ -11,13 +11,13 @@ export function stringifyError(error: unknown, noStack = false): string {
 			// Has a custom toString() method
 			str = `${(error as any).toString()}`
 		} else {
-			const strings: string[] = []
-			if (typeof (error as any).rawError === 'string') strings.push(`${(error as any).rawError}`) // Is an UserError
-			if (typeof (error as Error).message === 'string') strings.push(`${(error as Error).message}`) // Is an Error
-			if (typeof (error as any).reason === 'string') strings.push(`${(error as any).reason}`) // Is a Meteor.Error
-			if (typeof (error as any).details === 'string') strings.push(` ${(error as any).details}`)
-
-			str = strings.join(', ')
+			const strings: (string | undefined)[] = [
+				stringify((error as any).rawError), // UserError
+				stringify((error as Error).message), // Error
+				stringify((error as any).reason), // Meteor.Error
+				stringify((error as any).details),
+			]
+			str = strings.filter(Boolean).join(', ')
 		}
 
 		if (!str) {
@@ -45,4 +45,16 @@ export function stringifyError(error: unknown, noStack = false): string {
 	if (str.startsWith('Error: ')) str = str.slice('Error: '.length)
 
 	return str
+}
+
+function stringify(v: any): string | undefined {
+	// Tries to stringify objects if they have a toString() that returns something sensible
+	if (v === undefined) return undefined
+	if (v === null) return 'null'
+
+	if (typeof v === 'object') {
+		const str = `${v}`
+		if (str !== '[object Object]') return str
+		return undefined
+	} else return `${v}`
 }

--- a/packages/shared-lib/src/lib/stringifyError.ts
+++ b/packages/shared-lib/src/lib/stringifyError.ts
@@ -11,10 +11,13 @@ export function stringifyError(error: unknown, noStack = false): string {
 			// Has a custom toString() method
 			str = `${(error as any).toString()}`
 		} else {
-			str = ''
-			if ((error as Error).message) str += `${(error as Error).message} ` // Is an Error
-			if ((error as any).reason) str += `${(error as any).reason} ` // Is a Meteor.Error
-			if ((error as any).details) str += `${(error as any).details} `
+			const strings: string[] = []
+			if (typeof (error as any).rawError === 'string') strings.push(`${(error as any).rawError}`) // Is an UserError
+			if (typeof (error as Error).message === 'string') strings.push(`${(error as Error).message}`) // Is an Error
+			if (typeof (error as any).reason === 'string') strings.push(`${(error as any).reason}`) // Is a Meteor.Error
+			if (typeof (error as any).details === 'string') strings.push(` ${(error as any).details}`)
+
+			str = strings.join(', ')
 		}
 
 		if (!str) {
@@ -34,7 +37,7 @@ export function stringifyError(error: unknown, noStack = false): string {
 	}
 
 	if (!noStack) {
-		if (error && typeof error === 'object' && (error as any).stack) {
+		if (error && typeof error === 'object' && typeof (error as any).stack === 'string') {
 			str += ', ' + (error as any).stack
 		}
 	}


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
This pull request is posted on behalf of the NRK.

## Type of Contribution

This is a: Bug fix


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

If there is an error in a method run in a job worker, the error logged looks like this:

```
Ingest operation "mosInsertStory" failed: [object Object] , undefined
 => awaited here:
    at Function.Promise.await (/opt/core/programs/server/npm/node_modules/meteor/promise/node_modules/meteor-promise/promise_server.js:56:12)
    at server/api/ingest/lib.ts:40:12
    at /opt/core/programs/server/npm/node_modules/meteor/promise/node_modules/meteor-promise/fiber_pool.js:43:40
``` 


## New Behavior
<!--
What is the new behavior?
-->

```
Ingest operation "mosInsertStory" failed: Error: Test error!, Error: Test error!
     at \sofie-core-R50\packages\job-worker\dist\ingest\mosDevice\mosStoryJobs.js:100:19
     at \sofie-core-R50\packages\job-worker\dist\ingest\lock.js:37:38
     at processTicksAndRejections (internal/process/task_queues.js:95:5)
     at async runWithRundownLockInner (\sofie-core-R50\packages\job-worker\dist\ingest\lock.js:111:21)
     at async IngestWorkerChild.runJob (\sofie-core-R50\packages\job-worker\dist\workers\ingest\child.js:88:33), undefined
  => awaited here:
     at Function.Promise.await (AppData\Local\.meteor\packages\promise\0.12.0\npm\node_modules\meteor-promise\promise_server.js:56:12)
     at server/api/ingest/lib.ts:40:12
     at AppData\Local\.meteor\packages\promise\0.12.0\npm\node_modules\meteor-promise\fiber_pool.js:43:40
```


## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [x] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
* 
-->

* This PR affects error logging

## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
