### PR TITLE
Fix: UI Timing: Postroll and autonext timing

### DIFF
--- a/meteor/client/lib/__tests__/rundownTiming.test.ts
+++ b/meteor/client/lib/__tests__/rundownTiming.test.ts
@@ -1262,6 +1262,289 @@ describe('rundown Timing Calculator', () => {
 		)
 	})
 
+	it('Handles part with autonext', () => {
+		const timing = new RundownTimingCalculator()
+		const playlist: DBRundownPlaylist = makeMockPlaylist()
+		playlist.timing = {
+			type: 'forward-time' as any,
+			expectedStart: 0,
+			expectedDuration: 40000,
+		}
+		const rundownId1 = 'rundown1'
+		const segmentId1 = 'segment1'
+		const segmentId2 = 'segment2'
+		const segmentsMap: Map<SegmentId, DBSegment> = new Map()
+		segmentsMap.set(protectString<SegmentId>(segmentId1), makeMockSegment(segmentId1, 0, rundownId1))
+		segmentsMap.set(protectString<SegmentId>(segmentId2), makeMockSegment(segmentId2, 0, rundownId1))
+		const parts: DBPart[] = []
+		parts.push(
+			makeMockPart('part1', 0, rundownId1, segmentId1, {
+				budgetDuration: 2000,
+				expectedDuration: 1000,
+			})
+		)
+		parts.push(
+			makeMockPart('part2', 0, rundownId1, segmentId1, {
+				budgetDuration: 3000,
+				expectedDuration: 1000,
+			})
+		)
+		parts.push(
+			makeMockPart('part3', 0, rundownId1, segmentId2, {
+				budgetDuration: 3000,
+				expectedDuration: 1000,
+			})
+		)
+		parts.push(makeMockPart('part4', 0, rundownId1, segmentId2, { expectedDuration: 1000 }))
+		// set autonext and create partInstances
+		parts[0].autoNext = true
+		const partInstance1 = wrapPartToTemporaryInstance(protectString(''), parts[0])
+		partInstance1.isTemporary = false
+		partInstance1.timings = {
+			plannedStartedPlayback: 0,
+		}
+		const partInstance2 = wrapPartToTemporaryInstance(protectString(''), parts[1])
+		partInstance2.isTemporary = false
+		partInstance2.timings = {
+			plannedStartedPlayback: 1000, // start after part1's expectedDuration
+		}
+		const partInstances = [partInstance1, partInstance2, ...convertPartsToPartInstances([parts[2], parts[3]])]
+		const partInstancesMap: Map<PartId, PartInstance> = new Map()
+		const rundown = makeMockRundown(rundownId1, playlist)
+		const rundowns = [rundown]
+		// at t = 0
+		const result = timing.updateDurations(
+			0,
+			false,
+			playlist,
+			rundowns,
+			undefined,
+			partInstances,
+			partInstancesMap,
+			segmentsMap,
+			DEFAULT_DURATION,
+			[]
+		)
+		expect(result).toEqual(
+			literal<RundownTimingContext>({
+				currentPartInstanceId: null,
+				isLowResolution: false,
+				asDisplayedPlaylistDuration: 4000,
+				asPlayedPlaylistDuration: 8000,
+				currentPartWillAutoNext: false,
+				currentTime: 0,
+				rundownExpectedDurations: {
+					[rundownId1]: 4000,
+				},
+				rundownAsPlayedDurations: {
+					[rundownId1]: 8000,
+				},
+				partCountdown: {
+					part1: 0,
+					part2: 1000,
+					part3: 5000,
+					part4: 6000,
+				},
+				partDisplayDurations: {
+					part1_tmp_instance: 1000,
+					part2_tmp_instance: 1000,
+					part3: 1000,
+					part4: 1000,
+				},
+				partDisplayStartsAt: {
+					part1_tmp_instance: 0,
+					part2_tmp_instance: 1000,
+					part3: 2000,
+					part4: 3000,
+				},
+				partDurations: {
+					part1_tmp_instance: 1000,
+					part2_tmp_instance: 1000,
+					part3: 1000,
+					part4: 1000,
+				},
+				partExpectedDurations: {
+					part1_tmp_instance: 1000,
+					part2_tmp_instance: 1000,
+					part3: 1000,
+					part4: 1000,
+				},
+				partPlayed: {
+					part1_tmp_instance: 0,
+					part2_tmp_instance: 0,
+					part3: 0,
+					part4: 0,
+				},
+				partStartsAt: {
+					part1_tmp_instance: 0,
+					part2_tmp_instance: 1000,
+					part3: 2000,
+					part4: 3000,
+				},
+				remainingPlaylistDuration: 8000,
+				totalPlaylistDuration: 8000,
+				breakIsLastRundown: undefined,
+				remainingTimeOnCurrentPart: undefined,
+				rundownsBeforeNextBreak: undefined,
+				segmentBudgetDurations: {
+					[segmentId1]: 5000,
+					[segmentId2]: 3000,
+				},
+				segmentStartedPlayback: {},
+			})
+		)
+	})
+
+	it('Handles part with postroll', () => {
+		const timing = new RundownTimingCalculator()
+		const playlist: DBRundownPlaylist = makeMockPlaylist()
+		playlist.timing = {
+			type: 'forward-time' as any,
+			expectedStart: 0,
+			expectedDuration: 40000,
+		}
+		const rundownId1 = 'rundown1'
+		const segmentId1 = 'segment1'
+		const segmentId2 = 'segment2'
+		const segmentsMap: Map<SegmentId, DBSegment> = new Map()
+		segmentsMap.set(protectString<SegmentId>(segmentId1), makeMockSegment(segmentId1, 0, rundownId1))
+		segmentsMap.set(protectString<SegmentId>(segmentId2), makeMockSegment(segmentId2, 0, rundownId1))
+		const parts: DBPart[] = []
+		parts.push(
+			makeMockPart('part1', 0, rundownId1, segmentId1, {
+				budgetDuration: 2000,
+				expectedDuration: 2000,
+			})
+		)
+		parts.push(
+			makeMockPart('part2', 0, rundownId1, segmentId1, {
+				budgetDuration: 3000,
+				expectedDuration: 2000,
+			})
+		)
+		parts.push(
+			makeMockPart('part3', 0, rundownId1, segmentId2, {
+				budgetDuration: 3000,
+				expectedDuration: 1000,
+			})
+		)
+		parts.push(makeMockPart('part4', 0, rundownId1, segmentId2, { expectedDuration: 1000 }))
+		// set autonext and create partInstances
+		parts[0].autoNext = true
+		const partInstance1 = wrapPartToTemporaryInstance(protectString(''), parts[0])
+		partInstance1.isTemporary = false
+		partInstance1.timings = {
+			plannedStartedPlayback: 0,
+			reportedStartedPlayback: 0,
+			reportedStoppedPlayback: 2000,
+		}
+		partInstance1.partPlayoutTimings = {
+			inTransitionStart: 0,
+			toPartDelay: 0,
+			toPartPostroll: 500,
+			fromPartRemaining: 0,
+			fromPartPostroll: 0,
+		}
+		const partInstance2 = wrapPartToTemporaryInstance(protectString(''), parts[1])
+		partInstance2.isTemporary = false
+		partInstance2.timings = {
+			plannedStartedPlayback: 2000, // start after part1's expectedDuration
+			reportedStartedPlayback: 2000,
+		}
+		partInstance2.partPlayoutTimings = {
+			inTransitionStart: 0,
+			toPartDelay: 0,
+			toPartPostroll: 0,
+			fromPartRemaining: 500,
+			fromPartPostroll: 500,
+		}
+		const partInstances = [partInstance1, partInstance2, ...convertPartsToPartInstances([parts[2], parts[3]])]
+		const partInstancesMap: Map<PartId, PartInstance> = new Map()
+		const rundown = makeMockRundown(rundownId1, playlist)
+		const rundowns = [rundown]
+		// at t = 0
+		const result = timing.updateDurations(
+			3000,
+			false,
+			playlist,
+			rundowns,
+			undefined,
+			partInstances,
+			partInstancesMap,
+			segmentsMap,
+			DEFAULT_DURATION,
+			[]
+		)
+		expect(result).toEqual(
+			literal<RundownTimingContext>({
+				currentPartInstanceId: null,
+				isLowResolution: false,
+				asDisplayedPlaylistDuration: 6000,
+				asPlayedPlaylistDuration: 8000,
+				currentPartWillAutoNext: false,
+				currentTime: 3000,
+				rundownExpectedDurations: {
+					[rundownId1]: 6000,
+				},
+				rundownAsPlayedDurations: {
+					[rundownId1]: 8000,
+				},
+				partCountdown: {
+					part1: 4000,
+					part2: 6000,
+					part3: 6000,
+					part4: 7000,
+				},
+				partDisplayDurations: {
+					part1_tmp_instance: 2000,
+					part2_tmp_instance: 2000,
+					part3: 1000,
+					part4: 1000,
+				},
+				partDisplayStartsAt: {
+					part1_tmp_instance: 0,
+					part2_tmp_instance: 2000,
+					part3: 4000,
+					part4: 5000,
+				},
+				partDurations: {
+					part1_tmp_instance: 2000,
+					part2_tmp_instance: 2000,
+					part3: 1000,
+					part4: 1000,
+				},
+				partExpectedDurations: {
+					part1_tmp_instance: 2000,
+					part2_tmp_instance: 2000,
+					part3: 1000,
+					part4: 1000,
+				},
+				partPlayed: {
+					part1_tmp_instance: 0,
+					part2_tmp_instance: 1000,
+					part3: 0,
+					part4: 0,
+				},
+				partStartsAt: {
+					part1_tmp_instance: 0,
+					part2_tmp_instance: 2000,
+					part3: 4000,
+					part4: 5000,
+				},
+				remainingPlaylistDuration: 8000,
+				totalPlaylistDuration: 8000,
+				breakIsLastRundown: undefined,
+				remainingTimeOnCurrentPart: undefined,
+				rundownsBeforeNextBreak: undefined,
+				segmentBudgetDurations: {
+					[segmentId1]: 5000,
+					[segmentId2]: 3000,
+				},
+				segmentStartedPlayback: {},
+			})
+		)
+	})
+
 	it('Back-time: Can find the next expectedStart rundown anchor when it is in a future segment', () => {
 		const timing = new RundownTimingCalculator()
 		const playlist: DBRundownPlaylist = makeMockPlaylist()

--- a/meteor/client/lib/rundownTiming.ts
+++ b/meteor/client/lib/rundownTiming.ts
@@ -219,7 +219,11 @@ export class RundownTimingCalculator {
 					totalRundownDuration += calculatePartInstanceExpectedDurationWithTransition(partInstance) || 0
 				}
 
-				const lastStartedPlayback = partInstance.timings?.plannedStartedPlayback
+				// note: lastStartedPlayback that lies in the future means it hasn't started yet (like from autonext)
+				const lastStartedPlayback =
+					(partInstance.timings?.plannedStartedPlayback ?? 0) <= now
+						? partInstance.timings?.plannedStartedPlayback
+						: undefined
 				const playOffset = partInstance.timings?.playOffset || 0
 
 				let partDuration = 0

--- a/packages/corelib/src/playout/timings.ts
+++ b/packages/corelib/src/playout/timings.ts
@@ -159,7 +159,7 @@ export function getPartTimingsOrDefaults(
 
 function calculateExpectedDurationWithTransition(rawDuration: number, timings: PartCalculatedTimings): number {
 	// toPartDelay needs to be subtracted, because it is added to `fromPartRemaining` when the `fromPartRemaining` value is calculated.
-	return Math.max(0, rawDuration - (timings.fromPartRemaining - timings.toPartDelay))
+	return Math.max(0, rawDuration - (timings.fromPartRemaining - timings.toPartDelay - timings.fromPartPostroll))
 }
 
 export type CalculateExpectedDurationPart = Pick<DBPart, 'inTransition' | 'expectedDuration'>

--- a/packages/corelib/src/playout/timings.ts
+++ b/packages/corelib/src/playout/timings.ts
@@ -158,7 +158,7 @@ export function getPartTimingsOrDefaults(
 }
 
 function calculateExpectedDurationWithTransition(rawDuration: number, timings: PartCalculatedTimings): number {
-	// toPartDelay needs to be subtracted, because it is added to `fromPartRemaining` when the `fromPartRemaining` value is calculated.
+	// toPartDelay and fromPartPostroll needs to be subtracted, because it is added to `fromPartRemaining` when the `fromPartRemaining` value is calculated.
 	return Math.max(0, rawDuration - (timings.fromPartRemaining - timings.toPartDelay - timings.fromPartPostroll))
 }
 


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This pull request is posted on behalf of the **BBC**

## Type of Contribution

This is a: **Bug Fix**


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

- The current playing segment timer will have its duration reduced by the amount of postroll the previous on-air part has
- If the current part has an autonext, the next segment will have its duration and time-till-on-air padded with the duration of the current part. The duration will be counting down

## New Behavior
<!--
What is the new behavior?
-->

- Postroll is accounted for in the timing calculations (Postroll is not valid in any display timing since it plays after the part has ended)
- If a timestamp for lastStartedPlayback is in the future it will be ignored by the display calculations since that means the part hasn't actually started yet


## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [x] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
* 
-->
Rundown timing in the UI



## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
