### PR TITLE
fix: unexpected timeline updates while playing final part in rundown SOFIE-3371

### DIFF
--- a/packages/job-worker/src/ingest/__tests__/updateNext.test.ts
+++ b/packages/job-worker/src/ingest/__tests__/updateNext.test.ts
@@ -634,4 +634,26 @@ describe('ensureNextPartIsValid', () => {
 			await context.mockCollections.Parts.remove(part._id)
 		}
 	})
+
+	test('Current part is last in rundown, next is missing', async () => {
+		await resetPartIds('mock_part_instance9', 'fake_part_instance', false)
+
+		await expect(ensureNextPartIsValid()).resolves.toBeTruthy()
+
+		expect(setNextPartMock).toHaveBeenCalledTimes(1)
+		expect(setNextPartMock).toHaveBeenCalledWith(
+			expect.objectContaining({}),
+			expect.objectContaining({ PlaylistId: rundownPlaylistId }),
+			null,
+			false
+		)
+	})
+
+	test('Current part is last in rundown, no-op to update', async () => {
+		await resetPartIds('mock_part_instance9', null, false)
+
+		await expect(ensureNextPartIsValid()).resolves.toBeFalsy()
+
+		expect(setNextPartMock).toHaveBeenCalledTimes(0)
+	})
 })

