### PR TITLE
feat: Ensure peripheralDevice subdevice removal when requested

### DIFF
--- a/packages/mos-gateway/src/CoreMosDeviceHandler.ts
+++ b/packages/mos-gateway/src/CoreMosDeviceHandler.ts
@@ -427,7 +427,7 @@ export class CoreMosDeviceHandler {
 			}, 2000)
 		})
 	}
-	async dispose(): Promise<void> {
+	async dispose(subdevice: 'keepSubDevice' | 'removeSubDevice' = 'keepSubDevice'): Promise<void> {
 		this._observers.forEach((obs) => obs.stop())
 
 		await this.core.setStatus({
@@ -435,6 +435,7 @@ export class CoreMosDeviceHandler {
 			messages: ['Uninitialized'],
 		})
 
+		if (subdevice === 'removeSubDevice') await this.core.unInitialize()
 		await this.core.destroy()
 	}
 	killProcess(): void {

--- a/packages/mos-gateway/src/coreHandler.ts
+++ b/packages/mos-gateway/src/coreHandler.ts
@@ -167,7 +167,7 @@ export class CoreHandler {
 		const coreMosHandler = this._coreMosHandlers[foundI]
 		if (coreMosHandler) {
 			this._coreMosHandlers.splice(foundI, 1)
-			await coreMosHandler.dispose()
+			await coreMosHandler.dispose('removeSubDevice')
 		}
 	}
 	onConnectionRestored(): void {

--- a/packages/playout-gateway/src/coreHandler.ts
+++ b/packages/playout-gateway/src/coreHandler.ts
@@ -548,7 +548,7 @@ export class CoreTSRDeviceHandler {
 		)
 	}
 
-	async dispose(): Promise<void> {
+	async dispose(subdevice: 'keepSubDevice' | 'removeSubDevice' = 'keepSubDevice'): Promise<void> {
 		this._observers.forEach((obs) => obs.stop())
 
 		await this._tsrHandler.tsr.removeDevice(this._deviceId)
@@ -557,6 +557,7 @@ export class CoreTSRDeviceHandler {
 			messages: ['Uninitialized'],
 		})
 
+		if (subdevice === 'removeSubDevice') await this.core.unInitialize()
 		await this.core.destroy()
 	}
 	killProcess(): void {

--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -1002,7 +1002,7 @@ export class TSRHandler {
 		let success = false
 		if (this._coreTsrHandlers[deviceId]) {
 			try {
-				await this._coreTsrHandlers[deviceId].dispose()
+				await this._coreTsrHandlers[deviceId].dispose('removeSubDevice')
 				this.logger.debug('Disposed device ' + deviceId)
 				success = true
 			} catch (error) {


### PR DESCRIPTION
## This PR has been opened by SuperFly.tv on behalf of EVS Broadcast Equipment.

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Feature

### What is the current behaviour? (You can also link to an open issue here)

When changing the blueprint configuration through the API peripheralDevice subdevices can be added and removed. Currently the removal leaves the subdevice in place with a status of 'BAD' and with the message 'Uninitialized'.

### What is the new behaviour (if this is a feature change)?

This change forces the subdevice to be removed in this specific case.
The change is intended as a step towards allowing a Sofie instance to be completely reconfigured via API between productions.

### Other information:

#### Status

- [x] PR is ready to be reviewed.
- [x] Relevant unit tests have been checked.
- [x] The functionality has been tested by the PR author

#### Affected Areas

* This PR affects mos-gateway and playout-gateway subdevices.
