### PR TITLE
fix: on change infinites incorrect collision ends

### DIFF
--- a/packages/job-worker/src/playout/timeline/rundown.ts
+++ b/packages/job-worker/src/playout/timeline/rundown.ts
@@ -328,8 +328,16 @@ function generateCurrentInfinitePieceObjects(
 		infiniteGroup.enable.duration = infiniteInNextPart.piece.enable.duration
 	}
 
-	// If this piece does not continue in the next part, then set it to end with the part it belongs to
-	if (
+	const pieceInstanceWithUpdatedEndCap: PieceInstanceWithTimings = { ...pieceInstance }
+	// Give the infinite group and end cap when the end of the piece is known
+	if (pieceInstance.resolvedEndCap) {
+		// If the cap is a number, it is relative to the part, not the parent group so needs to be handled here
+		if (typeof pieceInstance.resolvedEndCap === 'number') {
+			infiniteGroup.enable.end = `#${timingContext.currentPartGroup.id}.start + ${pieceInstance.resolvedEndCap}`
+			delete pieceInstanceWithUpdatedEndCap.resolvedEndCap
+		}
+	} else if (
+		// If this piece does not continue in the next part, then set it to end with the part it belongs to
 		!infiniteInNextPart &&
 		currentPartInfo.partInstance.part.autoNext &&
 		infiniteGroup.enable.duration === undefined &&
@@ -355,7 +363,7 @@ function generateCurrentInfinitePieceObjects(
 			activePlaylist._id,
 			infiniteGroup,
 			nowInParent,
-			pieceInstance,
+			pieceInstanceWithUpdatedEndCap,
 			pieceEnable,
 			0,
 			groupClasses,


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
This pull request is posted on behalf of the BBC


## Type of Contribution

This is a: Bug fix

## Current Behavior

When a `outOnRundownChange` infinite is playing in the current part, and you take into a new part the infinite continues.
But if the new part has a piece on the same layer with a non-zero start time, the infinite continuation piece will not play.

This is because the end time of the infinite piece doesn't correctly get translated from time within the part, to the mangled timings that infinites use, as it needs to start earlier than the current part.


## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
* 
-->
This PR affects the timeline generation.

## Time Frame
<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->

This likely affects R51 too, so could probably be backported there, but we found and fixed it on R52

## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
