### PR TITLE
fix: QuickLoop timers are inconsistent

### DIFF
--- a/packages/job-worker/src/playout/model/PlayoutModel.ts
+++ b/packages/job-worker/src/playout/model/PlayoutModel.ts
@@ -335,6 +335,12 @@ export interface PlayoutModel extends PlayoutModelReadonly, StudioPlayoutModelBa
 	 */
 	setQuickLoopMarker(type: 'start' | 'end', marker: QuickLoopMarker | null): void
 
+	/**
+	 * Returns any segmentId's that are found between 2 quickloop markers, none will be returned if
+	 * the end is before the start.
+	 * @param start A quickloop marker
+	 * @param end A quickloop marker
+	 */
 	getSegmentsBetweenQuickLoopMarker(start: QuickLoopMarker, end: QuickLoopMarker): SegmentId[]
 
 	calculatePartTimings(

--- a/packages/job-worker/src/playout/model/PlayoutModel.ts
+++ b/packages/job-worker/src/playout/model/PlayoutModel.ts
@@ -335,6 +335,8 @@ export interface PlayoutModel extends PlayoutModelReadonly, StudioPlayoutModelBa
 	 */
 	setQuickLoopMarker(type: 'start' | 'end', marker: QuickLoopMarker | null): void
 
+	getSegmentsBetweenQuickLoopMarker(start: QuickLoopMarker, end: QuickLoopMarker): SegmentId[]
+
 	calculatePartTimings(
 		fromPartInstance: PlayoutPartInstanceModel | null,
 		toPartInstance: PlayoutPartInstanceModel,

--- a/packages/job-worker/src/playout/model/implementation/PlayoutModelImpl.ts
+++ b/packages/job-worker/src/playout/model/implementation/PlayoutModelImpl.ts
@@ -788,6 +788,10 @@ export class PlayoutModelImpl extends PlayoutModelReadonlyImpl implements Playou
 		this.#playlistHasChanged = true
 	}
 
+	getSegmentsBetweenQuickLoopMarker(start: QuickLoopMarker, end: QuickLoopMarker): SegmentId[] {
+		return this.quickLoopService.getSegmentsBetweenMarkers(start, end)
+	}
+
 	/** Lifecycle */
 
 	/** @deprecated */

--- a/packages/job-worker/src/playout/model/implementation/PlayoutModelImpl.ts
+++ b/packages/job-worker/src/playout/model/implementation/PlayoutModelImpl.ts
@@ -589,9 +589,11 @@ export class PlayoutModelImpl extends PlayoutModelReadonlyImpl implements Playou
 
 		if (regenerateActivationId) this.playlistImpl.activationId = getRandomId()
 
-		// reset quickloop:
-		this.setQuickLoopMarker('start', null)
-		this.setQuickLoopMarker('end', null)
+		// reset quickloop if applicable:
+		if (this.playlist.quickLoop && !this.playlist.quickLoop.locked) {
+			this.setQuickLoopMarker('start', null)
+			this.setQuickLoopMarker('end', null)
+		}
 
 		this.#playlistHasChanged = true
 	}

--- a/packages/job-worker/src/playout/model/implementation/PlayoutModelImpl.ts
+++ b/packages/job-worker/src/playout/model/implementation/PlayoutModelImpl.ts
@@ -589,7 +589,9 @@ export class PlayoutModelImpl extends PlayoutModelReadonlyImpl implements Playou
 
 		if (regenerateActivationId) this.playlistImpl.activationId = getRandomId()
 
-		if (this.playlistImpl.quickLoop?.running) this.playlistImpl.quickLoop.running = false
+		// reset quickloop:
+		this.setQuickLoopMarker('start', null)
+		this.setQuickLoopMarker('end', null)
 
 		this.#playlistHasChanged = true
 	}

--- a/packages/job-worker/src/playout/quickLoopMarkers.ts
+++ b/packages/job-worker/src/playout/quickLoopMarkers.ts
@@ -5,6 +5,9 @@ import { runJobWithPlayoutModel } from './lock'
 import { updateTimeline } from './timeline/generate'
 import { selectNextPart } from './selectNextPart'
 import { setNextPart } from './setNext'
