### PR TITLE
fix: compensate for piece preroll for adlibbed pieces SOFIE-3369

### DIFF
--- a/packages/corelib/src/playout/processAndPrune.ts
+++ b/packages/corelib/src/playout/processAndPrune.ts
@@ -10,8 +10,16 @@ import { getPieceControlObjectId } from './ids'
 /**
  * Get the `enable: { start: ?? }` for the new piece in terms that can be used as an `end` for another object
  */
-function getPieceStartTime(newPieceStart: number | 'now', newPiece: PieceInstance): number | string {
+function getPieceStartTimeAsReference(newPieceStart: number | 'now', newPiece: PieceInstance): number | string {
 	return typeof newPieceStart === 'number' ? newPieceStart : `#${getPieceControlObjectId(newPiece)}.start`
+}
+
+function getPieceStartTimeWithinPart(p: PieceInstance): 'now' | number {
+	if (p.piece.enable.start === 'now' || !p.dynamicallyInserted) {
+		return p.piece.enable.start
+	} else {
+		return p.piece.enable.start + (p.piece.prerollDuration ?? 0)
+	}
 }
 
 function isClear(piece?: PieceInstance): boolean {
@@ -85,7 +93,7 @@ export function processAndPrunePieceInstanceTimings(
 	for (const pieces of groupedPieces.values()) {
 		// Group and sort the pieces so that we can step through each point in time
 		const piecesByStart: Array<[number | 'now', PieceInstance[]]> = _.sortBy(
-			Array.from(groupByToMapFunc(pieces, (p) => p.piece.enable.start).entries()).map(([k, v]) =>
+			Array.from(groupByToMapFunc(pieces, (p) => getPieceStartTimeWithinPart(p)).entries()).map(([k, v]) =>
 				literal<[number | 'now', PieceInstance[]]>([k === 'now' ? 'now' : Number(k), v])
 			),
 			([k]) => (k === 'now' ? nowInPart : k)
@@ -120,7 +128,7 @@ function updateWithNewPieces(
 	if (newPiece) {
 		const activePiece = activePieces[key]
 		if (activePiece) {
-			activePiece.resolvedEndCap = getPieceStartTime(newPiecesStart, newPiece)
+			activePiece.resolvedEndCap = getPieceStartTimeAsReference(newPiecesStart, newPiece)
 		}
 		// track the new piece
 		activePieces[key] = newPiece
@@ -145,7 +153,7 @@ function updateWithNewPieces(
 					(newPiecesStart !== 0 || isCandidateBetterToBeContinued(activePieces.other, newPiece))
 				) {
 					// These modes should stop the 'other' when they start if not hidden behind a higher priority onEnd
-					activePieces.other.resolvedEndCap = getPieceStartTime(newPiecesStart, newPiece)
+					activePieces.other.resolvedEndCap = getPieceStartTimeAsReference(newPiecesStart, newPiece)
 					activePieces.other = undefined
 				}
 			}

--- a/packages/job-worker/src/playout/__tests__/timeline.test.ts
+++ b/packages/job-worker/src/playout/__tests__/timeline.test.ts
@@ -1439,6 +1439,8 @@ describe('Timeline', () => {
 					// Simulate the piece timing confirmation from playout-gateway
 					await doSimulatePiecePlaybackTimings(playlistId, pieceOffset, 1)
 
+					const pieceOffsetWithPreroll = pieceOffset + 340
+
 					// Now we have a concrete time
 					await checkTimings({
 						previousPart: null,
@@ -1446,7 +1448,7 @@ describe('Timeline', () => {
 							piece000: {
 								controlObj: {
 									start: 500, // This one gave the preroll
-									end: pieceOffset,
+									end: pieceOffsetWithPreroll,
 								},
 								childGroup: {
 									preroll: 500,
@@ -1465,7 +1467,7 @@ describe('Timeline', () => {
 							[adlibbedPieceId]: {
 								// Our adlibbed piece
 								controlObj: {
-									start: pieceOffset,
+									start: pieceOffsetWithPreroll,
 								},
 								childGroup: {
 									preroll: 340,

--- a/packages/job-worker/src/playout/timeline/piece.ts
+++ b/packages/job-worker/src/playout/timeline/piece.ts
@@ -93,10 +93,16 @@ export function getPieceEnableInsidePart(
 	partGroupId: string
 ): TSR.Timeline.TimelineEnable {
 	const pieceEnable: TSR.Timeline.TimelineEnable = { ...pieceInstance.piece.enable }
-	if (typeof pieceEnable.start === 'number' && !pieceInstance.dynamicallyInserted) {
-		// timed pieces should be offset based on the preroll of the part
-		pieceEnable.start += partTimings.toPartDelay
+	if (typeof pieceEnable.start === 'number') {
+		if (pieceInstance.dynamicallyInserted) {
+			// timed adlibbed pieces needs to factor in their preroll
+			pieceEnable.start += pieceInstance.piece.prerollDuration || 0
+		} else {
+			// timed planned pieces should be offset based on the preroll of the part
+			pieceEnable.start += partTimings.toPartDelay
+		}
 	}
+
 	if (partTimings.toPartPostroll) {
 		if (!pieceEnable.duration) {
 			// make sure that the control object is shortened correctly

--- a/packages/job-worker/src/playout/timings/timelineTriggerTime.ts
+++ b/packages/job-worker/src/playout/timings/timelineTriggerTime.ts
@@ -112,7 +112,7 @@ function timelineTriggerTimeInner(
 						pieceInstance.piece.enable.start === 'now'
 					) {
 						pieceInstanceCache.updateOne(pieceInstance._id, (p) => {
-							p.piece.enable.start = o.time + (p.piece.prerollDuration ?? 0)
+							p.piece.enable.start = o.time
 							return p
 						})
 

--- a/packages/job-worker/src/playout/timings/timelineTriggerTime.ts
+++ b/packages/job-worker/src/playout/timings/timelineTriggerTime.ts
@@ -112,7 +112,7 @@ function timelineTriggerTimeInner(
 						pieceInstance.piece.enable.start === 'now'
 					) {
 						pieceInstanceCache.updateOne(pieceInstance._id, (p) => {
-							p.piece.enable.start = o.time
+							p.piece.enable.start = o.time + (p.piece.prerollDuration ?? 0)
 							return p
 						})
 


### PR DESCRIPTION

## About the Contributor
This pull request is posted on behalf of the NRK.


## Type of Contribution

This is a:Bug fix

## Current Behavior

When adlibbing a clip (or another piece with preroll) into the current part, a subsequent update to the timeline will cause the start of the adlibbed piece to drift earlier, by the preroll amount


## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [x] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

* This PR affects playout.


## Time Frame
<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->

This happens because while the start of the piece is 'now', the preroll gets added here https://github.com/nrkno/sofie-core/blob/b700f568b20c698df82e387e2671179c0b939539/packages/corelib/src/playout/pieces.ts#L106-L127
But then once it is a concrete number (set to the start of that object), the preroll isnt added, causing it to shift.


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
