### PR TITLE
fix: adlibbed super fighting with planned super timings SOFIE-3378

### DIFF
--- a/packages/corelib/src/playout/__tests__/infinites.test.ts
+++ b/packages/corelib/src/playout/__tests__/infinites.test.ts
@@ -438,6 +438,41 @@ describe('Infinites', () => {
 			// don't expect virtual Pieces in the results, but 'one' should be pruned too
 			expect(resolvedInstances).toEqual([])
 		})
+		test('stop onSegmentChange continuation with planned onSegmentEnd start=0', () => {
+			const pieceInstances = [
+				createPieceInstance('one', { start: 0 }, 'one', PieceLifespan.OutOnSegmentChange, false, {
+					fromPreviousPart: true,
+					fromPreviousPlayhead: true,
+					infiniteInstanceId: protectString('one_a'),
+					infiniteInstanceIndex: 1,
+					infinitePieceId: protectString('one_b'),
+				}),
+				createPieceInstance('two', { start: 0 }, 'one', PieceLifespan.OutOnSegmentEnd, false, {
+					fromPreviousPart: false,
+					infiniteInstanceId: protectString('two_a'),
+					infiniteInstanceIndex: 0,
+					infinitePieceId: protectString('two_b'),
+				}),
+			]
+
+			// Set the first as adlibbed during the previous part
+			pieceInstances[0].dynamicallyInserted = 1
+
+			// Pieces should have preroll
+			pieceInstances[0].piece.prerollDuration = 200
+			pieceInstances[1].piece.prerollDuration = 200
+
+			const resolvedInstances = runAndTidyResult(pieceInstances, 500)
+
+			expect(resolvedInstances).toEqual([
+				{
+					_id: 'two',
+					end: undefined,
+					priority: 2,
+					start: 0,
+				},
+			])
+		})
 	})
 	describe('getPlayheadTrackingInfinitesForPart', () => {
 		function runAndTidyResult(

--- a/packages/corelib/src/playout/processAndPrune.ts
+++ b/packages/corelib/src/playout/processAndPrune.ts
@@ -15,10 +15,14 @@ function getPieceStartTimeAsReference(newPieceStart: number | 'now', newPiece: P
 }
 
 function getPieceStartTimeWithinPart(p: PieceInstance): 'now' | number {
-	if (p.piece.enable.start === 'now' || !p.dynamicallyInserted) {
-		return p.piece.enable.start
-	} else {
+	// If the piece is dynamically inserted, then its preroll should be factored into its start time, but not for any infinite continuations
+	const isStartOfAdlib =
+		!!p.dynamicallyInserted && !(p.infinite?.fromPreviousPart || p.infinite?.fromPreviousPlayhead)
+
+	if (isStartOfAdlib && p.piece.enable.start !== 'now') {
 		return p.piece.enable.start + (p.piece.prerollDuration ?? 0)
+	} else {
+		return p.piece.enable.start
 	}
 }
 


### PR DESCRIPTION

## About the Contributor
This pull request is posted on behalf of the NRK.


## Type of Contribution

This is a: Bug fix 

## Current Behavior

A sequence of events could cause the wrong piece to briefly play following a take.

It needs a segment of 2 parts, the first without a super, the second with a super (which is outOnSegmentEnd).

1) play the first part
1) adlib an outOnSegmentChange super
1) take into the second part
1) cue an adlib part
1) take the adlib part and observe the wrong super showing briefly

the outOnSegmentChange super was not getting stopped correctly, resulting in it being present later than it should, causing its higher priority to win and replace the correct super


## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [x] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
* 
-->


## Time Frame
<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
