### PR TITLE
AB session issues

### DIFF
--- a/packages/corelib/src/dataModel/RundownPlaylist.ts
+++ b/packages/corelib/src/dataModel/RundownPlaylist.ts
@@ -17,6 +17,8 @@ export interface ABSessionInfo {
 	id: string
 	/** The name of the session from the blueprints */
 	name: string
+	/** Whether the name is treated as globally unique */
+	isUniqueName: boolean
 	/** Set if the session is being by lookahead for a future part */
 	lookaheadForPartId?: PartId
 	/** Set if the session is being used by an infinite PieceInstance */

--- a/packages/job-worker/src/blueprints/context/OnTimelineGenerateContext.ts
+++ b/packages/job-worker/src/blueprints/context/OnTimelineGenerateContext.ts
@@ -85,13 +85,13 @@ export class OnTimelineGenerateContext extends RundownContext implements ITimeli
 		const partInstanceId = pieceInstance?.partInstanceId
 		if (!partInstanceId) throw new Error('Missing partInstanceId in call to getPieceABSessionId')
 
-		return this.abSessionsHelper.getPieceABSessionId(pieceInstance, sessionName)
+		return this.abSessionsHelper.getPieceABSessionIdFromSessionName(pieceInstance, sessionName)
 	}
 
 	/**
 	 * @deprecated Use core provided AB resolving
 	 */
 	getTimelineObjectAbSessionId(tlObj: OnGenerateTimelineObjExt, sessionName: string): string | undefined {
-		return this.abSessionsHelper.getTimelineObjectAbSessionId(tlObj, sessionName)
+		return this.abSessionsHelper.getTimelineObjectAbSessionIdFromSessionName(tlObj, sessionName)
 	}
 }

--- a/packages/job-worker/src/playout/abPlayback/__tests__/abPlayback.spec.ts
+++ b/packages/job-worker/src/playout/abPlayback/__tests__/abPlayback.spec.ts
@@ -1,4 +1,9 @@
-import { ABResolverOptions, IBlueprintPieceType, PieceLifespan } from '@sofie-automation/blueprints-integration'
+import {
+	ABResolverOptions,
+	IBlueprintPieceType,
+	PieceAbSessionInfo,
+	PieceLifespan,
+} from '@sofie-automation/blueprints-integration'
 import { EmptyPieceTimelineObjectsBlob } from '@sofie-automation/corelib/dist/dataModel/Piece'
 import { PieceInstancePiece, ResolvedPieceInstance } from '@sofie-automation/corelib/dist/dataModel/PieceInstance'
 import { ABSessionAssignments } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
