### PR TITLE
chore: replace react contextTypes with modern alternatives

### DIFF
--- a/packages/webui/src/client/ui/RundownView/RundownTiming/withTiming.tsx
+++ b/packages/webui/src/client/ui/RundownView/RundownTiming/withTiming.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import * as PropTypes from 'prop-types'
 import * as _ from 'underscore'
 import { RundownTiming } from './RundownTiming'
 import { RundownTimingContext } from '../../../lib/rundownTiming'
@@ -32,6 +31,19 @@ type IWrappedComponent<IProps, IState> =
 	| (new (props: WithTiming<IProps>, state: IState) => React.Component<WithTiming<IProps>, IState>)
 	| ((props: WithTiming<IProps>) => JSX.Element | null)
 
+export interface IRundownTimingProviderValues {
+	durations: RundownTimingContext
+	syncedDurations: RundownTimingContext
+}
+export const RundownTimingProviderContext = React.createContext<IRundownTimingProviderValues>({
+	durations: {
+		isLowResolution: false,
+	},
+	syncedDurations: {
+		isLowResolution: true,
+	},
+})
+
 /**
  * Wrap a component in a HOC that will inject a the timing context as a prop. Takes an optional options object that
  * allows a high timing resolution or filtering of the changes in the context, so that the child component only
@@ -58,16 +70,8 @@ export function withTiming<IProps, IState>(
 
 	return (WrappedComponent) => {
 		return class WithTimingHOCComponent extends React.Component<IProps, IState> {
-			static contextTypes = {
-				durations: PropTypes.object.isRequired,
-				syncedDurations: PropTypes.object.isRequired,
-			}
-
-			// Setup by React.Component constructor
-			declare context: {
-				durations: RundownTimingContext
-				syncedDurations: RundownTimingContext
-			}
+			static contextType = RundownTimingProviderContext
+			declare context: React.ContextType<typeof RundownTimingProviderContext>
 
 			filterGetter: ((o: any) => any) | undefined
 			previousValue: any = undefined

--- a/packages/webui/src/client/ui/SegmentTimeline/SegmentTimeline.tsx
+++ b/packages/webui/src/client/ui/SegmentTimeline/SegmentTimeline.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import * as PropTypes from 'prop-types'
 import { WithTranslation, withTranslation } from 'react-i18next'
 
 import ClassNames from 'classnames'
@@ -51,6 +50,7 @@ import {
 	TimingTickResolution,
 	TimingDataResolution,
 	WithTiming,
+	RundownTimingProviderContext,
 } from '../RundownView/RundownTiming/withTiming'
 import { SegmentTimeAnchorTime } from '../RundownView/RundownTiming/SegmentTimeAnchorTime'
 import { logger } from '../../lib/logging'
@@ -128,15 +128,8 @@ const SegmentTimelineZoom = class SegmentTimelineZoom extends React.Component<
 	IProps & IZoomPropsHeader,
 	IZoomStateHeader
 > {
-	static contextTypes = {
-		durations: PropTypes.object.isRequired,
-	}
-
-	declare context:
-		| {
-				durations: RundownTimingContext
-		  }
-		| undefined
+	static contextType = RundownTimingProviderContext
+	declare context: React.ContextType<typeof RundownTimingProviderContext>
 
 	constructor(props: IProps & IZoomPropsHeader, context: any) {
 		super(props, context)

--- a/packages/webui/src/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/packages/webui/src/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo } from 'react'
-import * as PropTypes from 'prop-types'
 import * as _ from 'underscore'
 import { SegmentTimeline, SegmentTimelineClass } from './SegmentTimeline'
 import { computeSegmentDisplayDuration, RundownTiming, TimingEvent } from '../RundownView/RundownTiming/RundownTiming'
@@ -24,7 +23,7 @@ import {
 	ITrackedResolvedSegmentProps,
 	IOutputLayerUi,
 } from '../SegmentContainer/withResolvedSegment'
-import { computeSegmentDuration, getPartInstanceTimingId, RundownTimingContext } from '../../lib/rundownTiming'
+import { computeSegmentDuration, getPartInstanceTimingId } from '../../lib/rundownTiming'
 import { RundownViewShelf } from '../RundownView/RundownViewShelf'
 import { PartInstanceId, SegmentId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { catchError, useDebounce } from '../../lib/lib'
@@ -39,6 +38,7 @@ import {
 	TIMELINE_RIGHT_PADDING,
 } from './Constants'
 import { UIPartInstances, UIParts } from '../Collections'
+import { RundownTimingProviderContext } from '../RundownView/RundownTiming/withTiming'
 
 // Kept for backwards compatibility
 export type {
@@ -141,10 +141,8 @@ export function SegmentTimelineContainer(props: Readonly<IProps>): JSX.Element {
 
 const SegmentTimelineContainerContent = withResolvedSegment(
 	class SegmentTimelineContainerContent extends React.Component<IProps & ITrackedResolvedSegmentProps, IState> {
-		static contextTypes = {
-			durations: PropTypes.object.isRequired,
-			syncedDurations: PropTypes.object.isRequired,
-		}
+		static contextType = RundownTimingProviderContext
+		declare context: React.ContextType<typeof RundownTimingProviderContext>
 
 		isVisible: boolean
 		rundownCurrentPartInstanceId: PartInstanceId | null = null
@@ -152,12 +150,6 @@ const SegmentTimelineContainerContent = withResolvedSegment(
 		intersectionObserver: IntersectionObserver | undefined
 		mountedTime = 0
 		nextPartOffset = 0
-
-		// Setup by React.Component constructor
-		declare context: {
-			durations: RundownTimingContext
-			syncedDurations: RundownTimingContext
-		}
 
 		constructor(props: IProps & ITrackedResolvedSegmentProps) {
 			super(props)

--- a/packages/webui/src/client/ui/SegmentTimeline/TimelineGrid.tsx
+++ b/packages/webui/src/client/ui/SegmentTimeline/TimelineGrid.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import _ from 'underscore'
-import PropTypes from 'prop-types'
 
 import { RundownUtils } from '../../lib/rundown'
 
@@ -10,8 +9,8 @@ import { PartUi } from './SegmentTimelineContainer'
 import { getCurrentTime } from '../../lib/systemTime'
 import { RundownTiming } from '../RundownView/RundownTiming/RundownTiming'
 import { SegmentTimelinePartClass } from './Parts/SegmentTimelinePart'
-import { RundownTimingContext } from '../../lib/rundownTiming'
 import { PartInstanceId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { RundownTimingProviderContext } from '../RundownView/RundownTiming/withTiming'
 
 // We're cheating a little: Fontface
 declare class FontFace {
@@ -51,15 +50,8 @@ let gridFont: any | undefined = undefined
 let gridFontAvailable = false
 
 export class TimelineGrid extends React.Component<ITimelineGridProps> {
-	static contextTypes = {
-		durations: PropTypes.object.isRequired,
-	}
-
-	declare context:
-		| {
-				durations: RundownTimingContext
-		  }
-		| undefined
+	static contextType = RundownTimingProviderContext
+	declare context: React.ContextType<typeof RundownTimingProviderContext>
 
 	canvasElement: HTMLCanvasElement | null = null
 	parentElement: HTMLDivElement | null = null


### PR DESCRIPTION
## About the Contributor
This pull request is posted on behalf of the BBC


## Type of Contribution

This is a: Code improvement

## New Behavior
This tackles a small bit of tech debt, removing the use of a deprecated react feature. This deprecation results in multiple long error messages in the browser console when in development mode.

I think I have understood the reactivity that it was subject to before and matched that, it would be good for the reviewer to verify that.

Refs:
https://react.dev/reference/react/Component#static-contexttypes
https://legacy.reactjs.org/docs/legacy-context.html



## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

I have done a little testing, nothing looks obviously wrong to me but I am not 100% sure what the side effects of this could be.

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
* 
-->

This affects the rundown and other playout UI pages.

## Time Frame
<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->
Not urgent, but we would like to get this merged into the in-development release.

## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
