### PR TITLE
fix: clear pieces with fixed duration

### DIFF
--- a/packages/job-worker/src/playout/adlibUtils.ts
+++ b/packages/job-worker/src/playout/adlibUtils.ts
@@ -274,61 +274,69 @@ export function innerStopPieces(
 
 	for (const resolvedPieceInstance of resolvedPieces) {
 		const pieceInstance = resolvedPieceInstance.instance
-		if (
-			!pieceInstance.userDuration &&
-			!pieceInstance.piece.virtual &&
-			filter(pieceInstance) &&
-			resolvedPieceInstance.resolvedStart !== undefined &&
-			resolvedPieceInstance.resolvedStart <= relativeStopAt &&
-			!pieceInstance.plannedStoppedPlayback
-		) {
-			switch (pieceInstance.piece.lifespan) {
-				case PieceLifespan.WithinPart:
-				case PieceLifespan.OutOnSegmentChange:
-				case PieceLifespan.OutOnRundownChange: {
-					logger.info(`Blueprint action: Cropping PieceInstance "${pieceInstance._id}" to ${stopAt}`)
 
-					const pieceInstanceModel = playoutModel.findPieceInstance(pieceInstance._id)
-					if (pieceInstanceModel) {
-						const newDuration: Required<PieceInstance>['userDuration'] = playoutModel.isMultiGatewayMode
-							? {
-									endRelativeToNow: offsetRelativeToNow,
-							  }
-							: {
-									endRelativeToPart: relativeStopAt,
-							  }
+		// Virtual pieces aren't allowed a timed end
+		if (pieceInstance.piece.virtual) continue
 
-						pieceInstanceModel.pieceInstance.setDuration(newDuration)
+		// Check if piece has already had an end defined
+		if (pieceInstance.userDuration) continue
 
-						stoppedInstances.push(pieceInstance._id)
-					} else {
-						logger.warn(
-							`Blueprint action: Failed to crop PieceInstance "${pieceInstance._id}", it was not found`
-						)
-					}
+		// Caller can filter out pieces
+		if (!filter(pieceInstance)) continue
 
-					break
-				}
-				case PieceLifespan.OutOnSegmentEnd:
-				case PieceLifespan.OutOnRundownEnd:
-				case PieceLifespan.OutOnShowStyleEnd: {
-					logger.info(
-						`Blueprint action: Cropping PieceInstance "${pieceInstance._id}" to ${stopAt} with a virtual`
-					)
+		// Check if piece has started yet
+		if (resolvedPieceInstance.resolvedStart == undefined || resolvedPieceInstance.resolvedStart > relativeStopAt)
+			continue
 
-					currentPartInstance.insertVirtualPiece(
-						relativeStopAt,
-						pieceInstance.piece.lifespan,
-						pieceInstance.piece.sourceLayerId,
-						pieceInstance.piece.outputLayerId
-					)
+		// If there end time of the piece is already known, make sure it is in the future
+		if (pieceInstance.plannedStoppedPlayback && pieceInstance.plannedStoppedPlayback <= stopAt) continue
+
+		switch (pieceInstance.piece.lifespan) {
+			case PieceLifespan.WithinPart:
+			case PieceLifespan.OutOnSegmentChange:
+			case PieceLifespan.OutOnRundownChange: {
+				logger.info(`Blueprint action: Cropping PieceInstance "${pieceInstance._id}" to ${stopAt}`)
+
+				const pieceInstanceModel = playoutModel.findPieceInstance(pieceInstance._id)
+				if (pieceInstanceModel) {
+					const newDuration: Required<PieceInstance>['userDuration'] = playoutModel.isMultiGatewayMode
+						? {
+								endRelativeToNow: offsetRelativeToNow,
+						  }
+						: {
+								endRelativeToPart: relativeStopAt,
+						  }
+
+					pieceInstanceModel.pieceInstance.setDuration(newDuration)
 
 					stoppedInstances.push(pieceInstance._id)
-					break
+				} else {
+					logger.warn(
+						`Blueprint action: Failed to crop PieceInstance "${pieceInstance._id}", it was not found`
+					)
 				}
-				default:
-					assertNever(pieceInstance.piece.lifespan)
+
+				break
 			}
+			case PieceLifespan.OutOnSegmentEnd:
+			case PieceLifespan.OutOnRundownEnd:
+			case PieceLifespan.OutOnShowStyleEnd: {
+				logger.info(
+					`Blueprint action: Cropping PieceInstance "${pieceInstance._id}" to ${stopAt} with a virtual`
+				)
+
+				currentPartInstance.insertVirtualPiece(
+					relativeStopAt,
+					pieceInstance.piece.lifespan,
+					pieceInstance.piece.sourceLayerId,
+					pieceInstance.piece.outputLayerId
+				)
+
+				stoppedInstances.push(pieceInstance._id)
+				break
+			}
+			default:
+				assertNever(pieceInstance.piece.lifespan)
 		}
 	}
 


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
This pull request is posted on behalf of the BBC


## Type of Contribution

This is a: Bug fix 

## Current Behavior
When using `stopPiecesOnLayers` inside an adlib-action, it does not any pieces which have a fixed duration. This is because `plannedStoppedPlayback` is now set when constructing the timeline, so is known even before the piece starts playing.

It now checks whether that `plannedStoppedPlayback` is in the past, instead of just whether it is set.


## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
* 
-->


## Time Frame
<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
