### PR TITLE
fix: the scss structure reimporting multiple times

### DIFF
--- a/packages/webui/src/client/styles/_colorScheme.scss
+++ b/packages/webui/src/client/styles/_colorScheme.scss
@@ -1,4 +1,3 @@
-@import 'defaultColors';
 
 // color variables are defined in defaultColors.scss
 

--- a/packages/webui/src/client/styles/_robotoFont.scss
+++ b/packages/webui/src/client/styles/_robotoFont.scss
@@ -1,2 +1,1 @@
 $FontPath: '../../fonts/roboto-gh-pages/fonts';
-@import 'fonts/roboto';

--- a/packages/webui/src/client/styles/_variables.scss
+++ b/packages/webui/src/client/styles/_variables.scss
@@ -1,4 +1,3 @@
-@import 'colorScheme';
 
 $fullscreen-controls__button--radius: 3.125rem;
 

--- a/packages/webui/src/client/styles/externalMessagesStatus.scss
+++ b/packages/webui/src/client/styles/externalMessagesStatus.scss
@@ -1,4 +1,3 @@
-@import '_colorScheme';
 
 .external-message-status {
 	padding-bottom: 70vh;

--- a/packages/webui/src/client/styles/main.scss
+++ b/packages/webui/src/client/styles/main.scss
@@ -8,6 +8,9 @@ input {
 	user-select: auto;
 } */
 
+@import 'defaultColors';
+@import 'itemTypeColors';
+@import 'colorScheme';
 @import '_variables';
 @import '_header';
 @import '_colorScheme';

--- a/packages/webui/src/client/styles/notifications.scss
+++ b/packages/webui/src/client/styles/notifications.scss
@@ -1,5 +1,3 @@
-@import '_colorScheme';
-@import '_variables';
 
 .notification-pop-ups {
 	position: fixed;

--- a/packages/webui/src/client/styles/rundownList.scss
+++ b/packages/webui/src/client/styles/rundownList.scss
@@ -1,4 +1,3 @@
-@import '_colorScheme';
 
 // Root playlist/rundown list, see RundownList.tsx
 .rundown-list {

--- a/packages/webui/src/client/styles/rundownView.scss
+++ b/packages/webui/src/client/styles/rundownView.scss
@@ -1,7 +1,4 @@
-@import 'colorScheme';
-@import 'itemTypeColors';
 @import 'utils';
-@import '_variables';
 
 $output-layer-group-line: 1px solid #5c5c5c;
 $output-layer-group-collapse-animation-duration: 0.3s;

--- a/packages/webui/src/client/styles/shelf/adLibPanel.scss
+++ b/packages/webui/src/client/styles/shelf/adLibPanel.scss
@@ -1,5 +1,4 @@
 @import '../colorScheme';
-@import '../itemTypeColors';
 
 :root {
 	--adlib-item-selected-color: #009dff;

--- a/packages/webui/src/client/styles/shelf/dashboard-rundownView.scss
+++ b/packages/webui/src/client/styles/shelf/dashboard-rundownView.scss
@@ -1,4 +1,3 @@
-@import '../_variables';
 
 .rundown-view-shelf.dashboard-panel {
 	width: auto;

--- a/packages/webui/src/client/styles/shelf/dashboard.scss
+++ b/packages/webui/src/client/styles/shelf/dashboard.scss
@@ -1,5 +1,4 @@
 @import '../colorScheme';
-@import '../itemTypeColors';
 
 $dashboard-button-width: 6.40625em;
 $dashboard-button-height: 5.625em;

--- a/packages/webui/src/client/styles/shelf/inspector.scss
+++ b/packages/webui/src/client/styles/shelf/inspector.scss
@@ -1,5 +1,4 @@
 @import '../colorScheme';
-@import '../itemTypeColors';
 @import '../variables';
 
 .shelf-inspector {

--- a/packages/webui/src/client/styles/shelf/partNamePanel.scss
+++ b/packages/webui/src/client/styles/shelf/partNamePanel.scss
@@ -1,4 +1,3 @@
-@import '../itemTypeColors';
 
 .part-name-panel {
 	position: absolute;

--- a/packages/webui/src/client/styles/splitDropdown.scss
+++ b/packages/webui/src/client/styles/splitDropdown.scss
@@ -1,4 +1,3 @@
-@import '_colorScheme';
 
 .expco.button {
 	border: 1px solid rgba(99, 99, 99, 0.5);

--- a/packages/webui/src/client/styles/statusbar.scss
+++ b/packages/webui/src/client/styles/statusbar.scss
@@ -1,5 +1,3 @@
-@import '_colorScheme';
-@import '_variables';
 
 .status-bar {
 	position: fixed;

--- a/packages/webui/src/client/styles/supportAndSwitchboardPanel.scss
+++ b/packages/webui/src/client/styles/supportAndSwitchboardPanel.scss
@@ -1,5 +1,3 @@
-@import '_colorScheme';
-@import '_variables';
 
 .status-bar__controls__button.support__toggle-button {
 	z-index: 310;

--- a/packages/webui/src/client/styles/systemStatus.scss
+++ b/packages/webui/src/client/styles/systemStatus.scss
@@ -1,4 +1,3 @@
-@import '_colorScheme';
 
 .status-dialog {
 	overflow: visible !important;

--- a/packages/webui/src/client/styles/users.scss
+++ b/packages/webui/src/client/styles/users.scss
@@ -1,4 +1,3 @@
-@import '_variables';
 
 .center-page {
 	align-items: center;

--- a/packages/webui/src/client/styles/utils.scss
+++ b/packages/webui/src/client/styles/utils.scss
@@ -1,4 +1,3 @@
-@import '_variables';
 
 @mixin take-arrow {
 	content: ' ';

--- a/packages/webui/src/client/ui/ClockView/CameraScreen/CameraScreen.scss
+++ b/packages/webui/src/client/ui/ClockView/CameraScreen/CameraScreen.scss
@@ -1,5 +1,4 @@
 @import '../../../styles/variables';
-@import '../../../styles/itemTypeColors';
 
 $page-margin: 1rem 1rem 0 3rem;
 

--- a/packages/webui/src/client/ui/PieceIcons/IconColors.scss
+++ b/packages/webui/src/client/ui/PieceIcons/IconColors.scss
@@ -1,4 +1,3 @@
-@import '../../styles/_itemTypeColors';
 
 svg.piece_icon {
 	@include item-type-colors-svg();

--- a/packages/webui/src/client/ui/RundownView/MediaStatusPopUp/MediaStatusPopUpItem.scss
+++ b/packages/webui/src/client/ui/RundownView/MediaStatusPopUp/MediaStatusPopUpItem.scss
@@ -1,5 +1,4 @@
 @import '../../../styles/colorScheme';
-@import '../../../styles/itemTypeColors';
 
 .media-status-popup-item {
 	.media-status-popup-item__playout-indicator {

--- a/packages/webui/src/client/ui/SegmentList/LinePartMainPiece/LinePartMainPiece.scss
+++ b/packages/webui/src/client/ui/SegmentList/LinePartMainPiece/LinePartMainPiece.scss
@@ -1,4 +1,3 @@
-@import '../../../styles/itemTypeColors';
 
 .segment-opl__main-piece {
 	position: relative;

--- a/packages/webui/src/client/ui/SegmentList/LinePartPieceIndicator/LinePartPieceIndicator.scss
+++ b/packages/webui/src/client/ui/SegmentList/LinePartPieceIndicator/LinePartPieceIndicator.scss
@@ -1,4 +1,3 @@
-@import '../../../styles/itemTypeColors';
 
 .segment-opl__piece-indicator-placeholder {
 	position: relative;

--- a/packages/webui/src/client/ui/SegmentList/LinePartPieceIndicator/PieceIndicatorMenu.scss
+++ b/packages/webui/src/client/ui/SegmentList/LinePartPieceIndicator/PieceIndicatorMenu.scss
@@ -1,4 +1,3 @@
-@import '../../../styles/itemTypeColors';
 
 .segment-opl__piece-indicator-menu {
 	background: #5a5a5a;

--- a/packages/webui/src/client/ui/SegmentList/LinePartSecondaryPiece/LinePartSecondaryPiece.scss
+++ b/packages/webui/src/client/ui/SegmentList/LinePartSecondaryPiece/LinePartSecondaryPiece.scss
@@ -1,4 +1,3 @@
-@import '../../../styles/itemTypeColors';
 
 .segment-opl__secondary-piece {
 	position: absolute;

--- a/packages/webui/src/client/ui/SegmentList/SegmentList.scss
+++ b/packages/webui/src/client/ui/SegmentList/SegmentList.scss
@@ -1,7 +1,5 @@
 @import '../../styles/colorScheme';
 @import '../../styles/utils';
-@import '../../styles/variables';
-@import '../../styles/itemTypeColors';
 
 /** Loans from rundownView.scss, to be refactored to a shared variable file */
 $segment-title-background-color: #4b4b4b;

--- a/packages/webui/src/client/ui/SegmentStoryboard/SegmentStoryboard.scss
+++ b/packages/webui/src/client/ui/SegmentStoryboard/SegmentStoryboard.scss
@@ -1,7 +1,6 @@
 @import '../../styles/colorScheme';
 @import '../../styles/utils';
 @import '../../styles/variables';
-@import '../../styles/itemTypeColors';
 
 $part-left-padding: 6px;
 $part-right-padding: 5px;

--- a/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/StoryboardPartSecondaryPieces.scss
+++ b/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/StoryboardPartSecondaryPieces.scss
@@ -1,4 +1,3 @@
-@import '../../../styles/itemTypeColors';
 
 $source-layer-height: 1.2rem;
 $source-layer-margin: 0.2rem;

--- a/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPartThumbnail/StoryboardPartThumbnail.scss
+++ b/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPartThumbnail/StoryboardPartThumbnail.scss
@@ -1,5 +1,4 @@
 @import '../../../styles/variables';
-@import '../../../styles/itemTypeColors';
 
 .segment-storyboard__part__thumbnail {
 	@include item-type-colors();

--- a/packages/webui/src/client/ui/Settings/components/triggeredActions/TriggeredActionsEditor.scss
+++ b/packages/webui/src/client/ui/Settings/components/triggeredActions/TriggeredActionsEditor.scss
@@ -1,4 +1,3 @@
-@import '../../../../styles/itemTypeColors';
 @import '../../../../styles/colorScheme';
 
 $triggered-action-color: #146985;

--- a/packages/webui/src/client/ui/Status/media-status/MediaStatusListItem.scss
+++ b/packages/webui/src/client/ui/Status/media-status/MediaStatusListItem.scss
@@ -1,5 +1,4 @@
 @import '../../../styles/colorScheme';
-@import '../../../styles/itemTypeColors';
 
 .media-status-item:nth-child(2n + 1) > td {
 	background: #f6f6f6;


### PR DESCRIPTION
## About the Contributor
this PR is made on the behalf of BBC

## Type of Contribution

This is a:
Bug fix


## Current Behavior
Currently the scss files is reimporting the same .scss files multiple times, ending up with a css styles stack of 144 :root elements.

## New Behavior
The imports are done in the main.scss and removed in the sub scss files, as their already shared by the main.scss

## Testing
It has been tested, going through the different components. But as all these 114 :root styles was identical, it shouldn't cause any issues.

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [X] No unit test changes are needed for this PR

### Affected areas
CSS - UI

## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