--- a/packages/job-worker/src/ingest/__tests__/updateNext.test.ts
+++ b/packages/job-worker/src/ingest/__tests__/updateNext.test.ts
@@ -344,7 +344,7 @@ describe('ensureNextPartIsValid', () => {
 		})
 	}
 	async function ensureNextPartIsValid() {
-		await runJobWithPlayoutCache(context, { playlistId: rundownPlaylistId }, null, async (cache) =>
+		return runJobWithPlayoutCache(context, { playlistId: rundownPlaylistId }, null, async (cache) =>
 			ensureNextPartIsValidRaw(context, cache)
 		)
 	}
@@ -352,7 +352,7 @@ describe('ensureNextPartIsValid', () => {
 	test('Start with null', async () => {
 		await resetPartIds(null, null)
 
-		await ensureNextPartIsValid()
+		await expect(ensureNextPartIsValid()).resolves.toBeTruthy()
 
 		expect(setNextPartMock).toHaveBeenCalledTimes(1)
 		expect(setNextPartMock).toHaveBeenCalledWith(
@@ -365,7 +365,7 @@ describe('ensureNextPartIsValid', () => {
 	test('Missing next PartInstance', async () => {
 		await resetPartIds('mock_part_instance3', 'fake_part')
 
-		await ensureNextPartIsValid()
+		await expect(ensureNextPartIsValid()).resolves.toBeTruthy()
 
 		expect(setNextPartMock).toHaveBeenCalledTimes(1)
 		expect(setNextPartMock).toHaveBeenCalledWith(
@@ -380,14 +380,14 @@ describe('ensureNextPartIsValid', () => {
 	test('Missing current PartInstance with valid next', async () => {
 		await resetPartIds('fake_part', 'mock_part_instance4')
 
-		await ensureNextPartIsValid()
+		await expect(ensureNextPartIsValid()).resolves.toBeFalsy()
 
 		expect(setNextPartMock).toHaveBeenCalledTimes(0)
 	})
 	test('Missing current and next PartInstance', async () => {
 		await resetPartIds('fake_part', 'not_real_either')
 
-		await ensureNextPartIsValid()
+		await expect(ensureNextPartIsValid()).resolves.toBeTruthy()
 
 		expect(setNextPartMock).toHaveBeenCalledTimes(1)
 		expect(setNextPartMock).toHaveBeenCalledWith(
@@ -400,21 +400,21 @@ describe('ensureNextPartIsValid', () => {
 	test('Ensure correct PartInstance doesnt change', async () => {
 		await resetPartIds('mock_part_instance3', 'mock_part_instance4')
 
-		await ensureNextPartIsValid()
+		await expect(ensureNextPartIsValid()).resolves.toBeFalsy()
 
 		expect(setNextPartMock).not.toHaveBeenCalled()
 	})
 	test('Ensure manual PartInstance doesnt change', async () => {
 		await resetPartIds('mock_part_instance3', 'mock_part_instance5', true)
 
-		await ensureNextPartIsValid()
+		await expect(ensureNextPartIsValid()).resolves.toBeFalsy()
 
 		expect(setNextPartMock).not.toHaveBeenCalled()
 	})
 	test('Ensure non-manual PartInstance does change', async () => {
 		await resetPartIds('mock_part_instance3', 'mock_part_instance5', false)
 
-		await ensureNextPartIsValid()
+		await expect(ensureNextPartIsValid()).resolves.toBeTruthy()
 
 		expect(setNextPartMock).toHaveBeenCalledTimes(1)
 		expect(setNextPartMock).toHaveBeenCalledWith(
@@ -427,7 +427,7 @@ describe('ensureNextPartIsValid', () => {
 	test('Ensure manual but missing PartInstance does change', async () => {
 		await resetPartIds('mock_part_instance3', 'fake_part', true)
 
-		await ensureNextPartIsValid()
+		await expect(ensureNextPartIsValid()).resolves.toBeTruthy()
 
 		expect(setNextPartMock).toHaveBeenCalledTimes(1)
 		expect(setNextPartMock).toHaveBeenCalledWith(
@@ -440,7 +440,7 @@ describe('ensureNextPartIsValid', () => {
 	test('Ensure manual but floated PartInstance does change', async () => {
 		await resetPartIds('mock_part_instance7', 'mock_part_instance8', true)
 
-		await ensureNextPartIsValid()
+		await expect(ensureNextPartIsValid()).resolves.toBeTruthy()
 
 		expect(setNextPartMock).toHaveBeenCalledTimes(1)
 		expect(setNextPartMock).toHaveBeenCalledWith(
@@ -453,7 +453,7 @@ describe('ensureNextPartIsValid', () => {
 	test('Ensure floated PartInstance does change', async () => {
 		await resetPartIds('mock_part_instance7', 'mock_part_instance8', false)
 
-		await ensureNextPartIsValid()
+		await expect(ensureNextPartIsValid()).resolves.toBeTruthy()
 
 		expect(setNextPartMock).toHaveBeenCalledTimes(1)
 		expect(setNextPartMock).toHaveBeenCalledWith(
@@ -490,7 +490,7 @@ describe('ensureNextPartIsValid', () => {
 
 		await resetPartIds(null, instanceId, false)
 
-		await ensureNextPartIsValid()
+		await expect(ensureNextPartIsValid()).resolves.toBeTruthy()
 
 		expect(setNextPartMock).toHaveBeenCalledTimes(1)
 		expect(setNextPartMock).toHaveBeenCalledWith(
@@ -527,7 +527,7 @@ describe('ensureNextPartIsValid', () => {
 
 		await resetPartIds(null, instanceId, true)
 
-		await ensureNextPartIsValid()
+		await expect(ensureNextPartIsValid()).resolves.toBeTruthy()
 
 		expect(setNextPartMock).toHaveBeenCalledTimes(1)
 		expect(setNextPartMock).toHaveBeenCalledWith(
@@ -568,7 +568,7 @@ describe('ensureNextPartIsValid', () => {
 
 		await resetPartIds('mock_part_instance1', instanceId, false)
 
-		await ensureNextPartIsValid()
+		await expect(ensureNextPartIsValid()).resolves.toBeFalsy()
 
 		expect(setNextPartMock).toHaveBeenCalledTimes(0)
 	})
@@ -601,7 +601,7 @@ describe('ensureNextPartIsValid', () => {
 		try {
 			// make sure it finds the part we expect
 			await resetPartIds('mock_part_instance9', null, false)
-			await ensureNextPartIsValid()
+			await expect(ensureNextPartIsValid()).resolves.toBeTruthy()
 
 			expect(setNextPartMock).toHaveBeenCalledTimes(1)
 			expect(setNextPartMock).toHaveBeenCalledWith(
@@ -619,7 +619,7 @@ describe('ensureNextPartIsValid', () => {
 			await context.mockCollections.Parts.remove(part._id)
 
 			// make sure the next part gets cleared
-			await ensureNextPartIsValid()
+			await expect(ensureNextPartIsValid()).resolves.toBeTruthy()
 
 			expect(setNextPartMock).toHaveBeenCalledTimes(1)
 			expect(setNextPartMock).toHaveBeenCalledWith(

--- a/packages/job-worker/src/ingest/commit.ts
+++ b/packages/job-worker/src/ingest/commit.ts
@@ -241,6 +241,7 @@ export async function CommitIngestOperation(
 				await pSaveIngest
 
 				// do some final playout checks, which may load back some Parts data
+				// Note: This should trigger a timeline update, one is already queued in the `deferAfterSave` above
 				await ensureNextPartIsValid(context, playoutCache)
 
 				// save the final playout changes
@@ -510,9 +511,9 @@ export async function updatePlayoutAfterChangingRundownInPlaylist(
 			)
 		}
 
-		await ensureNextPartIsValid(context, playoutCache)
+		const shouldUpdateTimeline = await ensureNextPartIsValid(context, playoutCache)
 
-		if (playoutCache.Playlist.doc.activationId) {
+		if (playoutCache.Playlist.doc.activationId || shouldUpdateTimeline) {
 			triggerUpdateTimelineAfterIngestData(context, playoutCache.PlaylistId)
 		}
 	})

--- a/packages/job-worker/src/ingest/updateNext.ts
+++ b/packages/job-worker/src/ingest/updateNext.ts
@@ -8,78 +8,85 @@ import {
 import { JobContext } from '../jobs'
 import { setNextPart } from '../playout/setNext'
 import { isPartPlayable } from '@sofie-automation/corelib/dist/dataModel/Part'
-import { updateTimeline } from '../playout/timeline/generate'
 
 /**
  * Make sure that the nextPartInstance for the current Playlist is still correct
  * This will often change the nextPartInstance
  * @param context Context of the job being run
  * @param cache Playout Cache to operate on
+ * @returns Whether the timeline should be updated following this operation
  */
-export async function ensureNextPartIsValid(context: JobContext, cache: CacheForPlayout): Promise<void> {
+export async function ensureNextPartIsValid(context: JobContext, cache: CacheForPlayout): Promise<boolean> {
 	const span = context.startSpan('api.ingest.ensureNextPartIsValid')
 
 	// Ensure the next-id is still valid
 	const playlist = cache.Playlist.doc
-	if (playlist?.activationId) {
-		const { currentPartInstance, nextPartInstance } = getSelectedPartInstancesFromCache(cache)
+	if (!playlist?.activationId) {
+		span?.end()
+		return false
+	}
+
+	const { currentPartInstance, nextPartInstance } = getSelectedPartInstancesFromCache(cache)
+
+	if (
+		playlist.nextPartInfo?.manuallySelected &&
+		nextPartInstance?.part &&
+		isPartPlayable(nextPartInstance.part) &&
+		nextPartInstance.orphaned !== 'deleted'
+	) {
+		// Manual next part is almost always valid. This includes orphaned (adlib-part) partinstances
+		span?.end()
+		return false
+	}
+
+	// If we are close to an autonext, then leave it to avoid glitches
+	if (isTooCloseToAutonext(currentPartInstance) && nextPartInstance) {
+		span?.end()
+		return false
+	}
+
+	const allPartsAndSegments = getOrderedSegmentsAndPartsFromPlayoutCache(cache)
+
+	if (currentPartInstance && nextPartInstance) {
+		// Check if the part is the same
+		const newNextPart = selectNextPart(
+			context,
+			playlist,
+			currentPartInstance,
+			nextPartInstance,
+			allPartsAndSegments
+		)
 
 		if (
-			playlist.nextPartInfo?.manuallySelected &&
-			nextPartInstance?.part &&
-			isPartPlayable(nextPartInstance.part) &&
-			nextPartInstance.orphaned !== 'deleted'
+			// Nothing should be nexted
+			!newNextPart ||
+			// The nexted-part should be different to what is selected
+			newNextPart.part._id !== nextPartInstance.part._id ||
+			// The nexted-part Instance is no longer playable
+			!isPartPlayable(nextPartInstance.part)
 		) {
-			// Manual next part is almost always valid. This includes orphaned (adlib-part) partinstances
-			span?.end()
-			return
-		}
-
-		// If we are close to an autonext, then leave it to avoid glitches
-		if (isTooCloseToAutonext(currentPartInstance) && nextPartInstance) {
-			span?.end()
-			return
-		}
-
-		const allPartsAndSegments = getOrderedSegmentsAndPartsFromPlayoutCache(cache)
-
-		if (currentPartInstance && nextPartInstance) {
-			// Check if the part is the same
-			const newNextPart = selectNextPart(
-				context,
-				playlist,
-				currentPartInstance,
-				nextPartInstance,
-				allPartsAndSegments
-			)
-
-			if (
-				// Nothing should be nexted
-				!newNextPart ||
-				// The nexted-part should be different to what is selected
-				newNextPart.part._id !== nextPartInstance.part._id ||
-				// The nexted-part Instance is no longer playable
-				!isPartPlayable(nextPartInstance.part)
-			) {
-				// The 'new' next part is before the current next, so move the next point
-				await setNextPart(context, cache, newNextPart ?? null, false)
-
-				await updateTimeline(context, cache)
-			}
-		} else if (!nextPartInstance || nextPartInstance.orphaned === 'deleted') {
-			// Don't have a nextPart or it has been deleted, so autoselect something
-			const newNextPart = selectNextPart(
-				context,
-				playlist,
-				currentPartInstance ?? null,
-				nextPartInstance ?? null,
-				allPartsAndSegments
-			)
+			// The 'new' next part is before the current next, so move the next point
 			await setNextPart(context, cache, newNextPart ?? null, false)
 
-			await updateTimeline(context, cache)
+			span?.end()
+			return true
 		}
+	} else if (!nextPartInstance || nextPartInstance.orphaned === 'deleted') {
+		// Don't have a nextPart or it has been deleted, so autoselect something
+		const newNextPart = selectNextPart(
+			context,
+			playlist,
+			currentPartInstance ?? null,
+			nextPartInstance ?? null,
+			allPartsAndSegments
+		)
+
+		await setNextPart(context, cache, newNextPart ?? null, false)
+
+		span?.end()
+		return true
 	}
 
 	span?.end()
+	return false
 }

--- a/packages/job-worker/src/ingest/updateNext.ts
+++ b/packages/job-worker/src/ingest/updateNext.ts
@@ -81,6 +81,12 @@ export async function ensureNextPartIsValid(context: JobContext, cache: CacheFor
 			allPartsAndSegments
 		)
 
+		if (!newNextPart && !cache.Playlist.doc?.nextPartInfo) {
+			// No currently nexted part, and nothing was selected, so nothing to update
+			span?.end()
+			return false
+		}
+
 		await setNextPart(context, cache, newNextPart ?? null, false)
 
 		span?.end()


### PR DESCRIPTION
…1190)<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
This pull request is posted on behalf of the NRK.


## Type of Contribution

This is a: Bug fix 

## Current Behavior
This fixes two bugs:
1) When playing the final part of the rundown, we try to correct that there is no nexted part, resulting in unnecessary regenerating of the timeline, following ingest/playout operations.

1) When updating the timeline following an ingest change, we don’t apply the updates to the timeline immediately, and skip it if we are waiting for playout-gateway do confirm some concrete times. But if the ingest change causes us to update what is nexted, we update it immediately.



## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [x] I have added one or more unit tests for this PR
- [x] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

This PR affects playout, following an ingest update

## Time Frame
<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
…ller SOFIE-3371