### PR TITLE
fix: action trigger settings ui previews

### DIFF
--- a/meteor/server/publications/partsUI/publication.ts
+++ b/meteor/server/publications/partsUI/publication.ts
@@ -190,7 +190,7 @@ export async function manipulateUIPartsPublicationData(
 meteorCustomPublish(
 	MeteorPubSub.uiParts,
 	CustomCollectionName.UIParts,
-	async function (pub, playlistId: RundownPlaylistId) {
+	async function (pub, playlistId: RundownPlaylistId | null) {
 		check(playlistId, String)
 
 		const credentials = await resolveCredentials({ userId: this.userId, token: undefined })
@@ -198,7 +198,7 @@ meteorCustomPublish(
 		if (
 			!credentials ||
 			NoSecurityReadAccess.any() ||
-			(await RundownPlaylistReadAccess.rundownPlaylistContent(playlistId, credentials))
+			(playlistId && (await RundownPlaylistReadAccess.rundownPlaylistContent(playlistId, credentials)))
 		) {
 			await setUpCollectionOptimizedObserver<
 				Omit<DBPart, PartOmitedFields>,

--- a/packages/meteor-lib/src/api/pubsub.ts
+++ b/packages/meteor-lib/src/api/pubsub.ts
@@ -249,7 +249,6 @@ export interface MeteorPubSubTypes {
 	[MeteorPubSub.uiBlueprintUpgradeStatuses]: () => CustomCollectionName.UIBlueprintUpgradeStatuses
 	[MeteorPubSub.uiParts]: (playlistId: RundownPlaylistId) => CustomCollectionName.UIParts
 	[MeteorPubSub.uiPartInstances]: (
-		rundownIds: RundownId[],
 		playlistActivationId: RundownPlaylistActivationId | null
 	) => CustomCollectionName.UIPartInstances
 }

--- a/packages/meteor-lib/src/api/pubsub.ts
+++ b/packages/meteor-lib/src/api/pubsub.ts
@@ -2,7 +2,6 @@ import {
 	BucketId,
 	OrganizationId,
 	PartId,
-	RundownId,
 	RundownPlaylistActivationId,
 	RundownPlaylistId,
 	ShowStyleBaseId,
@@ -247,7 +246,7 @@ export interface MeteorPubSubTypes {
 		bucketId: BucketId
 	) => CustomCollectionName.UIBucketContentStatuses
 	[MeteorPubSub.uiBlueprintUpgradeStatuses]: () => CustomCollectionName.UIBlueprintUpgradeStatuses
-	[MeteorPubSub.uiParts]: (playlistId: RundownPlaylistId) => CustomCollectionName.UIParts
+	[MeteorPubSub.uiParts]: (playlistId: RundownPlaylistId | null) => CustomCollectionName.UIParts
 	[MeteorPubSub.uiPartInstances]: (
 		playlistActivationId: RundownPlaylistActivationId | null
 	) => CustomCollectionName.UIPartInstances

--- a/packages/webui/src/client/ui/ClockView/CameraScreen/index.tsx
+++ b/packages/webui/src/client/ui/ClockView/CameraScreen/index.tsx
@@ -100,7 +100,7 @@ export function CameraScreen({ playlist, studioId }: Readonly<IProps>): JSX.Elem
 	useSubscription(CorelibPubSub.segments, rundownIds, {})
 
 	const studioReady = useSubscription(MeteorPubSub.uiStudio, studioId)
-	useSubscription(MeteorPubSub.uiPartInstances, rundownIds, playlist?.activationId ?? null)
+	useSubscription(MeteorPubSub.uiPartInstances, playlist?.activationId ?? null)
 
 	useSubscription(CorelibPubSub.parts, rundownIds, null)
 

--- a/packages/webui/src/client/ui/ClockView/PresenterScreen.tsx
+++ b/packages/webui/src/client/ui/ClockView/PresenterScreen.tsx
@@ -341,7 +341,7 @@ export function usePresenterScreenSubscriptions(props: PresenterScreenProps): vo
 
 	useSubscription(CorelibPubSub.segments, rundownIds, {})
 	useSubscription(CorelibPubSub.parts, rundownIds, null)
-	useSubscription(MeteorPubSub.uiPartInstances, rundownIds, playlist?.activationId ?? null)
+	useSubscription(MeteorPubSub.uiPartInstances, playlist?.activationId ?? null)
 	useSubscriptions(
 		MeteorPubSub.uiShowStyleBase,
 		showStyleBaseIds.map((id) => [id])

--- a/packages/webui/src/client/ui/Prompter/PrompterView.tsx
+++ b/packages/webui/src/client/ui/Prompter/PrompterView.tsx
@@ -597,7 +597,7 @@ function Prompter(props: Readonly<PropsWithChildren<IPrompterProps>>): JSX.Eleme
 	const rundownIDs = playlist ? RundownPlaylistCollectionUtil.getRundownUnorderedIDs(playlist) : []
 	useSubscription(CorelibPubSub.segments, rundownIDs, {})
 	useSubscription(MeteorPubSub.uiParts, props.rundownPlaylistId)
-	useSubscription(MeteorPubSub.uiPartInstances, rundownIDs, playlist?.activationId ?? null)
+	useSubscription(MeteorPubSub.uiPartInstances, playlist?.activationId ?? null)
 	useSubscription(CorelibPubSub.pieces, rundownIDs, null)
 	useSubscription(CorelibPubSub.pieceInstancesSimple, rundownIDs, null)
 

--- a/packages/webui/src/client/ui/RundownView.tsx
+++ b/packages/webui/src/client/ui/RundownView.tsx
@@ -1289,12 +1289,7 @@ export function RundownView(props: Readonly<IProps>): JSX.Element {
 	)
 	auxSubsReady.push(useSubscriptionIfEnabled(MeteorPubSub.uiParts, rundownIds.length > 0, playlistId))
 	auxSubsReady.push(
-		useSubscriptionIfEnabled(
-			MeteorPubSub.uiPartInstances,
-			rundownIds.length > 0,
-			rundownIds,
-			playlistActivationId ?? null
-		)
+		useSubscriptionIfEnabled(MeteorPubSub.uiPartInstances, !!playlistActivationId, playlistActivationId ?? null)
 	)
 
 	useTracker(() => {

--- a/packages/webui/src/client/ui/Settings/components/triggeredActions/TriggeredActionEntry.tsx
+++ b/packages/webui/src/client/ui/Settings/components/triggeredActions/TriggeredActionEntry.tsx
@@ -198,7 +198,7 @@ export const TriggeredActionEntry: React.FC<IProps> = React.memo(function Trigge
 			}
 			return [] as IWrappedAdLib[]
 		},
-		[selected, resolvedActions, sourceLayers],
+		[selected, resolvedActions, sourceLayers, previewContext],
 		[] as IWrappedAdLib[]
 	)
 

--- a/packages/webui/src/client/ui/Settings/components/triggeredActions/TriggeredActionsEditor.tsx
+++ b/packages/webui/src/client/ui/Settings/components/triggeredActions/TriggeredActionsEditor.tsx
@@ -192,7 +192,7 @@ export const TriggeredActionsEditor: React.FC<IProps> = function TriggeredAction
 	)
 
 	useSubscription(MeteorPubSub.uiPartInstances, rundownPlaylist?.activationId ?? null)
-	useSubscription(CorelibPubSub.parts, rundown ? [rundown._id] : [], null)
+	useSubscription(MeteorPubSub.uiParts, rundownPlaylist?._id ?? null)
 
 	const previewContext = useTracker(
 		() => {

--- a/packages/webui/src/client/ui/Settings/components/triggeredActions/TriggeredActionsEditor.tsx
+++ b/packages/webui/src/client/ui/Settings/components/triggeredActions/TriggeredActionsEditor.tsx
@@ -191,7 +191,7 @@ export const TriggeredActionsEditor: React.FC<IProps> = function TriggeredAction
 		null
 	)
 
-	useSubscription(MeteorPubSub.uiPartInstances, rundown ? [rundown._id] : [], rundownPlaylist?.activationId ?? null)
+	useSubscription(MeteorPubSub.uiPartInstances, rundownPlaylist?.activationId ?? null)
 	useSubscription(CorelibPubSub.parts, rundown ? [rundown._id] : [], null)
 
 	const previewContext = useTracker(


### PR DESCRIPTION
## About the Contributor
This pull request is posted on behalf of the BBC


## Type of Contribution

This is a: Bug fix 


## Current Behavior

When using the 'Action Triggers' settings page, it would not correctly show previews related to the current segment.
This was due to the ui subscribing to the 'parts' collection, but then using the 'uiparts' collection.
Q) should this be using parts or ui parts? I want to say parts as this is a settings page, but its trying to match playout behaviour so maybe should be using uiparts? it only needs the document ids, so it probably doesn't matter.

Additionally, when performing a take, this would not be reflected correctly in this ui, the tracker hook was missing a dependency.

I also found that the uiPartInstances publication had a rundownIds parameter that was unused by the publication implementation. This would cause the publication to be restarted unnecessarily, so has been removed.

## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
* 
-->
This PR affects the Action Triggers settings ui

## Time Frame
<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.