### PR TITLE
Fixed broken Slack invite link

### DIFF
--- a/packages/documentation/docs/user-guide/further-reading.md
+++ b/packages/documentation/docs/user-guide/further-reading.md
@@ -10,7 +10,7 @@ description: This guide has a lot of links. Here they are all listed by section.
 - [Gateways](concepts-and-architecture.md#gateways)
 - [Blueprints](concepts-and-architecture.md#blueprints)
 
-- Ask questions in the [Sofie Slack Channel](https://join.slack.com/t/sofietv/shared_invite/enQtNTk2Mzc3MTQ1NzAzLTJkZjMyMDg3OGM0YWU3MmU4YzBhZDAyZWI1YmJmNmRiYWQ1OTZjYTkzOTkzMTA2YTE1YjgxMmVkM2U1OGZlNWI)
+- Ask questions in the [Sofie Slack Channel](https://sofietv.slack.com/join/shared_invite/zt-2bfz8l9lw-azLeDB55cvN2wvMgqL1alA#/shared-invite/email)
 
 ## Installation & Setup
 


### PR DESCRIPTION
Updated the broken link to the Sofie Slack channel.

## About the Contributor
Part of the Sofie team at SuperFly.tv


## Type of Contribution

This is a:
Documentation improvement


## Current Behavior
Broken Slack invite link.


## New Behavior
Working Slack invite link.


## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas
Documentation


## Time Frame
ASAP


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