@@ -21,7 +26,8 @@ function createBasicResolvedPieceInstance(
 	start: number,
 	duration: number | undefined,
 	reqId: string | undefined,
-	optional?: boolean
+	optional?: boolean,
+	uniqueSessionName?: boolean
 ): ResolvedPieceInstance {
 	const piece = literal<PieceInstancePiece>({
 		_id: protectString(id),
@@ -47,6 +53,7 @@ function createBasicResolvedPieceInstance(
 				sessionName: reqId,
 				poolName: POOL_NAME,
 				optional: optional,
+				sessionNameIsGloballyUnique: uniqueSessionName,
 			},
 		]
 	}
@@ -120,7 +127,9 @@ describe('resolveMediaPlayers', () => {
 			createBasicResolvedPieceInstance('2', 800, 4000, 'ghi'),
 		]
 
-		mockGetPieceSessionId.mockImplementation((piece, name) => `${piece._id}_${name}`)
+		mockGetPieceSessionId.mockImplementation(
+			(piece, session) => `${piece._id}_${session.poolName}_${session.sessionName}`
+		)
 
 		const assignments = resolveAbSessions(
 			abSessionHelper,
@@ -143,9 +152,18 @@ describe('resolveMediaPlayers', () => {
 
 		expect(mockGetPieceSessionId).toHaveBeenCalledTimes(3)
 		expect(mockGetObjectSessionId).toHaveBeenCalledTimes(0)
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(1, pieces[0].instance, 'clip_abc')
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(2, pieces[1].instance, 'clip_def')
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(3, pieces[2].instance, 'clip_ghi')
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(1, pieces[0].instance, {
+			poolName: 'clip',
+			sessionName: 'abc',
+		} satisfies PieceAbSessionInfo)
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(2, pieces[1].instance, {
+			poolName: 'clip',
+			sessionName: 'def',
+		} satisfies PieceAbSessionInfo)
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(3, pieces[2].instance, {
+			poolName: 'clip',
+			sessionName: 'ghi',
+		} satisfies PieceAbSessionInfo)
 	})
 
 	test('basic pieces - players with string Ids', () => {
@@ -156,7 +174,9 @@ describe('resolveMediaPlayers', () => {
 			createBasicResolvedPieceInstance('2', 800, 4000, 'ghi'),
 		]
 
-		mockGetPieceSessionId.mockImplementation((piece, name) => `${piece._id}_${name}`)
+		mockGetPieceSessionId.mockImplementation(
+			(piece, session) => `${piece._id}_${session.poolName}_${session.sessionName}`
+		)
 
 		const assignments = resolveAbSessions(
 			abSessionHelper,
@@ -179,9 +199,18 @@ describe('resolveMediaPlayers', () => {
 
 		expect(mockGetPieceSessionId).toHaveBeenCalledTimes(3)
 		expect(mockGetObjectSessionId).toHaveBeenCalledTimes(0)
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(1, pieces[0].instance, 'clip_abc')
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(2, pieces[1].instance, 'clip_def')
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(3, pieces[2].instance, 'clip_ghi')
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(1, pieces[0].instance, {
+			poolName: 'clip',
+			sessionName: 'abc',
+		} satisfies PieceAbSessionInfo)
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(2, pieces[1].instance, {
+			poolName: 'clip',
+			sessionName: 'def',
+		} satisfies PieceAbSessionInfo)
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(3, pieces[2].instance, {
+			poolName: 'clip',
+			sessionName: 'ghi',
+		} satisfies PieceAbSessionInfo)
 	})
 
 	test('basic pieces - players with number and string Ids', () => {
@@ -192,7 +221,9 @@ describe('resolveMediaPlayers', () => {
 			createBasicResolvedPieceInstance('2', 800, 4000, 'ghi'),
 		]
 
-		mockGetPieceSessionId.mockImplementation((piece, name) => `${piece._id}_${name}`)
+		mockGetPieceSessionId.mockImplementation(
+			(piece, session) => `${piece._id}_${session.poolName}_${session.sessionName}`
+		)
 
 		const assignments = resolveAbSessions(
 			abSessionHelper,
@@ -215,9 +246,18 @@ describe('resolveMediaPlayers', () => {
 
 		expect(mockGetPieceSessionId).toHaveBeenCalledTimes(3)
 		expect(mockGetObjectSessionId).toHaveBeenCalledTimes(0)
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(1, pieces[0].instance, 'clip_abc')
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(2, pieces[1].instance, 'clip_def')
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(3, pieces[2].instance, 'clip_ghi')
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(1, pieces[0].instance, {
+			poolName: 'clip',
+			sessionName: 'abc',
+		} satisfies PieceAbSessionInfo)
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(2, pieces[1].instance, {
+			poolName: 'clip',
+			sessionName: 'def',
+		} satisfies PieceAbSessionInfo)
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(3, pieces[2].instance, {
+			poolName: 'clip',
+			sessionName: 'ghi',
+		} satisfies PieceAbSessionInfo)
 	})
 
 	test('Multiple pieces same id', () => {
@@ -229,7 +269,7 @@ describe('resolveMediaPlayers', () => {
 			createBasicResolvedPieceInstance('3', 6400, 1000, 'abc'), // Gap before
 		]
 
-		mockGetPieceSessionId.mockImplementation((_piece, name) => `tmp_${name}`)
+		mockGetPieceSessionId.mockImplementation((_piece, session) => `tmp_${session.poolName}_${session.sessionName}`)
 
 		const assignments = resolveAbSessions(
 			abSessionHelper,
@@ -250,10 +290,22 @@ describe('resolveMediaPlayers', () => {
 
 		expect(mockGetPieceSessionId).toHaveBeenCalledTimes(4)
 		expect(mockGetObjectSessionId).toHaveBeenCalledTimes(0)
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(1, pieces[0].instance, 'clip_abc')
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(2, pieces[1].instance, 'clip_abc')
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(3, pieces[2].instance, 'clip_abc')
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(4, pieces[3].instance, 'clip_abc')
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(1, pieces[0].instance, {
+			poolName: 'clip',
+			sessionName: 'abc',
+		} satisfies PieceAbSessionInfo)
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(2, pieces[1].instance, {
+			poolName: 'clip',
+			sessionName: 'abc',
+		} satisfies PieceAbSessionInfo)
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(3, pieces[2].instance, {
+			poolName: 'clip',
+			sessionName: 'abc',
+		} satisfies PieceAbSessionInfo)
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(4, pieces[3].instance, {
+			poolName: 'clip',
+			sessionName: 'abc',
+		} satisfies PieceAbSessionInfo)
 	})
 
 	test('Reuse after gap', () => {
@@ -264,7 +316,9 @@ describe('resolveMediaPlayers', () => {
 			createBasicResolvedPieceInstance('3', 6400, 1000, 'ghi'), // Wait, then reuse first
 		]
 
-		mockGetPieceSessionId.mockImplementation((piece, name) => `${piece._id}_${name}`)
+		mockGetPieceSessionId.mockImplementation(
+			(piece, session) => `${piece._id}_${session.poolName}_${session.sessionName}`
+		)
 
 		const assignments = resolveAbSessions(
 			abSessionHelper,
@@ -287,9 +341,18 @@ describe('resolveMediaPlayers', () => {
 
 		expect(mockGetPieceSessionId).toHaveBeenCalledTimes(3)
 		expect(mockGetObjectSessionId).toHaveBeenCalledTimes(0)
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(1, pieces[0].instance, 'clip_abc')
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(2, pieces[1].instance, 'clip_def')
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(3, pieces[2].instance, 'clip_ghi')
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(1, pieces[0].instance, {
+			poolName: 'clip',
+			sessionName: 'abc',
+		} satisfies PieceAbSessionInfo)
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(2, pieces[1].instance, {
+			poolName: 'clip',
+			sessionName: 'def',
+		} satisfies PieceAbSessionInfo)
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(3, pieces[2].instance, {
+			poolName: 'clip',
+			sessionName: 'ghi',
+		} satisfies PieceAbSessionInfo)
 	})
 
 	test('Reuse immediately', () => {
@@ -300,7 +363,9 @@ describe('resolveMediaPlayers', () => {
 			createBasicResolvedPieceInstance('3', 5400, 1000, 'ghi'), // Wait, then reuse first
 		]
 
-		mockGetPieceSessionId.mockImplementation((piece, name) => `${piece._id}_${name}`)
+		mockGetPieceSessionId.mockImplementation(
+			(piece, session) => `${piece._id}_${session.poolName}_${session.sessionName}`
+		)
 
 		const assignments = resolveAbSessions(
 			abSessionHelper,
@@ -323,9 +388,18 @@ describe('resolveMediaPlayers', () => {
 
 		expect(mockGetPieceSessionId).toHaveBeenCalledTimes(3)
 		expect(mockGetObjectSessionId).toHaveBeenCalledTimes(0)
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(1, pieces[0].instance, 'clip_abc')
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(2, pieces[1].instance, 'clip_def')
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(3, pieces[2].instance, 'clip_ghi')
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(1, pieces[0].instance, {
+			poolName: 'clip',
+			sessionName: 'abc',
+		} satisfies PieceAbSessionInfo)
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(2, pieces[1].instance, {
+			poolName: 'clip',
+			sessionName: 'def',
+		} satisfies PieceAbSessionInfo)
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(3, pieces[2].instance, {
+			poolName: 'clip',
+			sessionName: 'ghi',
+		} satisfies PieceAbSessionInfo)
 	})
 
 	test('Reuse immediately dense', () => {
@@ -336,7 +410,9 @@ describe('resolveMediaPlayers', () => {
 			createBasicResolvedPieceInstance('3', 5400, 1000, 'ghi'), // Wait, then reuse first
 		]
 
-		mockGetPieceSessionId.mockImplementation((piece, name) => `${piece._id}_${name}`)
+		mockGetPieceSessionId.mockImplementation(
+			(piece, session) => `${piece._id}_${session.poolName}_${session.sessionName}`
+		)
 
 		const assignments = resolveAbSessions(
 			abSessionHelper,
@@ -359,9 +435,18 @@ describe('resolveMediaPlayers', () => {
 
 		expect(mockGetPieceSessionId).toHaveBeenCalledTimes(3)
 		expect(mockGetObjectSessionId).toHaveBeenCalledTimes(0)
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(1, pieces[0].instance, 'clip_abc')
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(2, pieces[1].instance, 'clip_def')
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(3, pieces[2].instance, 'clip_ghi')
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(1, pieces[0].instance, {
+			poolName: 'clip',
+			sessionName: 'abc',
+		} satisfies PieceAbSessionInfo)
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(2, pieces[1].instance, {
+			poolName: 'clip',
+			sessionName: 'def',
+		} satisfies PieceAbSessionInfo)
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(3, pieces[2].instance, {
+			poolName: 'clip',
+			sessionName: 'ghi',
+		} satisfies PieceAbSessionInfo)
 	})
 
 	test('basic reassignment', () => {
@@ -383,7 +468,9 @@ describe('resolveMediaPlayers', () => {
 			createBasicResolvedPieceInstance('2', 2800, 4000, 'ghi'),
 		]
 
-		mockGetPieceSessionId.mockImplementation((piece, name) => `${piece._id}_${name}`)
+		mockGetPieceSessionId.mockImplementation(
+			(piece, session) => `${piece._id}_${session.poolName}_${session.sessionName}`
+		)
 
 		const assignments = resolveAbSessions(
 			abSessionHelper,
@@ -406,9 +493,18 @@ describe('resolveMediaPlayers', () => {
 
 		expect(mockGetPieceSessionId).toHaveBeenCalledTimes(3)
 		expect(mockGetObjectSessionId).toHaveBeenCalledTimes(0)
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(1, pieces[0].instance, 'clip_abc')
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(2, pieces[1].instance, 'clip_def')
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(3, pieces[2].instance, 'clip_ghi')
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(1, pieces[0].instance, {
+			poolName: 'clip',
+			sessionName: 'abc',
+		} satisfies PieceAbSessionInfo)
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(2, pieces[1].instance, {
+			poolName: 'clip',
+			sessionName: 'def',
+		} satisfies PieceAbSessionInfo)
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(3, pieces[2].instance, {
+			poolName: 'clip',
+			sessionName: 'ghi',
+		} satisfies PieceAbSessionInfo)
 	})
 
 	test('optional gets discarded', () => {
@@ -430,7 +526,9 @@ describe('resolveMediaPlayers', () => {
 			createBasicResolvedPieceInstance('2', 2800, 4000, 'ghi'),
 		]
 
-		mockGetPieceSessionId.mockImplementation((piece, name) => `${piece._id}_${name}`)
+		mockGetPieceSessionId.mockImplementation(
+			(piece, session) => `${piece._id}_${session.poolName}_${session.sessionName}`
+		)
 
 		const assignments = resolveAbSessions(
 			abSessionHelper,
@@ -453,9 +551,19 @@ describe('resolveMediaPlayers', () => {
 
 		expect(mockGetPieceSessionId).toHaveBeenCalledTimes(3)
 		expect(mockGetObjectSessionId).toHaveBeenCalledTimes(0)
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(1, pieces[0].instance, 'clip_abc')
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(2, pieces[1].instance, 'clip_def')
-		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(3, pieces[2].instance, 'clip_ghi')
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(1, pieces[0].instance, {
+			poolName: 'clip',
+			sessionName: 'abc',
+		} satisfies PieceAbSessionInfo)
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(2, pieces[1].instance, {
+			poolName: 'clip',
+			sessionName: 'def',
+			optional: true,
+		} satisfies PieceAbSessionInfo)
+		expect(mockGetPieceSessionId).toHaveBeenNthCalledWith(3, pieces[2].instance, {
+			poolName: 'clip',
+			sessionName: 'ghi',
+		} satisfies PieceAbSessionInfo)
 	})
 
 	// TODO add some tests which check lookahead

--- a/packages/job-worker/src/playout/abPlayback/__tests__/abPlaybackResolver.spec.ts
+++ b/packages/job-worker/src/playout/abPlayback/__tests__/abPlaybackResolver.spec.ts
@@ -394,6 +394,47 @@ describe('resolveAbAssignmentsFromRequests', () => {
 		expectGotPlayer(res, 'c', undefined)
 		expectGotPlayer(res, 'd', undefined)
 	})
+	test('Run timed adlib bts', () => {
+		const requests: SessionRequest[] = [
+			// current part
+			{
+				id: 'a',
+				start: 1000,
+				end: 10500,
+				playerId: 2,
+			},
+			// adlib
+			{
+				id: 'b',
+				start: 10000,
+				end: 15000,
+			},
+			// lookaheads (in order of future use)
+			{
+				id: 'c',
+				start: Number.POSITIVE_INFINITY,
+				end: undefined,
+				playerId: 1,
+				lookaheadRank: 1,
+			},
+			{
+				id: 'd',
+				start: Number.POSITIVE_INFINITY,
+				end: undefined,
+				playerId: 2,
+				lookaheadRank: 2,
+			},
+		]
+
+		const res = resolveAbAssignmentsFromRequests(resolverOptions, TWO_SLOTS, requests, 10000)
+		expect(res).toBeTruthy()
+		expect(res.failedOptional).toEqual([])
+		expect(res.failedRequired).toEqual([])
+		expectGotPlayer(res, 'a', 2)
+		expectGotPlayer(res, 'b', 1)
+		expectGotPlayer(res, 'c', 2) // moved so that it alternates
+		expectGotPlayer(res, 'd', 1)
+	})
 
 	test('Autonext run bts', () => {
 		const requests: SessionRequest[] = [

--- a/packages/job-worker/src/playout/abPlayback/__tests__/applyAssignments.spec.ts
+++ b/packages/job-worker/src/playout/abPlayback/__tests__/applyAssignments.spec.ts
@@ -75,7 +75,9 @@ describe('applyMediaPlayersAssignments', () => {
 		const pieceInstanceId = 'piece0'
 		const partInstanceId = protectString('part0')
 
-		mockGetObjectSessionId.mockImplementation((obj, name) => `${obj.pieceInstanceId}_${name}`)
+		mockGetObjectSessionId.mockImplementation(
+			(obj, session) => `${obj.pieceInstanceId}_${session.poolName}_${session.sessionName}`
+		)
 
 		const objects = [
 			literal<OnGenerateTimelineObjExt>({

--- a/packages/job-worker/src/playout/abPlayback/abPlaybackResolver.ts
+++ b/packages/job-worker/src/playout/abPlayback/abPlaybackResolver.ts
@@ -2,13 +2,15 @@ import { ABResolverOptions } from '@sofie-automation/blueprints-integration'
 import { clone } from '@sofie-automation/corelib/dist/lib'
 import * as _ from 'underscore'
 
+export type PlayerId = number | string
+
 export interface SessionRequest {
 	readonly id: string
 	readonly start: number
 	readonly end: number | undefined
 	readonly optional?: boolean
 	readonly lookaheadRank?: number
-	playerId?: number | string
+	playerId?: PlayerId
 }
 
 export interface AssignmentResult {
@@ -21,7 +23,7 @@ export interface AssignmentResult {
 }
 
 interface SlotAvailability {
-	id: number | string
+	id: PlayerId
 	before: (SessionRequest & { end: number }) | null
 	after: SessionRequest | null
 	clashes: SessionRequest[]
@@ -55,7 +57,7 @@ function safeMin<T>(arr: T[], func: (val: T) => number): T | undefined {
  */
 export function resolveAbAssignmentsFromRequests(
 	resolverOptions: ABResolverOptions,
-	playerIds: Array<number | string>,
+	playerIds: PlayerId[],
 	rawRequests: SessionRequest[],
 	now: number // Current time
 ): AssignmentResult {
@@ -80,7 +82,7 @@ export function resolveAbAssignmentsFromRequests(
 		return res
 	}
 
-	const originalLookaheadAssignments: Record<string, number | string> = {}
+	const originalLookaheadAssignments: Record<string, PlayerId> = {}
 	for (const req of rawRequests) {
 		if (req.lookaheadRank !== undefined && req.playerId !== undefined) {
 			originalLookaheadAssignments[req.id] = req.playerId
@@ -104,7 +106,7 @@ export function resolveAbAssignmentsFromRequests(
 	pendingRequests = grouped[undefined as any]
 
 	// build map of slots and what they already have assigned
-	const slots: Map<number | string, SessionRequest[]> = new Map()
+	const slots = new Map<PlayerId, SessionRequest[]>()
 	_.each(playerIds, (id) => slots.set(id, grouped[id] || []))
 
 	const beforeHasGap = (p: SlotAvailability, req: SessionRequest): boolean =>
@@ -311,16 +313,27 @@ export function resolveAbAssignmentsFromRequests(
 		}
 	}
 
+	assignPlayersForLookahead(slots, res, originalLookaheadAssignments, safeNow)
+
+	return res
+}
+
+function assignPlayersForLookahead(
+	slots: Map<PlayerId, SessionRequest[]>,
+	res: AssignmentResult,
+	originalLookaheadAssignments: Record<string, PlayerId>,
+	safeNow: number
+) {
 	// Ensure lookahead gets assigned based on priority not some randomness
 	// Includes slots which have either no sessions, or the last has a known end time
-	const lastSessionPerSlot: Record<number | string, number | undefined> = {} // playerId, end
+	const lastSessionPerSlot = new Map<PlayerId, number>() // playerId, end
 	for (const [playerId, sessions] of slots) {
 		const last = _.last(sessions.filter((s) => s.lookaheadRank === undefined))
 		if (!last) {
-			lastSessionPerSlot[playerId] = Number.NEGATIVE_INFINITY
+			lastSessionPerSlot.set(playerId, Number.NEGATIVE_INFINITY)
 		} else if (last.end !== undefined) {
 			// If there is a defined end, then it can be useful after that point of time
-			lastSessionPerSlot[playerId] = last.end
+			lastSessionPerSlot.set(playerId, last.end)
 		}
 	}
 
@@ -328,56 +341,39 @@ export function resolveAbAssignmentsFromRequests(
 	const lookaheadsToAssign = _.sortBy(
 		res.requests.filter((r) => r.lookaheadRank !== undefined),
 		(r) => r.lookaheadRank
-	).slice(0, Object.keys(lastSessionPerSlot).length)
+	).slice(0, lastSessionPerSlot.size)
 
-	// Persist previous players if possible
-	const remainingLookaheads: SessionRequest[] = []
-	for (const req of lookaheadsToAssign) {
-		delete req.playerId
+	const [playersClearNow, playersClearSoon] = _.partition(
+		Array.from(lastSessionPerSlot.entries()),
+		(session) => session[1] < safeNow
+	)
 
+	// Assign the players which are clear right now
+	const playersClearNowIds = new Set(playersClearNow.map((p) => p[0]))
+	// First persist any previous players
+	const lookaheadsToAssignNow = lookaheadsToAssign.slice(0, playersClearNow.length)
+	for (const req of lookaheadsToAssignNow) {
 		const prevPlayer = originalLookaheadAssignments[req.id]
-		if (prevPlayer === undefined) {
-			remainingLookaheads.push(req)
-		} else {
-			// Ensure the assignment is ok
-			const slotEnd = lastSessionPerSlot[prevPlayer]
-			if (slotEnd === undefined || slotEnd >= safeNow) {
-				// It isnt available for this lookahead, or isnt visible yet
-				remainingLookaheads.push(req)
-			} else {
-				// It is ours, so remove the player from the pool
-				req.playerId = prevPlayer
-				delete lastSessionPerSlot[req.playerId]
-			}
-		}
-	}
-
-	// Assign any remaining lookaheads
-	const sortedSlots = _.sortBy(Object.entries<number | undefined>(lastSessionPerSlot), (s) => s[1] ?? 0)
-	for (let i = 0; i < remainingLookaheads.length; i++) {
-		const slot = sortedSlots[i]
-		const req = remainingLookaheads[i]
-
-		if (slot) {
-			// Check if we were originally given a player index rather than a string Id
-			if (playerIds.find((id) => typeof id === 'number' && id === Number(slot[0]))) {
-				req.playerId = Number(slot[0])
-			} else {
-				req.playerId = slot[0]
-			}
+		if (prevPlayer !== undefined && playersClearNowIds.delete(prevPlayer)) {
+			req.playerId = prevPlayer
 		} else {
 			delete req.playerId
 		}
 	}
+	// Then fill in the blanks
+	const playersClearNowRemainingIds = Array.from(playersClearNowIds)
+	for (const req of lookaheadsToAssignNow) {
+		if (req.playerId === undefined) req.playerId = playersClearNowRemainingIds.shift()
+	}
 
-	return res
+	// Assign the players which are clear soon. These aren't visible, so don't need to preserve anything
+	const lookaheadsToAssignSoon = lookaheadsToAssign.slice(playersClearNow.length)
+	for (const req of lookaheadsToAssignSoon) {
+		req.playerId = playersClearSoon.shift()?.[0]
+	}
 }
 
-function getAvailability(
-	id: number | string,
-	thisReq: SessionRequest,
-	orderedRequests: SessionRequest[]
-): SlotAvailability {
+function getAvailability(id: PlayerId, thisReq: SessionRequest, orderedRequests: SessionRequest[]): SlotAvailability {
 	const res: SlotAvailability = {
 		id,
 		before: null,

--- a/packages/job-worker/src/playout/abPlayback/abPlaybackSessions.ts
+++ b/packages/job-worker/src/playout/abPlayback/abPlaybackSessions.ts
@@ -35,10 +35,7 @@ export function calculateSessionTimeRanges(
 		for (const session of abSessions) {
 			if (session.poolName !== poolName) continue
 
-			const sessionId = abSessionHelper.getPieceABSessionId(
-				p.instance,
-				abSessionHelper.validateSessionName(p.instance._id, session)
-			)
+			const sessionId = abSessionHelper.getPieceABSessionId(p.instance, session)
 
 			// Note: multiple generated sessionIds for a single piece will not work as there will not be enough info to assign objects to different players. TODO is this still true?
 			const val = sessionRequests[sessionId]
@@ -81,10 +78,7 @@ export function calculateSessionTimeRanges(
 		) {
 			for (const session of obj.abSessions) {
 				if (session.poolName === poolName) {
-					const sessionId = abSessionHelper.getTimelineObjectAbSessionId(
-						obj,
-						abSessionHelper.validateSessionName(obj.pieceInstanceId, session)
-					)
+					const sessionId = abSessionHelper.getTimelineObjectAbSessionId(obj, session)
 					if (sessionId) {
 						const existing = groupedLookaheadMap.get(sessionId)
 						groupedLookaheadMap.set(sessionId, existing ? [...existing, obj] : [obj])

--- a/packages/job-worker/src/playout/abPlayback/abSessionHelper.ts
+++ b/packages/job-worker/src/playout/abPlayback/abSessionHelper.ts
@@ -41,10 +41,49 @@ export class AbSessionHelper {
 	}
 
 	/**
+	 * Get the full session id for an ab playback session with a globally unique sessionName
+	 */
+	getUniqueSessionId(session: TimelineObjectAbSessionInfo): string {
+		const sessionName = `${session.poolName}_${session.sessionName}`
+
+		const uniqueNameSession = this.#knownSessions.find((s) => s.isUniqueName && s.name === sessionName)
+		if (uniqueNameSession) {
+			uniqueNameSession.keep = true
+			return uniqueNameSession.id
+		}
+
+		// Otherwise define a new session
+		const sessionId = this.getNewSessionId()
+		const newSession: ABSessionInfoExt = {
+			id: sessionId,
+			name: sessionName,
+			isUniqueName: true,
+			keep: true,
+		}
+		this.#knownSessions.push(newSession)
+		return sessionId
+	}
+
+	/**
+	 * Get the full session id for an ab playback session.
+	 * Note: If sessionNameIsGloballyUnique is set, then the sessionName every reference will be treated as the same session,
+	 * otherwise sessionName should be unique within the segment unless pieces want to share a session
+	 */
+	getPieceABSessionId(pieceInstance: ReadonlyDeep<PieceInstance>, session: TimelineObjectAbSessionInfo): string {
+		if (session.sessionNameIsGloballyUnique) return this.getUniqueSessionId(session)
+
+		return this.getPieceABSessionIdFromSessionName(
+			pieceInstance,
+			this.#validateSessionName(pieceInstance._id, session)
+		)
+	}
+
+	/**
 	 * Get the full session id for an ab playback session.
 	 * Note: sessionName should be unique within the segment unless pieces want to share a session
+	 * Future: This should be private, but is exposed as a deprecated method to blueprints
 	 */
-	getPieceABSessionId(pieceInstance: ReadonlyDeep<PieceInstance>, sessionName: string): string {
+	getPieceABSessionIdFromSessionName(pieceInstance: ReadonlyDeep<PieceInstance>, sessionName: string): string {
 		const partInstanceIndex = this.#partInstances.findIndex((p) => p._id === pieceInstance.partInstanceId)
 		const partInstance = partInstanceIndex >= 0 ? this.#partInstances[partInstanceIndex] : undefined
 		if (!partInstance) throw new Error('Unknown partInstanceId in call to getPieceABSessionId')
@@ -57,19 +96,20 @@ export class AbSessionHelper {
 			return session.id
 		}
 
+		// Sessions to consider are those with the same name
+		const sessionsToConsider = this.#knownSessions.filter((s) => !s.isUniqueName && s.name === sessionName)
+
 		// If this is an infinite continuation, then reuse that
 		if (infiniteId) {
-			const infiniteSession = this.#knownSessions.find(
-				(s) => s.infiniteInstanceId === infiniteId && s.name === sessionName
-			)
+			const infiniteSession = sessionsToConsider.find((s) => s.infiniteInstanceId === infiniteId)
 			if (infiniteSession) {
 				return preserveSession(infiniteSession)
 			}
 		}
 
 		// We only want to consider sessions already tagged to this partInstance
-		const existingSession = this.#knownSessions.find(
-			(s) => s.partInstanceIds?.includes(pieceInstance.partInstanceId) && s.name === sessionName
+		const existingSession = sessionsToConsider.find((s) =>
+			s.partInstanceIds?.includes(pieceInstance.partInstanceId)
 		)
 		if (existingSession) {
 			return preserveSession(existingSession)
@@ -82,9 +122,7 @@ export class AbSessionHelper {
 		if (canReuseFromPartInstanceBefore) {
 			// Try and find a session from the part before that we can use
 			const previousPartInstanceId = this.#partInstances[partInstanceIndex - 1]._id
-			const continuedSession = this.#knownSessions.find(
-				(s) => s.partInstanceIds?.includes(previousPartInstanceId) && s.name === sessionName
-			)
+			const continuedSession = sessionsToConsider.find((s) => s.partInstanceIds?.includes(previousPartInstanceId))
 			if (continuedSession) {
 				continuedSession.partInstanceIds = [
 					...(continuedSession.partInstanceIds || []),
@@ -96,9 +134,7 @@ export class AbSessionHelper {
 
 		// Find an existing lookahead session to convert
 		const partId = partInstance.part._id
-		const lookaheadSession = this.#knownSessions.find(
-			(s) => s.name === sessionName && s.lookaheadForPartId === partId
-		)
+		const lookaheadSession = sessionsToConsider.find((s) => s.lookaheadForPartId === partId)
 		if (lookaheadSession) {
 			lookaheadSession.partInstanceIds = [pieceInstance.partInstanceId]
 			return preserveSession(lookaheadSession)
@@ -109,6 +145,7 @@ export class AbSessionHelper {
 		const newSession: ABSessionInfoExt = {
 			id: sessionId,
 			name: sessionName,
+			isUniqueName: false,
 			infiniteInstanceId: unpartialString(infiniteId),
 			partInstanceIds: !infiniteId ? [pieceInstance.partInstanceId] : [],
 			keep: true,
@@ -119,15 +156,36 @@ export class AbSessionHelper {
 
 	/**
 	 * Get the full session id for a timelineobject that belongs to an ab playback session
-	 * sessionName should also be used in calls to getPieceABSessionId for the owning piece
+	 * The same session should also be used in calls for the owning piece
 	 */
-	getTimelineObjectAbSessionId(tlObj: OnGenerateTimelineObjExt, sessionName: string): string | undefined {
+	getTimelineObjectAbSessionId(
+		tlObj: OnGenerateTimelineObjExt,
+		session: TimelineObjectAbSessionInfo
+	): string | undefined {
+		if (session.sessionNameIsGloballyUnique) return this.getUniqueSessionId(session)
+
+		return this.getTimelineObjectAbSessionIdFromSessionName(
+			tlObj,
+			this.#validateSessionName(tlObj.pieceInstanceId || session.sessionName, session)
+		)
+	}
+
+	/**
+	 * Get the full session id for a timelineobject that belongs to an ab playback session
+	 * sessionName should also be used in calls to getPieceABSessionId for the owning piece
+	 * Future: This should be private, but is exposed as a deprecated method to blueprints
+	 */
+	getTimelineObjectAbSessionIdFromSessionName(
+		tlObj: OnGenerateTimelineObjExt,
+		sessionName: string
+	): string | undefined {
+		// Sessions to consider are those with the same name
+		const sessionsToConsider = this.#knownSessions.filter((s) => !s.isUniqueName && s.name === sessionName)
+
 		// Find an infinite
 		const searchId = tlObj.infinitePieceInstanceId
 		if (searchId) {
-			const infiniteSession = this.#knownSessions.find(
-				(s) => s.infiniteInstanceId === searchId && s.name === sessionName
-			)
+			const infiniteSession = sessionsToConsider.find((s) => s.infiniteInstanceId === searchId)
 			if (infiniteSession) {
 				infiniteSession.keep = true
 				return infiniteSession.id
@@ -137,9 +195,7 @@ export class AbSessionHelper {
 		// Find an normal partInstance
 		const partInstanceId = tlObj.partInstanceId
 		if (partInstanceId) {
-			const partInstanceSession = this.#knownSessions.find(
-				(s) => s.partInstanceIds?.includes(partInstanceId) && s.name === sessionName
-			)
+			const partInstanceSession = sessionsToConsider.find((s) => s.partInstanceIds?.includes(partInstanceId))
 			if (partInstanceSession) {
 				partInstanceSession.keep = true
 				return partInstanceSession.id
@@ -153,9 +209,7 @@ export class AbSessionHelper {
 			const partInstance = this.#partInstances.find((p) => p._id === partInstanceId)
 			if (partInstance) partId = partInstance.part._id
 
-			const lookaheadSession = this.#knownSessions.find(
-				(s) => s.lookaheadForPartId === partId && s.name === sessionName
-			)
+			const lookaheadSession = sessionsToConsider.find((s) => s.lookaheadForPartId === partId)
 			if (lookaheadSession) {
 				lookaheadSession.keep = true
 				if (partInstance) {
@@ -167,6 +221,7 @@ export class AbSessionHelper {
 				this.#knownSessions.push({
 					id: sessionId,
 					name: sessionName,
+					isUniqueName: false,
 					lookaheadForPartId: partId,
 					partInstanceIds: partInstance ? [partInstanceId] : undefined,
 					keep: true,
@@ -181,7 +236,7 @@ export class AbSessionHelper {
 	/**
 	 * Make the sessionName unique for the pool, and ensure it isn't set to AUTO
 	 */
-	validateSessionName(pieceInstanceId: PieceInstanceId | string, session: TimelineObjectAbSessionInfo): string {
+	#validateSessionName(pieceInstanceId: PieceInstanceId | string, session: TimelineObjectAbSessionInfo): string {
 		const newName = session.sessionName === AB_MEDIA_PLAYER_AUTO ? pieceInstanceId : session.sessionName
 		return `${session.poolName}_${newName}`
 	}

--- a/packages/job-worker/src/playout/abPlayback/applyAssignments.ts
+++ b/packages/job-worker/src/playout/abPlayback/applyAssignments.ts
@@ -5,7 +5,7 @@ import {
 	ICommonContext,
 	ABTimelineLayerChangeRules,
 } from '@sofie-automation/blueprints-integration'
-import { ABSessionAssignments } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
+import { ABSessionAssignment, ABSessionAssignments } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { OnGenerateTimelineObjExt } from '@sofie-automation/corelib/dist/dataModel/Timeline'
 import { logger } from '../../logging'
 import * as _ from 'underscore'
@@ -47,10 +47,7 @@ export function applyAbPlayerObjectAssignments(
 		if (obj.abSessions && obj.pieceInstanceId) {
 			for (const session of obj.abSessions) {
 				if (session.poolName === poolName) {
-					const sessionId = abSessionHelper.getTimelineObjectAbSessionId(
-						obj,
-						abSessionHelper.validateSessionName(obj.pieceInstanceId, session)
-					)
+					const sessionId = abSessionHelper.getTimelineObjectAbSessionId(obj, session)
 					if (sessionId) {
 						const existing = groupedObjectsMap.get(sessionId)
 						groupedObjectsMap.set(sessionId, existing ? [...existing, obj] : [obj])
@@ -108,7 +105,12 @@ export function applyAbPlayerObjectAssignments(
 		logger.debug(`Unexpected sessions are: ${unexpectedSessions.join(', ')}`)
 	}
 
-	logger.silly(`ABPlayback calculated assignments for "${poolName}": ${JSON.stringify(newAssignments)}`)
+	for (const assignment of Object.values<ABSessionAssignment | undefined>(newAssignments)) {
+		if (!assignment) continue
+		logger.silly(
+			`ABPlayback: Assigned session "${poolName}"-"${assignment.sessionId}" to player "${assignment.playerId}" (lookahead: ${assignment.lookahead})`
+		)
+	}
 
 	return newAssignments
 }

--- a/packages/job-worker/src/playout/abPlayback/index.ts
+++ b/packages/job-worker/src/playout/abPlayback/index.ts
@@ -6,7 +6,7 @@ import { WrappedShowStyleBlueprint } from '../../blueprints/cache'
 import { ReadonlyDeep } from 'type-fest'
 import { JobContext, ProcessedShowStyleCompound } from '../../jobs'
 import { getCurrentTime } from '../../lib'
-import { resolveAbAssignmentsFromRequests } from './abPlaybackResolver'
+import { resolveAbAssignmentsFromRequests, SessionRequest } from './abPlaybackResolver'
 import { calculateSessionTimeRanges } from './abPlaybackSessions'
 import { applyAbPlayerObjectAssignments } from './applyAssignments'
 import { AbSessionHelper } from './abSessionHelper'
@@ -48,6 +48,17 @@ export function applyAbPlaybackForTimeline(
 	)
 
 	const previousAbSessionAssignments: Record<string, ABSessionAssignments> = playlist.assignedAbSessions || {}
+	logger.silly(`ABPlayback: Starting AB playback resolver ----------------------------`)
+	for (const [pool, assignments] of Object.entries<ABSessionAssignments>(previousAbSessionAssignments)) {
+		for (const assignment of Object.values<ABSessionAssignment | undefined>(assignments)) {
+			if (assignment) {
+				logger.silly(
+					`ABPlayback: Previous assignment "${pool}"-"${assignment.sessionId}" to player "${assignment.playerId}"`
+				)
+			}
+		}
+	}
+
 	const newAbSessionsResult: Record<string, ABSessionAssignments> = {}
 
 	const span = context.startSpan('blueprint.abPlaybackResolver')
@@ -73,7 +84,13 @@ export function applyAbPlaybackForTimeline(
 			now
 		)
 
-		logger.silly(`ABPlayback resolved sessions for "${poolName}": ${JSON.stringify(assignments)}`)
+		for (const assignment of Object.values<SessionRequest>(assignments.requests)) {
+			logger.silly(
+				`ABPlayback resolved session "${poolName}"-"${assignment.id}" to player "${
+					assignment.playerId
+				}" (${JSON.stringify(assignment)})`
+			)
+		}
 		if (assignments.failedRequired.length > 0) {
 			logger.warn(
 				`ABPlayback failed to assign sessions for "${poolName}": ${JSON.stringify(assignments.failedRequired)}`

--- a/packages/job-worker/src/playout/abPlayback/index.ts
+++ b/packages/job-worker/src/playout/abPlayback/index.ts
@@ -1,5 +1,9 @@
 import { ResolvedPieceInstance } from '@sofie-automation/corelib/dist/dataModel/PieceInstance'
-import { ABSessionAssignments, DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
+import {
+	ABSessionAssignment,
+	ABSessionAssignments,
+	DBRundownPlaylist,
+} from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { OnGenerateTimelineObjExt } from '@sofie-automation/corelib/dist/dataModel/Timeline'
 import { endTrace, sendTrace, startTrace } from '@sofie-automation/corelib/dist/influxdb'
 import { WrappedShowStyleBlueprint } from '../../blueprints/cache'

--- a/packages/job-worker/src/playout/resolvedPieces.ts
+++ b/packages/job-worker/src/playout/resolvedPieces.ts
@@ -47,13 +47,14 @@ export function getResolvedPiecesForPartInstancesOnTimeline(
 
 	const currentPartStarted = partInstancesInfo.current.partStarted ?? now
 	const nextPartStarted =
+		partInstancesInfo.current.partInstance.part.autoNext &&
 		partInstancesInfo.current.partInstance.part.expectedDuration !== undefined
 			? currentPartStarted + partInstancesInfo.current.partInstance.part.expectedDuration
 			: null
 
 	// Calculate the next part if needed
 	let nextResolvedPieces: ResolvedPieceInstance[] = []
-	if (partInstancesInfo.next && partInstancesInfo.current.partInstance.part.autoNext && nextPartStarted != null) {
+	if (partInstancesInfo.next && nextPartStarted != null) {
 		const nowInPart = partInstancesInfo.next.nowInPart
 		nextResolvedPieces = partInstancesInfo.next.pieceInstances.map((instance) =>
 			resolvePrunedPieceInstance(nowInPart, instance)

--- a/packages/job-worker/src/playout/timeline/part.ts
+++ b/packages/job-worker/src/playout/timeline/part.ts
@@ -61,7 +61,12 @@ export function transformPartIntoTimeline(
 				}
 				break
 			case IBlueprintPieceType.Normal:
-				pieceEnable = getPieceEnableInsidePart(pieceInstance, partTimings, parentGroup.id)
+				pieceEnable = getPieceEnableInsidePart(
+					pieceInstance,
+					partTimings,
+					parentGroup.id,
+					parentGroup.enable.duration !== undefined || parentGroup.enable.end !== undefined
+				)
 				break
 			default:
 				assertNever(pieceInstance.piece.pieceType)

--- a/packages/job-worker/src/playout/timeline/piece.ts
+++ b/packages/job-worker/src/playout/timeline/piece.ts
@@ -90,7 +90,8 @@ export function transformPieceGroupAndObjects(
 export function getPieceEnableInsidePart(
 	pieceInstance: ReadonlyDeep<PieceInstanceWithTimings>,
 	partTimings: PartCalculatedTimings,
-	partGroupId: string
+	partGroupId: string,
+	partHasEndTime: boolean
 ): TSR.Timeline.TimelineEnable {
 	const pieceEnable: TSR.Timeline.TimelineEnable = { ...pieceInstance.piece.enable }
 	if (typeof pieceEnable.start === 'number') {
@@ -103,7 +104,8 @@ export function getPieceEnableInsidePart(
 		}
 	}
 
-	if (partTimings.toPartPostroll) {
+	// If the part has an end time, we can consider post-roll
+	if (partHasEndTime && partTimings.toPartPostroll) {
 		if (!pieceEnable.duration) {
 			// make sure that the control object is shortened correctly
 			pieceEnable.duration = `#${partGroupId} - ${partTimings.toPartPostroll}`

--- a/packages/job-worker/src/playout/timeline/rundown.ts
+++ b/packages/job-worker/src/playout/timeline/rundown.ts
@@ -266,7 +266,9 @@ function generateCurrentInfinitePieceObjects(
 	const pieceEnable = getPieceEnableInsidePart(
 		pieceInstance,
 		currentPartInstanceTimings,
-		timingContext.currentPartGroup.id
+		timingContext.currentPartGroup.id,
+		timingContext.currentPartGroup.enable.end !== undefined ||
+			timingContext.currentPartGroup.enable.duration !== undefined
 	)
 
 	let nowInParent = currentPartInfo.nowInPart // Where is 'now' inside of the infiniteGroup?

--- a/packages/shared-lib/src/core/model/Timeline.ts
+++ b/packages/shared-lib/src/core/model/Timeline.ts
@@ -16,6 +16,14 @@ export interface TimelineObjectAbSessionInfo {
 	 * The name of the AB Pool this session is for
 	 */
 	poolName: string
+
+	/**
+	 * Whether the `sessionName` of this session is globally unique
+	 * This means that every usage of this name will be treated as the same session, regardless of where it is used
+	 * This should typically only be used when generating a unique id in an adlib-action, if used during ingest
+	 * then replaying a part will often cause the session to be reused which is likely not the desired behaviour
+	 */
+	sessionNameIsGloballyUnique?: boolean
 }
 
 export enum TimelineObjHoldMode {


### PR DESCRIPTION

## About the Contributor
This pull request is posted on behalf of the BBC


## Type of Contribution

This is a: Bug fix / Feature

This is a couple of intertwined changes. It might be possible to pull the feature out into its own PR if wanted, but its a pretty isolated opt-in functionality and overlaps in area with the fixes.

Each change is a separate commit in this PR.

## Current/New Behavior

There is a limitation in the AB logic, where an infinite piece is not allowed to share a session with any other piece. This limitation was added originally because a `sessionName` was described as needing to be unique within a segment, once out of that segment, it is hard to be sure that the name won't be reused unless care is taken to ensure it is globally unique.  
This PR allows sessions to opt into being treated as a globally unique id. This allows for skipping a lot of the complex session matching logic performed across parts, as we can be confident that any other references to the same id must be a continuation of a session.  
This can also be used for some hold-like behaviour, where a piece gets copied between parts during `onSetAsNext`, prior to this change that would sometimes work, depending on where the two parts were located in the rundown.

This fixes a bug where pieces with a postrollDuration were being added to the timeline, referencing the end of their part, which did not have an end time set. This added some noise to the timeline objects, and confused sofie when doing `getResolvedPieces`, as the pieces ended up reporting as having an end time based on the planned duration of the part. This in turn would confuse the AB resolver, as it would see all the sessions as ending when the part reached its expectedDuration, which could cause players to be reallocated while they were still being used.

And another fixed bug, where adlibbing a piece using ab with a fixed duration into a part would not cause the ab of lookahead objects to be reassigned correctly, which would result in the next clip disappearing from the multiviewer until the adlibbed clip ended. I think that during a take it would end up swapping to the other player, without sufficient time to preload





## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [x] I have added one or more unit tests for this PR
- [x] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
* 
-->


## Time Frame
<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
