### PR TITLE
SOFIE-3367 feat: allows to cofigure an offset-factor between the L and R joycon …

### DIFF
--- a/meteor/client/ui/Prompter/PrompterView.tsx
+++ b/meteor/client/ui/Prompter/PrompterView.tsx
@@ -44,6 +44,7 @@ interface PrompterConfig {
 	joycon_rangeNeutralMin?: number
 	joycon_rangeNeutralMax?: number
 	joycon_rangeFwdMax?: number
+	joycon_rightHandOffset?: number
 	pedal_speedMap?: number[]
 	pedal_reverseSpeedMap?: number[]
 	pedal_rangeRevMin?: number
@@ -144,6 +145,7 @@ export class PrompterViewInner extends MeteorReactComponent<Translated<IProps & 
 			joycon_rangeNeutralMin: parseInt(firstIfArray(queryParams['joycon_rangeNeutralMin']) as string, 10) || undefined,
 			joycon_rangeNeutralMax: parseInt(firstIfArray(queryParams['joycon_rangeNeutralMax']) as string, 10) || undefined,
 			joycon_rangeFwdMax: parseInt(firstIfArray(queryParams['joycon_rangeFwdMax']) as string, 10) || undefined,
+			joycon_rightHandOffset: parseInt(firstIfArray(queryParams['joycon_rightHandOffset']) as string, 10) || undefined,
 			pedal_speedMap:
 				queryParams['pedal_speedMap'] === undefined
 					? undefined

--- a/meteor/client/ui/Prompter/controller/joycon-device.ts
+++ b/meteor/client/ui/Prompter/controller/joycon-device.ts
@@ -17,6 +17,7 @@ export class JoyConController extends ControllerAbstract {
 	private rangeNeutralMin = -0.25 // pedal "back" position where reverse-range transistions to the neutral x
 	private rangeNeutralMax = 0.25 // pedal "front" position where scrolling starts, the 0 speed origin
 	private rangeFwdMax = 1 // pedal "all front" position where scrolling is maxed out
+	private rightHandOffset = 1.4 // factor increased by 1.4 to account for the R joystick being less sensitive than L
 	private speedMap = [1, 2, 3, 4, 5, 8, 12, 30]
 	private reverseSpeedMap = [1, 2, 3, 4, 5, 8, 12, 30]
 	private deadBand = 0.25
@@ -40,6 +41,7 @@ export class JoyConController extends ControllerAbstract {
 		this.rangeNeutralMin = view.configOptions.joycon_rangeNeutralMin || this.rangeNeutralMin
 		this.rangeNeutralMax = view.configOptions.joycon_rangeNeutralMax || this.rangeNeutralMax
 		this.rangeFwdMax = view.configOptions.joycon_rangeFwdMax || this.rangeFwdMax
+		this.rightHandOffset = view.configOptions.joycon_rightHandOffset || this.rightHandOffset
 		this.speedMap = view.configOptions.joycon_speedMap || this.speedMap
 		this.reverseSpeedMap = view.configOptions.joycon_reverseSpeedMap || this.reverseSpeedMap
 		this.deadBand = Math.min(Math.abs(this.rangeNeutralMin), Math.abs(this.rangeNeutralMax))
@@ -249,8 +251,8 @@ export class JoyConController extends ControllerAbstract {
 						if (joycon.mode === 'L') {
 							lastSeenSpeed = joycon.axes[0] * -1 // in this mode, L is "negative"
 						} else if (joycon.mode === 'R') {
-							lastSeenSpeed = joycon.axes[0] * 1.4 // in this mode, R is "positive"
-							// factor increased by 1.4 to account for the R joystick being less sensitive than L
+							lastSeenSpeed = joycon.axes[0] * this.rightHandOffset // in this mode, R is "positive"
+							// rightHandOffset allows for different rates between the two controllers
 						}
 						this.timestampOfLastUsedJoyconInput = joycon.timestamp
 					}
@@ -260,8 +262,8 @@ export class JoyConController extends ControllerAbstract {
 					if (Math.abs(joycon.axes[1]) > this.deadBand) {
 						lastSeenSpeed = joycon.axes[1] * -1 // in this mode, we are "negative" on both sticks....
 					} else if (Math.abs(joycon.axes[3]) > this.deadBand) {
-						lastSeenSpeed = joycon.axes[3] * -1.4 // in this mode, we are "negative" on both sticks....
-						// factor increased by 1.4 to account for the R joystick being less sensitive than L
+						lastSeenSpeed = joycon.axes[3] * this.rightHandOffset * -1 // in this mode, we are "negative" on both sticks....
+						// rightHandOffset allows for different rates between the two controllers
 					}
 					this.timestampOfLastUsedJoyconInput = joycon.timestamp
 				}

--- a/packages/documentation/docs/user-guide/features/prompter.md
+++ b/packages/documentation/docs/user-guide/features/prompter.md
@@ -28,7 +28,7 @@ The prompter UI can be configured using query parameters:
 | `showmarker`    | 0 / 1  | If the marker is not set to "hide", control if the marker is hidden or not                                                                                          | `1`     |
 | `showscroll`    | 0 / 1  | Whether the scroll bar should be shown                                                                                                                              | `1`     |
 | `followtake`    | 0 / 1  | Whether the prompter should automatically scroll to current segment when the operator TAKE:s it                                                                     | `1`     |
-| `showoverunder`    | 0 / 1  | The timer in the top-right of the prompter, showing the overtime/undertime of the current show.                                                                     | `1`     |
+| `showoverunder` | 0 / 1  | The timer in the top-right of the prompter, showing the overtime/undertime of the current show.                                                                     | `1`     |
 | `debug`         | 0 / 1  | Whether to display a debug box showing controller input values and the calculated speed the prompter is currently scrolling at. Used to tweak speedMaps and ranges. | `0`     |
 
 Example: [http://127.0.0.1/prompter/studio0/?mode=mouse&followtake=0&fontsize=20](http://127.0.0.1/prompter/studio0/?mode=mouse&followtake=0&fontsize=20)
@@ -37,9 +37,9 @@ Example: [http://127.0.0.1/prompter/studio0/?mode=mouse&followtake=0&fontsize=20
 
 The prompter can be controlled by different types of controllers. The control mode is set by a query parameter, like so: `?mode=mouse`.
 
-| Query parameter         | Description                                                                                                                                                                                                                                 |
-| :---------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Default                 | Controlled by both mouse and keyboard                                                                                                                                                                                                       |
+| Query parameter         | Description                                                                                                                                                                                                                                    |
+| :---------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Default                 | Controlled by both mouse and keyboard                                                                                                                                                                                                          |
 | `?mode=mouse`           | Controlled by mouse only. [See configuration details](prompter.md#control-using-mouse-scroll-wheel)                                                                                                                                            |
 | `?mode=keyboard`        | Controlled by keyboard only. [See configuration details](prompter.md#control-using-keyboard)                                                                                                                                                   |
 | `?mode=shuttlekeyboard` | Controlled by a Contour Design ShuttleXpress, X-keys Jog and Shuttle or any compatible, configured as keyboard-ish device. [See configuration details](prompter.md#control-using-contour-shuttlexpress-or-x-keys)                              |
@@ -117,7 +117,7 @@ If you want to use traditional analogue pedals with 5 volt TRS connection, a con
 - `pedal_rangeNeutralMax` has to be greater than `pedal_rangeNeutralMin`
 - `pedal_rangeFwdMax` has to be greater than `pedal_rangeNeutralMax`
 
-![Yamaha FC7 mapped for both a forward \(80-127\) and backwards \(0-35\) range.](/img/docs/main/features/yamaha-fc7.jpg)
+![Yamaha FC7 mapped for both a forward (80-127) and backwards (0-35) range.](/img/docs/main/features/yamaha-fc7.jpg)
 
 The default values allow for both going forwards and backwards. This matches the _Yamaha FC7_ expression pedal. The default values create a forward-range from 80-127, a neutral zone from 35-80 and a reverse-range from 0-35.
 
@@ -158,6 +158,7 @@ The Joycons can operate in 3 modes, the L-stick, the R-stick or both L+R sticks 
 | `joycon_rangeNeutralMin` | number           | The beginning of the backwards-range.                                                                                                                                                                                                                                                      | `-0.25`                      |
 | `joycon_rangeNeutralMax` | number           | The minimum input to run forward, the start of the forward-range \(min speed\). This is also the end of any "deadband" you want filter out before starting moving forwards.                                                                                                                | `0.25`                       |
 | `joycon_rangeFwdMax`     | number           | The maximum input, the end of the forward-range \(max speed\)                                                                                                                                                                                                                              | `1`                          |
+| `joycon_rightHandOffset` | number           | A ratio to increase or decrease the R Joycon joystick sensitivity relative to the L Joycon.                                                                                                                                                                                                | `1.4`                        |
 
 - `joycon_rangeNeutralMin` has to be greater than `joycon_rangeRevMin`
 - `joycon_rangeNeutralMax` has to be greater than `joycon_rangeNeutralMin`


### PR DESCRIPTION
…joysticks to compensate for different rates.

New URL param is called joycon_rightHandOffset. Used to be hardcoded to 1.4 which now is a default.

(cherry picked from commit 9d186ae622df925d2bd3a6b789571c3d6f000ed9)

## About the Contributor
This pull request is posted on behalf of the NRK.


## Type of Contribution

This is a:
Feature

## Current Behavior
Hard-coded 1.4x multiplier of joystick values for R joycon compared to the L one.


## New Behavior
Configurable multiplier of R joycon joystick values relative tot he L one. Default/unconfigured = 1.4, for backwards compatibility.


## Testing

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas
Prompter controller


## Time Frame
<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [ ] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
