### PR TITLE
fix: always call `validateAdlibTestingPartInstanceProperties` during `syncIngestChangesToPartInstances`

### DIFF
--- a/packages/job-worker/src/ingest/syncChangesToPartInstance.ts
+++ b/packages/job-worker/src/ingest/syncChangesToPartInstance.ts
@@ -212,9 +212,10 @@ export async function syncChangesToPartInstances(
 					// TODO - these dont get shown to the user currently
 					// TODO - old notes from the sync may need to be pruned, or we will end up with duplicates and 'stuck' notes?+
 					existingPartInstance.appendNotes(newNotes)
-
-					validateAdlibTestingPartInstanceProperties(context, playoutModel, existingPartInstance)
 				}
+
+				// Make sure an adlib-testing part is still labeled correctly. This could happen if the partInstance used any recently updated adlibs
+				validateAdlibTestingPartInstanceProperties(context, playoutModel, existingPartInstance)
 
 				if (existingPartInstance.partInstance._id === playoutModel.playlist.currentPartInfo?.partInstanceId) {
 					// This should be run after 'current', before 'next':


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
This pull request is posted on behalf of the BBC


## Type of Contribution

This is a: Bug fix

## Current Behavior

This fixes a bug where `syncIngestChangesToPartInstances` would only call `validateAdlibTestingPartInstanceProperties` for a partInstance if the blueprint method produced any notes.

I haven't tested this, as we are not currently using either one of these features, this is something I noticed while implementing another change.

This looks to have been introduced as a bad rebase during https://github.com/nrkno/sofie-core/commit/f2281bda6e61808e4417edeb1a7cba834e752cbd#diff-8af2b9f79873bd3db961e678a8e722803844318f4fdb1f7e63a972f71e818c53

## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
* 
-->

This PR affects the syncIngestChanges flow, when also using adlib-testing rundowns.


## Time Frame
<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
