### PR TITLE
fix(job-worker): queue a PartInstanceTimingEvent on deactivation (SOFIE-3470)

### DIFF
--- a/packages/job-worker/src/playout/model/PlayoutPartInstanceModel.ts
+++ b/packages/job-worker/src/playout/model/PlayoutPartInstanceModel.ts
@@ -176,6 +176,11 @@ export interface PlayoutPartInstanceModel {
 	 * @param time Reported stopped time
 	 */
 	setReportedStoppedPlayback(time: Time): boolean
+	/**
+	 * Set the Reported stopped playback time, including still-playing PieceInstances
+	 * @param time Reported stopped time on all available objects
+	 */
+	setReportedStoppedPlaybackWithPieceInstances(time: Time): boolean
 
 	/**
 	 * Set the rank of this PartInstance, to update it's position in the Segment

--- a/packages/job-worker/src/playout/model/implementation/PlayoutModelImpl.ts
+++ b/packages/job-worker/src/playout/model/implementation/PlayoutModelImpl.ts
@@ -432,6 +432,11 @@ export class PlayoutModelImpl extends PlayoutModelReadonlyImpl implements Playou
 	deactivatePlaylist(): void {
 		delete this.playlistImpl.activationId
 
+		if (this.currentPartInstance) {
+			this.currentPartInstance.setReportedStoppedPlaybackWithPieceInstances(getCurrentTime())
+			this.queuePartInstanceTimingEvent(this.currentPartInstance.partInstance._id)
+		}
+
 		this.clearSelectedPartInstances()
 
 		this.#playlistHasChanged = true

--- a/packages/job-worker/src/playout/model/implementation/PlayoutPartInstanceModelImpl.ts
+++ b/packages/job-worker/src/playout/model/implementation/PlayoutPartInstanceModelImpl.ts
@@ -471,6 +471,19 @@ export class PlayoutPartInstanceModelImpl implements PlayoutPartInstanceModel {
 		}
 		return false
 	}
+	setReportedStoppedPlaybackWithPieceInstances(time: number): boolean {
+		if (!this.partInstance.timings?.reportedStartedPlayback) return false
+
+		let setOnAll = this.setReportedStoppedPlayback(time)
+
+		for (const model of this.pieceInstances) {
+			if (model.pieceInstance.reportedStartedPlayback) {
+				setOnAll &&= model.setReportedStoppedPlayback(time)
+			}
+		}
+
+		return setOnAll
+	}
 
 	setRank(rank: number): void {
 		this.#compareAndSetPartValue('_rank', rank)


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This pull request is posted on behalf of the NRK.


## Type of Contribution

This is a:
<!-- (pick one) -->
Bug fix


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->
It's impossible to send metadata using the `onRundownTimingEvent` callback for the very last PartInstance of the Rundown, since the callback is not called on deactivating the Rundown.


## New Behavior
<!--
What is the new behavior?
-->
`onRundownTimingEvent` is called on deactivating a Rundown with a currentPartInstance.


## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
* 
-->
This PR affects Rundown deactivation and metadata flow.


## Time Frame
<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->
We intend to finish the development on this feature in two weeks time.


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
