### PR TITLE
fix: `queuedSegmentId` ignored when taking last part of the rundown

### DIFF
--- a/packages/job-worker/src/playout/__tests__/selectNextPart.test.ts
+++ b/packages/job-worker/src/playout/__tests__/selectNextPart.test.ts
@@ -417,4 +417,11 @@ describe('selectNextPart', () => {
 			expect(nextPart).toEqual({ index: 6, part: defaultParts[6], consumesQueuedSegmentId: false })
 		}
 	})
+
+	test('on last part, with queued segment', () => {
+		// On the last part in the rundown, with a queuedSegment id set to earlier
+		defaultPlaylist.queuedSegmentId = segment2
+		const nextPart = selectNextPart2(defaultParts[8].toPartInstance(), defaultParts[8].toPartInstance())
+		expect(nextPart).toEqual({ index: 4, part: defaultParts[4], consumesQueuedSegmentId: true })
+	})
 })

--- a/packages/job-worker/src/playout/selectNextPart.ts
+++ b/packages/job-worker/src/playout/selectNextPart.ts
@@ -176,7 +176,7 @@ export function selectNextPart(
 
 	if (rundownPlaylist.queuedSegmentId) {
 		// No previous part, or segment has changed
-		if (!previousPartInstance || (nextPart && previousPartInstance.segmentId !== nextPart.part.segmentId)) {
+		if (!previousPartInstance || !nextPart || previousPartInstance.segmentId !== nextPart.part.segmentId) {
 			// Find first in segment
 			const newSegmentPart = findFirstPlayablePart(
 				0,


### PR DESCRIPTION


## About the Contributor
This pull request is posted on behalf of the BBC


## Type of Contribution

This is a: Bug fix 

## Current Behavior

To replicate:

- Have a final segment with multiple parts
- Take the first part in the final segment
- Queue a previous segment (Queue, not set as next)
- Take remaining parts
- Sofie gets stuck on final part with an error stating that there are no more parts (despite previous segment showing the little queue green triangle)


## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [x] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
* 
-->


## Time Frame
<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->

I suspect this will affect earlier releases too, but I am not setup to test in earlier versions

## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
