### PR TITLE
fix: regenerate timeline after routeset

### DIFF
--- a/packages/job-worker/src/playout/adlibAction.ts
+++ b/packages/job-worker/src/playout/adlibAction.ts
@@ -234,6 +234,7 @@ async function applyAnyExecutionSideEffects(
 	if (actionContext.takeAfterExecute) {
 		await performTakeToNextedPart(context, playoutModel, now)
 	} else if (
+		actionContext.forceRegenerateTimeline ||
 		actionContext.currentPartState !== ActionPartChange.NONE ||
 		actionContext.nextPartState !== ActionPartChange.NONE
 	) {

--- a/packages/job-worker/src/playout/debug.ts
+++ b/packages/job-worker/src/playout/debug.ts
@@ -8,7 +8,8 @@ import { logger } from '../logging'
 import { syncPlayheadInfinitesForNextPartInstance } from './infinites'
 import { setNextPart } from './setNext'
 import { runJobWithPlayoutModel } from './lock'
-import { updateStudioTimeline, updateTimeline } from './timeline/generate'
+import { updateTimeline } from './timeline/generate'
+import { updateTimelineFromStudioPlayoutModel } from './lib'
 
 /**
  * Ensure that the infinite pieces on the nexted-part are correct
@@ -80,17 +81,6 @@ export async function handleDebugCrash(context: JobContext, data: DebugRegenerat
  */
 export async function handleDebugUpdateTimeline(context: JobContext, _data: void): Promise<void> {
 	await runJobWithStudioPlayoutModel(context, async (studioPlayoutModel) => {
-		const activePlaylists = studioPlayoutModel.getActiveRundownPlaylists()
-		if (activePlaylists.length > 1) {
-			throw new Error(`Too many active playlists`)
-		} else if (activePlaylists.length > 0) {
-			const playlist = activePlaylists[0]
-
-			await runJobWithPlayoutModel(context, { playlistId: playlist._id }, null, async (playoutModel) => {
-				await updateTimeline(context, playoutModel)
-			})
-		} else {
-			await updateStudioTimeline(context, studioPlayoutModel)
-		}
+		await updateTimelineFromStudioPlayoutModel(context, studioPlayoutModel)
 	})
 }

--- a/packages/job-worker/src/playout/model/PlayoutModel.ts
+++ b/packages/job-worker/src/playout/model/PlayoutModel.ts
@@ -195,8 +195,9 @@ export interface PlayoutModel extends PlayoutModelReadonly, StudioPlayoutModelBa
 	 * Update the active state of a RouteSet
 	 * @param routeSetId
 	 * @param isActive
+	 * @returns Whether the change may affect timeline generation
 	 */
-	switchRouteSet(routeSetId: string, isActive: boolean | 'toggle'): void
+	switchRouteSet(routeSetId: string, isActive: boolean | 'toggle'): boolean
 
 	/**
 	 * Clear the currently selected PartInstances, so that nothing is selected for playback

--- a/packages/job-worker/src/playout/model/implementation/PlayoutModelImpl.ts
+++ b/packages/job-worker/src/playout/model/implementation/PlayoutModelImpl.ts
@@ -480,8 +480,8 @@ export class PlayoutModelImpl extends PlayoutModelReadonlyImpl implements Playou
 		return partInstance
 	}
 
-	switchRouteSet(routeSetId: string, isActive: boolean | 'toggle'): void {
-		this.#baselineHelper.updateRouteSetActive(routeSetId, isActive)
+	switchRouteSet(routeSetId: string, isActive: boolean | 'toggle'): boolean {
+		return this.#baselineHelper.updateRouteSetActive(routeSetId, isActive)
 	}
 
 	cycleSelectedPartInstances(): void {

--- a/packages/job-worker/src/studio/model/StudioPlayoutModel.ts
+++ b/packages/job-worker/src/studio/model/StudioPlayoutModel.ts
@@ -73,6 +73,7 @@ export interface StudioPlayoutModel extends StudioPlayoutModelBase, BaseModel {
 	 * Update the active state of a RouteSet
 	 * @param routeSetId The RouteSet to update
 	 * @param isActive The new active state of the RouteSet
+	 * @returns Whether the change may affect timeline generation
 	 */
-	switchRouteSet(routeSetId: string, isActive: boolean | 'toggle'): void
+	switchRouteSet(routeSetId: string, isActive: boolean | 'toggle'): boolean
 }

--- a/packages/job-worker/src/studio/model/StudioPlayoutModelImpl.ts
+++ b/packages/job-worker/src/studio/model/StudioPlayoutModelImpl.ts
@@ -101,8 +101,8 @@ export class StudioPlayoutModelImpl implements StudioPlayoutModel {
 		return this.#timeline
 	}
 
-	switchRouteSet(routeSetId: string, isActive: boolean | 'toggle'): void {
-		this.#baselineHelper.updateRouteSetActive(routeSetId, isActive)
+	switchRouteSet(routeSetId: string, isActive: boolean | 'toggle'): boolean {
+		return this.#baselineHelper.updateRouteSetActive(routeSetId, isActive)
 	}
 
 	/**

--- a/packages/job-worker/src/studio/routeSet.ts
+++ b/packages/job-worker/src/studio/routeSet.ts
@@ -1,9 +1,14 @@
 import { SwitchRouteSetProps } from '@sofie-automation/corelib/dist/worker/studio'
 import { JobContext } from '../jobs'
 import { runJobWithStudioPlayoutModel } from './lock'
+import { updateTimelineFromStudioPlayoutModel } from '../playout/lib'
 
 export async function handleSwitchRouteSet(context: JobContext, data: SwitchRouteSetProps): Promise<void> {
 	await runJobWithStudioPlayoutModel(context, async (studioPlayoutModel) => {
-		studioPlayoutModel.switchRouteSet(data.routeSetId, data.state)
+		const routesetChangeMayAffectTimeline = studioPlayoutModel.switchRouteSet(data.routeSetId, data.state)
+
+		if (routesetChangeMayAffectTimeline) {
+			await updateTimelineFromStudioPlayoutModel(context, studioPlayoutModel)
+		}
 	})
 }


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
This pull request is posted on behalf of the BBC


## Type of Contribution

This is a: Bug fix

## New Behavior
Follow up to #1272

When toggling a routeset which affects ab-players, this should also regenerate the timeline so that the timeline is using the correct set of ab-players.

This will now check whether a routeset may affect the timeline, and will regenerate it if so.
This means it should have no additional cost for routesets which do not control an abplayer.

## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
* 
-->


## Time Frame
<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