+import { resetPartInstancesWithPieceInstances } from './lib'
+import { QuickLoopMarker, QuickLoopMarkerType } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
+import { SegmentId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 
 export async function handleSetQuickLoopMarker(context: JobContext, data: SetQuickLoopMarkerProps): Promise<void> {
 	return runJobWithPlayoutModel(
@@ -17,8 +20,73 @@ export async function handleSetQuickLoopMarker(context: JobContext, data: SetQui
 		async (playoutModel) => {
 			const playlist = playoutModel.playlist
 			if (!playlist.activationId) throw new Error(`Playlist has no activationId!`)
-			const wasQuickLoopRunning = playoutModel.playlist.quickLoop?.running
+			const oldProps = playoutModel.playlist.quickLoop
+			const wasQuickLoopRunning = oldProps?.running
 			playoutModel.setQuickLoopMarker(data.type, data.marker)
+
+			const markerChanged = (
+				markerA: QuickLoopMarker | undefined,
+				markerB: QuickLoopMarker | undefined
+			): boolean => {
+				if (!markerA || !markerB) return false
+
+				if (
+					(markerA.type === QuickLoopMarkerType.RUNDOWN ||
+						markerA.type === QuickLoopMarkerType.SEGMENT ||
+						markerA.type === QuickLoopMarkerType.PART) &&
+					(markerB.type === QuickLoopMarkerType.RUNDOWN ||
+						markerB.type === QuickLoopMarkerType.SEGMENT ||
+						markerB.type === QuickLoopMarkerType.PART)
+				) {
+					return markerA.id !== markerB.id
+				}
+
+				return false
+			}
+
+			if (playlist.currentPartInfo) {
+				// rundown is on air
+				let segmentsToReset: SegmentId[] = []
+
+				if (
+					playlist.quickLoop?.start &&
+					oldProps?.start &&
+					markerChanged(oldProps.start, playlist.quickLoop.start)
+				) {
+					// start marker changed
+					segmentsToReset = playoutModel.getSegmentsBetweenQuickLoopMarker(
+						playlist.quickLoop.start,
+						oldProps.start
+					)
+				} else if (
+					playlist.quickLoop?.end &&
+					oldProps?.end &&
+					markerChanged(oldProps.end, playlist.quickLoop.end)
+				) {
+					// end marker changed
+					segmentsToReset = playoutModel.getSegmentsBetweenQuickLoopMarker(
+						oldProps.end,
+						playlist.quickLoop.end
+					)
+				} else if (playlist.quickLoop?.start && playlist.quickLoop.end && !(oldProps?.start && oldProps.end)) {
+					// a new loop was created
+					segmentsToReset = playoutModel.getSegmentsBetweenQuickLoopMarker(
+						playlist.quickLoop.start,
+						playlist.quickLoop.end
+					)
+				}
+
+				// reset segments that have been added to the loop and are not on-air
+				resetPartInstancesWithPieceInstances(context, playoutModel, {
+					segmentId: {
+						$in: segmentsToReset.filter(
+							(segmentId) =>
+								segmentId !== playoutModel.currentPartInstance?.partInstance.segmentId &&
+								segmentId !== playoutModel.nextPartInstance?.partInstance.segmentId
+						),
+					},
+				})
+			}
 
 			if (wasQuickLoopRunning) {
 				const nextPart = selectNextPart(

--- a/packages/job-worker/src/playout/quickLoopMarkers.ts
+++ b/packages/job-worker/src/playout/quickLoopMarkers.ts
@@ -8,6 +8,7 @@ import { setNextPart } from './setNext'
 import { resetPartInstancesWithPieceInstances } from './lib'
 import { QuickLoopMarker, QuickLoopMarkerType } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { SegmentId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { clone } from 'underscore'
 
 export async function handleSetQuickLoopMarker(context: JobContext, data: SetQuickLoopMarkerProps): Promise<void> {
 	return runJobWithPlayoutModel(
@@ -20,7 +21,7 @@ export async function handleSetQuickLoopMarker(context: JobContext, data: SetQui
 		async (playoutModel) => {
 			const playlist = playoutModel.playlist
 			if (!playlist.activationId) throw new Error(`Playlist has no activationId!`)
-			const oldProps = playoutModel.playlist.quickLoop
+			const oldProps = clone(playoutModel.playlist.quickLoop)
 			const wasQuickLoopRunning = oldProps?.running
 			playoutModel.setQuickLoopMarker(data.type, data.marker)
 

--- a/packages/webui/src/client/lib/rundownTiming.ts
+++ b/packages/webui/src/client/lib/rundownTiming.ts
@@ -107,6 +107,8 @@ export class RundownTimingCalculator {
 		let remainingRundownDuration = 0
 		let asPlayedRundownDuration = 0
 		let asDisplayedRundownDuration = 0
+		// the "wait" for a part is defined as its asPlayedDuration or its displayDuration or its expectedDuration
+		const waitPerPart: Record<string, number> = {}
 		let waitAccumulator = 0
 		let currentRemaining = 0
 		let startsAtAccumulator = 0
@@ -434,10 +436,13 @@ export class RundownTimingCalculator {
 						0
 				}
 				if (segmentUsesBudget) {
-					waitAccumulator += Math.min(waitDuration, Math.max(segmentBudgetDurationLeft, 0))
+					const wait = Math.min(waitDuration, Math.max(segmentBudgetDurationLeft, 0))
+					waitAccumulator += wait
 					segmentBudgetDurationLeft -= waitDuration
+					waitPerPart[unprotectString(partId)] = wait + Math.max(0, segmentBudgetDurationLeft)
 				} else {
 					waitAccumulator += waitDuration
+					waitPerPart[unprotectString(partId)] = waitDuration
 				}
 
 				// remaining is the sum of unplayed lines + whatever is left of the current segment
@@ -478,7 +483,9 @@ export class RundownTimingCalculator {
 			})
 
 			// This is where the waitAccumulator-generated data in the linearSegLines is used to calculate the countdowns.
+			// at this point the "waitAccumulator" should be the total sum of all the "waits" in the rundown
 			let localAccum = 0
+			let timeTillEndLoop: undefined | number = undefined
 			for (let i = 0; i < this.linearParts.length; i++) {
 				if (i < nextAIndex) {
 					// this is a line before next line
@@ -515,6 +522,11 @@ export class RundownTimingCalculator {
 					// and add the currentRemaining countdown, since we are currentRemaining + diff between next and
 					// this away from this line.
 					this.linearParts[i][1] = (this.linearParts[i][1] || 0) - localAccum + currentRemaining
+
+					if (!partsInQuickLoop[unprotectString(this.linearParts[i][0])]) {
+						timeTillEndLoop = timeTillEndLoop ?? this.linearParts[i][1] ?? undefined
+					}
+
 					if (nextRundownAnchor === undefined) {
 						nextRundownAnchor = getSegmentRundownAnchorFromPart(
 							this.linearParts[i][0],
@@ -525,13 +537,22 @@ export class RundownTimingCalculator {
 					}
 				}
 			}
-			// contiunation of linearParts calculations for looping playlists
+			// at this point the localAccumulator should be the sum of waits before the next line
+			// continuation of linearParts calculations for looping playlists
 			if (isLoopRunning(playlist)) {
+				// we track the sum of all the "waits" that happen in the loop
+				let waitInLoop = 0
+				// if timeTillEndLoop was undefined then we can assume the end of the loop is the last line in the rundown
+				timeTillEndLoop = timeTillEndLoop ?? waitAccumulator - localAccum + currentRemaining
 				for (let i = 0; i < nextAIndex; i++) {
 					if (!partsInQuickLoop[unprotectString(this.linearParts[i][0])]) continue
-					// offset the parts before the on air line by the countdown for the end of the rundown
-					this.linearParts[i][1] =
-						(this.linearParts[i][1] || 0) + waitAccumulator - localAccum + currentRemaining
+
+					// this countdown is the wait until the loop ends + whatever waits occur before this part but inside the loop
+					this.linearParts[i][1] = timeTillEndLoop + waitInLoop
+
+					// add the wait from this part to the waitInLoop (the lookup here should still work by the definition of a "wait")
+					waitInLoop += waitPerPart[unprotectString(this.linearParts[i][0])] ?? 0
+
 					if (nextRundownAnchor === undefined) {
 						nextRundownAnchor = getSegmentRundownAnchorFromPart(
 							this.linearParts[i][0],


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This pull request is posted on behalf of the **BBC**.

## Type of Contribution

This is a: Bug Fix


## Current Behavior

- Inconsistent countdown timers in the UI when a loop is active
- When changing the loop while it was on-air, already played segments could be included


## New Behavior

- Consistent countdown timers in the UI when a loop is active
- Segments that are added to the loop after it has started playing will be reset upon inclusion

### Affected areas

This PR affects Countdown Timers when the loop is active and this PR affects the setting QuickLoop markers.



## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
