### PR TITLE
re-enable build step for openapi for test and publishing

### DIFF
--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -575,6 +575,13 @@ jobs:
           yarn build
         env:
           CI: true
+      - name: Generate OpenAPI docs and server
+        run: |
+          cd packages/openapi
+          yarn gendocs
+          yarn genserver
+        env:
+          CI: true
 
   publish-docs:
     name: Publish Docs

--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -569,13 +569,10 @@ jobs:
           yarn
         env:
           CI: true
-      - name: Run generator
+      - name: Build OpenAPI client library
         run: |
           cd packages/openapi
-
-          yarn gendocs
-          yarn genserver
-          yarn genclient:ts
+          yarn build
         env:
           CI: true
 
@@ -682,22 +679,13 @@ jobs:
           yarn build
         env:
           CI: true
-      # Temporarily disabled due to failing in CI:
-      # - name: Generate OpenAPI client library
-      #   if: ${{ steps.do-publish.outputs.tag }}
-      #   uses: hatamiarash7/openapi-generator@v0.3.0
-      #   with:
-      #     generator: typescript-fetch
-      #     openapi-file: ./packages/openapi/api/actions.yaml
-      #     output-dir: ./packages/openapi/client/ts
-      #     command-args: -p supportsES6=true
-      # - name: Build OpenAPI client library
-      #   if: ${{ steps.do-publish.outputs.tag }}
-      #   run: |
-      #     cd packages/openapi
-      #     yarn build:main
-      #   env:
-      #     CI: true
+      - name: Build OpenAPI client library
+        if: ${{ steps.do-publish.outputs.tag }}
+        run: |
+          cd packages/openapi
+          yarn build
+        env:
+          CI: true
       - name: Modify dependencies to use npm packages
         run: node scripts/prepublish.js
       - name: Publish to NPM

--- a/.github/workflows/prerelease-libs.yml
+++ b/.github/workflows/prerelease-libs.yml
@@ -133,7 +133,7 @@ jobs:
           CI: true
 
       - name: Build OpenAPI client library
-        if: ${{ steps.do-publish.outputs.tag }}
+        if: ${{ steps.do-publish.outputs.publish }}
         run: |
           cd packages/openapi
           yarn build

--- a/.github/workflows/prerelease-libs.yml
+++ b/.github/workflows/prerelease-libs.yml
@@ -131,22 +131,14 @@ jobs:
           yarn build
         env:
           CI: true
-      # Temporarily disabled due to failing in CI:
-      # - name: Generate OpenAPI client library
-      #   if: ${{ steps.do-publish.outputs.tag }}
-      #   uses: hatamiarash7/openapi-generator@v0.3.0
-      #   with:
-      #     generator: typescript-fetch
-      #     openapi-file: ./packages/openapi/api/actions.yaml
-      #     output-dir: ./packages/openapi/client/ts
-      #     command-args: -p supportsES6=true
-      # - name: Build OpenAPI client library
-      #   if: ${{ steps.do-publish.outputs.tag }}
-      #   run: |
-      #     cd packages/openapi
-      #     yarn build:main
-      #   env:
-      #     CI: true
+
+      - name: Build OpenAPI client library
+        if: ${{ steps.do-publish.outputs.tag }}
+        run: |
+          cd packages/openapi
+          yarn build
+        env:
+          CI: true
       - name: Modify dependencies to use npm packages
         run: node scripts/prepublish.js
       - name: Publish to NPM


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->

This pull request is posted on behalf of the NRK.


## Type of Contribution

This is a: CI bug fix

## Description

There was [an issue in the CI](https://github.com/nrkno/sofie-core/actions/runs/11014653966/job/30588750698) Release step where the openAPI client generated by `hatamiarash7/openapi-generator@v0.3.0` caused the subsequent `yarn build:main` to fail.

The CI step was added in https://github.com/nrkno/sofie-core/pull/1182 but since it failed I temporarily disabled the step in release51.

I did a bit of investigation and came to the conclusion that the `hatamiarash7/openapi-generator` isn't really needed, instead just running `yarn build` seems to generate the artifacts needed (test [npm publish](https://www.npmjs.com/package/@sofie-automation/openapi/v/1.51.0-nightly-chore-openapi-ci-fix-20240925-072200-7c918ac.0?activeTab=versions)).


### Affected areas

* This PR affects CI and publishing of the openAPI npm package


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
