### PR TITLE
Bug fix: currentPart timeline duration should respect postroll in autonext

### DIFF
--- a/packages/job-worker/src/playout/timeline/piece.ts
+++ b/packages/job-worker/src/playout/timeline/piece.ts
@@ -106,7 +106,7 @@ export function getPieceEnableInsidePart(
 	if (partTimings.toPartPostroll) {
 		if (!pieceEnable.duration) {
 			// make sure that the control object is shortened correctly
-			pieceEnable.duration = `#${partGroupId} - ${partTimings.toPartPostroll}`
+			pieceEnable.end = `#${partGroupId} - ${partTimings.toPartPostroll}`
 		}
 	}
 

--- a/packages/job-worker/src/playout/timeline/rundown.ts
+++ b/packages/job-worker/src/playout/timeline/rundown.ts
@@ -146,7 +146,8 @@ export function buildTimelineObjsForRundown(
 			// If there is a valid autonext out of the current part, then calculate the duration
 			currentPartEnable.duration =
 				partInstancesInfo.current.partInstance.part.expectedDuration +
-				partInstancesInfo.current.calculatedTimings.toPartDelay
+				partInstancesInfo.current.calculatedTimings.toPartDelay +
+				partInstancesInfo.current.calculatedTimings.toPartPostroll // autonext should have the postroll added to it to not confuse the timeline
 		}
 		const currentPartGroup = createPartGroup(partInstancesInfo.current.partInstance, currentPartEnable)
 


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This pull request is posted on behalf of **BBC**.


## Type of Contribution

This is a Bug fix.


## Current Behavior
When a part has autoNext set to true as well as a piece with Post Roll the take will be done too early (exactly by the amount of postroll), in addition the infinites may stop at odd times


## New Behavior
Auto next take is done at the correct time (after the expectedDuration has passed), and the infinites do not interrupt.


### Affected areas

This PR affects the timeline generation.


## Time Frame
This Bug Fix is a blocker for us, please review and merge it as soon as possible.


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
