### PR TITLE
chore: disable nrk specific workflows

### DIFF
--- a/.github/workflows/prune-container-images.yml
+++ b/.github/workflows/prune-container-images.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   prune-container-images:
+    if: ${{ github.repository_owner == 'nrkno' }}
+    
     uses: nrkno/sofie-github-workflows/.github/workflows/prune-container-images.yml@main
     strategy:
       max-parallel: 1

--- a/.github/workflows/prune-tags.yml
+++ b/.github/workflows/prune-tags.yml
@@ -16,6 +16,8 @@ on:
 
 jobs:
   prune-tags:
+    if: ${{ github.repository_owner == 'nrkno' }}
+    
     name: Prune tags
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   trivy:
+    if: ${{ github.repository_owner == 'nrkno' }}
+
     name: Trivy scan
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION

## About the Contributor
This pull request is posted on behalf of the BBC


## Type of Contribution

This is a workflow usability improvement


## Current Behavior
Some of the Github Actions workflows are nrk specific, or make assumptions and do not make sense to run for others.

## New Behavior
These workflows are either disabled for anyone other than nrkno


## Testing
I have not tested this, but the changes match a guard on an existing workflow https://github.com/nrkno/sofie-core/blob/master/.github/workflows/sonar.yaml#L15

### Affected areas

Github actions workflows


## Time Frame
<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->
Ideally as soon as possible, this adds noise for our team due to the workflows failing. 
Our master branch is currently mirroring yours, so we can't easily fix directly on our side 

## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
