### PR TITLE
feat: exclude pieces from part keepalive

### DIFF
--- a/packages/blueprints-integration/src/documents/piece.ts
+++ b/packages/blueprints-integration/src/documents/piece.ts
@@ -35,6 +35,11 @@ export interface IBlueprintPiece<TPrivateData = unknown, TPublicData = unknown>
 	 * User editing definitions for this piece
 	 */
 	userEditOperations?: UserEditingDefinition[]
+
+	/**
+	 * Whether to stop this piece before the 'keepalive' period of the part
+	 */
+	excludeDuringPartKeepalive?: boolean
 }
 export interface IBlueprintPieceDB<TPrivateData = unknown, TPublicData = unknown>
 	extends IBlueprintPiece<TPrivateData, TPublicData> {

--- a/packages/corelib/src/playout/__tests__/timings.test.ts
+++ b/packages/corelib/src/playout/__tests__/timings.test.ts
@@ -80,6 +80,7 @@ describe('Part Playout Timings', () => {
 							fromPartRemaining: 0,
 							fromPartPostroll: 0,
 							toPartPostroll: 0,
+							fromPartKeepalive: 0,
 						})
 					)
 				})
@@ -102,6 +103,7 @@ describe('Part Playout Timings', () => {
 							fromPartRemaining: 0,
 							fromPartPostroll: 0,
 							toPartPostroll: 0,
+							fromPartKeepalive: 0,
 						})
 					)
 				})
@@ -124,6 +126,7 @@ describe('Part Playout Timings', () => {
 							fromPartRemaining: 231,
 							fromPartPostroll: 231,
 							toPartPostroll: 0,
+							fromPartKeepalive: 0,
 						})
 					)
 				})
@@ -146,6 +149,7 @@ describe('Part Playout Timings', () => {
 							fromPartRemaining: 289,
 							fromPartPostroll: 0,
 							toPartPostroll: 0,
+							fromPartKeepalive: 0,
 						})
 					)
 				})
@@ -168,6 +172,7 @@ describe('Part Playout Timings', () => {
 							fromPartRemaining: 231 + 289,
 							fromPartPostroll: 231,
 							toPartPostroll: 0,
+							fromPartKeepalive: 0,
 						})
 					)
 				})
@@ -191,6 +196,7 @@ describe('Part Playout Timings', () => {
 							fromPartRemaining: 452,
 							fromPartPostroll: 0,
 							toPartPostroll: 0,
+							fromPartKeepalive: 452,
 						})
 					)
 				})
@@ -214,6 +220,7 @@ describe('Part Playout Timings', () => {
 							fromPartRemaining: 231 + 452,
 							fromPartPostroll: 231,
 							toPartPostroll: 0,
+							fromPartKeepalive: 452,
 						})
 					)
 				})
@@ -238,6 +245,7 @@ describe('Part Playout Timings', () => {
 							fromPartRemaining: 452,
 							fromPartPostroll: 0,
 							toPartPostroll: 0,
+							fromPartKeepalive: 452,
 						})
 					)
 				})
@@ -262,6 +270,7 @@ describe('Part Playout Timings', () => {
 							fromPartRemaining: 231 + 452,
 							fromPartPostroll: 231,
 							toPartPostroll: 0,
+							fromPartKeepalive: 452,
 						})
 					)
 				})
@@ -286,6 +295,7 @@ describe('Part Playout Timings', () => {
 							fromPartRemaining: 2256,
 							fromPartPostroll: 0,
 							toPartPostroll: 0,
+							fromPartKeepalive: 452,
 						})
 					)
 				})
@@ -310,6 +320,7 @@ describe('Part Playout Timings', () => {
 							fromPartRemaining: 231 + 2256,
 							fromPartPostroll: 231,
 							toPartPostroll: 0,
+							fromPartKeepalive: 452,
 						})
 					)
 				})
@@ -331,6 +342,7 @@ describe('Part Playout Timings', () => {
 							fromPartRemaining: 500,
 							fromPartPostroll: 0,
 							toPartPostroll: 0,
+							fromPartKeepalive: 0,
 						})
 					)
 				})
@@ -345,6 +357,7 @@ describe('Part Playout Timings', () => {
 							fromPartRemaining: 500,
 							fromPartPostroll: 0,
 							toPartPostroll: 0,
+							fromPartKeepalive: 0,
 						})
 					)
 				})
@@ -365,6 +378,7 @@ describe('Part Playout Timings', () => {
 							fromPartRemaining: 231 + 500,
 							fromPartPostroll: 231,
 							toPartPostroll: 0,
+							fromPartKeepalive: 0,
 						})
 					)
 				})
@@ -387,6 +401,7 @@ describe('Part Playout Timings', () => {
 							fromPartRemaining: 500,
 							fromPartPostroll: 0,
 							toPartPostroll: 0,
+							fromPartKeepalive: 0,
 						})
 					)
 				})
@@ -409,6 +424,7 @@ describe('Part Playout Timings', () => {
 							fromPartRemaining: 231 + 500,
 							fromPartPostroll: 231,
 							toPartPostroll: 0,
+							fromPartKeepalive: 0,
 						})
 					)
 				})
@@ -431,6 +447,7 @@ describe('Part Playout Timings', () => {
 							fromPartRemaining: 823,
 							fromPartPostroll: 0,
 							toPartPostroll: 0,
+							fromPartKeepalive: 0,
 						})
 					)
 				})
@@ -453,6 +470,7 @@ describe('Part Playout Timings', () => {
 							fromPartRemaining: 231 + 823,
 							fromPartPostroll: 231,
 							toPartPostroll: 0,
+							fromPartKeepalive: 0,
 						})
 					)
 				})
@@ -476,6 +494,7 @@ describe('Part Playout Timings', () => {
 							fromPartRemaining: 500 + 452,
 							fromPartPostroll: 0,
 							toPartPostroll: 0,
+							fromPartKeepalive: 452,
 						})
 					)
 				})
@@ -499,6 +518,7 @@ describe('Part Playout Timings', () => {
 							fromPartRemaining: 231 + 500 + 452,
 							fromPartPostroll: 231,
 							toPartPostroll: 0,
+							fromPartKeepalive: 452,
 						})
 					)
 				})
@@ -523,6 +543,7 @@ describe('Part Playout Timings', () => {
 							fromPartRemaining: 500 + 452,
 							fromPartPostroll: 0,
 							toPartPostroll: 0,
+							fromPartKeepalive: 452,
 						})
 					)
 				})
@@ -547,6 +568,7 @@ describe('Part Playout Timings', () => {
 							fromPartRemaining: 231 + 500 + 452,
 							fromPartPostroll: 231,
 							toPartPostroll: 0,
+							fromPartKeepalive: 452,
 						})
 					)
 				})
@@ -571,6 +593,7 @@ describe('Part Playout Timings', () => {
 							fromPartRemaining: 2256,
 							fromPartPostroll: 0,
 							toPartPostroll: 0,
+							fromPartKeepalive: 452,
 						})
 					)
 				})
@@ -595,6 +618,7 @@ describe('Part Playout Timings', () => {
 							fromPartRemaining: 231 + 2256,
 							fromPartPostroll: 231,
 							toPartPostroll: 0,
+							fromPartKeepalive: 452,
 						})
 					)
 				})
@@ -624,6 +648,7 @@ describe('Part Playout Timings', () => {
 						fromPartRemaining: 500,
 						fromPartPostroll: 0,
 						toPartPostroll: 0,
+						fromPartKeepalive: 0,
 					})
 				)
 			})
@@ -653,6 +678,7 @@ describe('Part Playout Timings', () => {
 						fromPartRemaining: 500 + 452,
 						fromPartPostroll: 0,
 						toPartPostroll: 0,
+						fromPartKeepalive: 452,
 					})
 				)
 			})
@@ -682,6 +708,7 @@ describe('Part Playout Timings', () => {
 						fromPartRemaining: 231 + 500 + 452,
 						fromPartPostroll: 231,
 						toPartPostroll: 0,
+						fromPartKeepalive: 452,
 					})
 				)
 			})
@@ -710,6 +737,7 @@ describe('Part Playout Timings', () => {
 						fromPartRemaining: 500,
 						fromPartPostroll: 0,
 						toPartPostroll: 0,
+						fromPartKeepalive: 0,
 					})
 				)
 			})
@@ -738,6 +766,7 @@ describe('Part Playout Timings', () => {
 						fromPartRemaining: 231 + 500,
 						fromPartPostroll: 231,
 						toPartPostroll: 0,
+						fromPartKeepalive: 0,
 					})
 				)
 			})
@@ -764,6 +793,7 @@ describe('Part Playout Timings', () => {
 						fromPartRemaining: 5000,
 						fromPartPostroll: 0,
 						toPartPostroll: 0,
+						fromPartKeepalive: 5000,
 					})
 				)
 			})
@@ -790,6 +820,7 @@ describe('Part Playout Timings', () => {
 						fromPartRemaining: 500,
 						fromPartPostroll: 0,
 						toPartPostroll: 0,
+						fromPartKeepalive: 0,
 					})
 				)
 			})
@@ -816,6 +847,7 @@ describe('Part Playout Timings', () => {
 						fromPartRemaining: 500,
 						fromPartPostroll: 0,
 						toPartPostroll: 0,
+						fromPartKeepalive: 0,
 					})
 				)
 			})
@@ -843,6 +875,7 @@ describe('Part Playout Timings', () => {
 							fromPartRemaining: 231 + 5000,
 							fromPartPostroll: 231,
 							toPartPostroll: 0,
+							fromPartKeepalive: 5000,
 						})
 					)
 				})
@@ -869,6 +902,7 @@ describe('Part Playout Timings', () => {
 							fromPartRemaining: 231 + 500,
 							fromPartPostroll: 231,
 							toPartPostroll: 0,
+							fromPartKeepalive: 0,
 						})
 					)
 				})
@@ -895,6 +929,7 @@ describe('Part Playout Timings', () => {
 							fromPartRemaining: 231 + 500,
 							fromPartPostroll: 231 + 0,
 							toPartPostroll: 0 + 0,
+							fromPartKeepalive: 0,
 						})
 					)
 				})
@@ -924,6 +959,7 @@ describe('Part Playout Timings', () => {
 						fromPartRemaining: 500 - 345 + 628,
 						fromPartPostroll: 0,
 						toPartPostroll: 0,
+						fromPartKeepalive: 628,
 					})
 				)
 			})
@@ -950,6 +986,7 @@ describe('Part Playout Timings', () => {
 						fromPartRemaining: 231 + 500 - 345 + 628,
 						fromPartPostroll: 231,
 						toPartPostroll: 0,
+						fromPartKeepalive: 628,
 					})
 				)
 			})
@@ -976,6 +1013,7 @@ describe('Part Playout Timings', () => {
 						fromPartRemaining: 628,
 						fromPartPostroll: 0,
 						toPartPostroll: 0,
+						fromPartKeepalive: 628,
 					})
 				)
 			})
@@ -1002,6 +1040,7 @@ describe('Part Playout Timings', () => {
 						fromPartRemaining: 231 + 628,
 						fromPartPostroll: 231,
 						toPartPostroll: 0,
+						fromPartKeepalive: 628,
 					})
 				)
 			})
@@ -1030,6 +1069,7 @@ describe('Part Playout Timings', () => {
 						fromPartRemaining: 500 - 345 + 628,
 						fromPartPostroll: 0,
 						toPartPostroll: 0,
+						fromPartKeepalive: 628,
 					})
 				)
 			})
@@ -1058,6 +1098,7 @@ describe('Part Playout Timings', () => {
 						fromPartRemaining: 231 + 500 - 345 + 628,
 						fromPartPostroll: 231,
 						toPartPostroll: 0,
+						fromPartKeepalive: 628,
 					})
 				)
 			})
@@ -1086,6 +1127,7 @@ describe('Part Playout Timings', () => {
 						fromPartRemaining: 987,
 						fromPartPostroll: 0,
 						toPartPostroll: 0,
+						fromPartKeepalive: 628,
 					})
 				)
 			})
@@ -1114,6 +1156,7 @@ describe('Part Playout Timings', () => {
 						fromPartRemaining: 231 + 987,
 						fromPartPostroll: 231,
 						toPartPostroll: 0,
+						fromPartKeepalive: 628,
 					})
 				)
 			})

--- a/packages/corelib/src/playout/timings.ts
+++ b/packages/corelib/src/playout/timings.ts
@@ -58,6 +58,7 @@ export interface PartCalculatedTimings {
 	toPartPostroll: number
 	fromPartRemaining: number // How long after the start of toPartGroup should fromPartGroup continue?
 	fromPartPostroll: number
+	fromPartKeepalive: number
 }
 
 export type CalculateTimingsPiece = Pick<Piece, 'enable' | 'prerollDuration' | 'postrollDuration' | 'pieceType'>
@@ -117,6 +118,7 @@ export function calculatePartTimings(
 			// The old part needs to continue for a while
 			fromPartRemaining: takeOffset + fromPartPostroll,
 			fromPartPostroll: fromPartPostroll,
+			fromPartKeepalive: 0,
 		}
 	} else {
 		// The amount of time needed to complete the outTransition before the 'take' point
@@ -136,6 +138,7 @@ export function calculatePartTimings(
 			toPartPostroll: toPartPostroll,
 			fromPartRemaining: takeOffset + inTransition.previousPartKeepaliveDuration + fromPartPostroll,
 			fromPartPostroll: fromPartPostroll,
+			fromPartKeepalive: inTransition.previousPartKeepaliveDuration,
 		}
 	}
 }

--- a/packages/job-worker/src/blueprints/context/lib.ts
+++ b/packages/job-worker/src/blueprints/context/lib.ts
@@ -97,6 +97,7 @@ export const IBlueprintPieceObjectsSampleKeys = allKeysOfObject<IBlueprintPiece>
 	notInVision: true,
 	abSessions: true,
 	userEditOperations: true,
+	excludeDuringPartKeepalive: true,
 })
 
 // Compile a list of the keys which are allowed to be set
@@ -239,6 +240,7 @@ export function convertPieceToBlueprints(piece: ReadonlyDeep<PieceInstancePiece>
 		extendOnHold: piece.extendOnHold,
 		notInVision: piece.notInVision,
 		userEditOperations: translateUserEditsToBlueprint(piece.userEditOperations),
+		excludeDuringPartKeepalive: piece.excludeDuringPartKeepalive,
 	}
 
 	return obj

--- a/packages/job-worker/src/playout/timeline/__tests__/__snapshots__/rundown.test.ts.snap
+++ b/packages/job-worker/src/playout/timeline/__tests__/__snapshots__/rundown.test.ts.snap
@@ -1,0 +1,2350 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`buildTimelineObjsForRundown current and previous parts 1`] = `
+{
+  "timeline": [
+    {
+      "classes": [
+        "rundown_active",
+        "last_part",
+      ],
+      "enable": {
+        "while": 1,
+      },
+      "id": "mockPlaylist_status",
+      "layer": "rundown_status",
+      "partInstanceId": null,
+      "priority": 0,
+    },
+    {
+      "children": [
+        {
+          "classes": [
+            "previous_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece9",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece9.end + 0",
+            "start": "#piece_group_control_piece9.start - 0",
+          },
+          "id": "piece_group_piece9",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "end": "#part_group_part0.start + 0",
+        "start": 1235,
+      },
+      "id": "part_group_part9",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part9",
+      "priority": -1,
+    },
+    {
+      "children": [
+        {
+          "enable": {
+            "start": 0,
+          },
+          "id": "part_group_firstobject_part0",
+          "layer": "group_first_object",
+          "partInstanceId": "part0",
+          "priority": 0,
+        },
+        {
+          "classes": [
+            "current_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece0",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece0.end + 0",
+            "start": "#piece_group_control_piece0.start - 0",
+          },
+          "id": "piece_group_piece0",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "start": "now",
+      },
+      "id": "part_group_part0",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+  ],
+  "timingContext": {
+    "currentPartDuration": undefined,
+    "currentPartGroup": {
+      "children": 3,
+      "content": {
+        "deviceType": "ABSTRACT",
+        "objects": [],
+        "type": "group",
+      },
+      "enable": {
+        "start": "now",
+      },
+      "id": "part_group_part0",
+      "isGroup": true,
+      "layer": "",
+      "metaData": {
+        "isPieceTimeline": true,
+      },
+      "objectType": "rundown",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+    "nextPartGroup": undefined,
+    "previousPartOverlap": 0,
+  },
+}
+`;
+
+exports[`buildTimelineObjsForRundown current part with startedPlayback 1`] = `
+{
+  "timeline": [
+    {
+      "classes": [
+        "rundown_active",
+        "last_part",
+      ],
+      "enable": {
+        "while": 1,
+      },
+      "id": "mockPlaylist_status",
+      "layer": "rundown_status",
+      "partInstanceId": null,
+      "priority": 0,
+    },
+    {
+      "children": [
+        {
+          "enable": {
+            "start": 0,
+          },
+          "id": "part_group_firstobject_part0",
+          "layer": "group_first_object",
+          "partInstanceId": "part0",
+          "priority": 0,
+        },
+        {
+          "classes": [
+            "current_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece0",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece0.end + 0",
+            "start": "#piece_group_control_piece0.start - 0",
+          },
+          "id": "piece_group_piece0",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "start": 5678,
+      },
+      "id": "part_group_part0",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+  ],
+  "timingContext": {
+    "currentPartDuration": undefined,
+    "currentPartGroup": {
+      "children": 3,
+      "content": {
+        "deviceType": "ABSTRACT",
+        "objects": [],
+        "type": "group",
+      },
+      "enable": {
+        "start": 5678,
+      },
+      "id": "part_group_part0",
+      "isGroup": true,
+      "layer": "",
+      "metaData": {
+        "isPieceTimeline": true,
+      },
+      "objectType": "rundown",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+    "nextPartGroup": undefined,
+  },
+}
+`;
+
+exports[`buildTimelineObjsForRundown infinite pieces infinite continuing from previous 1`] = `
+{
+  "timeline": [
+    {
+      "classes": [
+        "rundown_active",
+        "last_part",
+      ],
+      "enable": {
+        "while": 1,
+      },
+      "id": "mockPlaylist_status",
+      "layer": "rundown_status",
+      "partInstanceId": null,
+      "priority": 0,
+    },
+    {
+      "children": [
+        {
+          "classes": [
+            "previous_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece9",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece9.end + 0",
+            "start": "#piece_group_control_piece9.start - 0",
+          },
+          "id": "piece_group_piece9",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "end": "#part_group_part0.start + 0",
+        "start": 1235,
+      },
+      "id": "part_group_part9",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part9",
+      "priority": -1,
+    },
+    {
+      "children": [
+        {
+          "classes": [
+            "current_part",
+            "continues_infinite",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece6b",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece6b.end + 0",
+            "start": "#piece_group_control_piece6b.start - 0",
+          },
+          "id": "piece_group_piece6b",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "start": 123,
+      },
+      "id": "part_group_piece6b_infinite",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part0",
+      "priority": 1,
+    },
+    {
+      "children": [
+        {
+          "enable": {
+            "start": 0,
+          },
+          "id": "part_group_firstobject_part0",
+          "layer": "group_first_object",
+          "partInstanceId": "part0",
+          "priority": 0,
+        },
+        {
+          "classes": [
+            "current_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece0",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece0.end + 0",
+            "start": "#piece_group_control_piece0.start - 0",
+          },
+          "id": "piece_group_piece0",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "start": "now",
+      },
+      "id": "part_group_part0",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+  ],
+  "timingContext": {
+    "currentPartDuration": undefined,
+    "currentPartGroup": {
+      "children": 3,
+      "content": {
+        "deviceType": "ABSTRACT",
+        "objects": [],
+        "type": "group",
+      },
+      "enable": {
+        "start": "now",
+      },
+      "id": "part_group_part0",
+      "isGroup": true,
+      "layer": "",
+      "metaData": {
+        "isPieceTimeline": true,
+      },
+      "objectType": "rundown",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+    "nextPartGroup": undefined,
+    "previousPartOverlap": 0,
+  },
+}
+`;
+
+exports[`buildTimelineObjsForRundown infinite pieces infinite continuing into next with autonext 1`] = `
+{
+  "timeline": [
+    {
+      "classes": [
+        "rundown_active",
+      ],
+      "enable": {
+        "while": 1,
+      },
+      "id": "mockPlaylist_status",
+      "layer": "rundown_status",
+      "partInstanceId": null,
+      "priority": 0,
+    },
+    {
+      "children": [
+        {
+          "classes": [
+            "current_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece6",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece6.end + 0",
+            "start": "#piece_group_control_piece6.start - 0",
+          },
+          "id": "piece_group_piece6",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "start": 123,
+      },
+      "id": "part_group_piece6_infinite",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part0",
+      "priority": 1,
+    },
+    {
+      "children": [
+        {
+          "enable": {
+            "start": 0,
+          },
+          "id": "part_group_firstobject_part0",
+          "layer": "group_first_object",
+          "partInstanceId": "part0",
+          "priority": 0,
+        },
+        {
+          "classes": [
+            "current_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece0",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece0.end + 0",
+            "start": "#piece_group_control_piece0.start - 0",
+          },
+          "id": "piece_group_piece0",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "duration": 5000,
+        "start": 1235,
+      },
+      "id": "part_group_part0",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+    {
+      "children": [
+        {
+          "enable": {
+            "start": 0,
+          },
+          "id": "part_group_firstobject_part1",
+          "layer": "group_first_object",
+          "partInstanceId": "part1",
+          "priority": 0,
+        },
+        {
+          "classes": [
+            "next_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece1",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece1.end + 0",
+            "start": "#piece_group_control_piece1.start - 0",
+          },
+          "id": "piece_group_piece1",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "start": "#part_group_part0.end - 0",
+      },
+      "id": "part_group_part1",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part1",
+      "priority": 5,
+    },
+  ],
+  "timingContext": {
+    "currentPartDuration": 5000,
+    "currentPartGroup": {
+      "children": 3,
+      "content": {
+        "deviceType": "ABSTRACT",
+        "objects": [],
+        "type": "group",
+      },
+      "enable": {
+        "duration": 5000,
+        "start": 1235,
+      },
+      "id": "part_group_part0",
+      "isGroup": true,
+      "layer": "",
+      "metaData": {
+        "isPieceTimeline": true,
+      },
+      "objectType": "rundown",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+    "nextPartGroup": {
+      "children": 3,
+      "content": {
+        "deviceType": "ABSTRACT",
+        "objects": [],
+        "type": "group",
+      },
+      "enable": {
+        "start": "#part_group_part0.end - 0",
+      },
+      "id": "part_group_part1",
+      "isGroup": true,
+      "layer": "",
+      "metaData": {
+        "isPieceTimeline": true,
+      },
+      "objectType": "rundown",
+      "partInstanceId": "part1",
+      "priority": 5,
+    },
+    "nextPartOverlap": 0,
+  },
+}
+`;
+
+exports[`buildTimelineObjsForRundown infinite pieces infinite ending with previous 1`] = `
+{
+  "timeline": [
+    {
+      "classes": [
+        "rundown_active",
+        "last_part",
+      ],
+      "enable": {
+        "while": 1,
+      },
+      "id": "mockPlaylist_status",
+      "layer": "rundown_status",
+      "partInstanceId": null,
+      "priority": 0,
+    },
+    {
+      "children": [
+        {
+          "classes": [
+            "previous_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece9",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece9.end + 0",
+            "start": "#piece_group_control_piece9.start - 0",
+          },
+          "id": "piece_group_piece9",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+        {
+          "classes": [
+            "previous_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece6",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece6.end + 0",
+            "start": "#piece_group_control_piece6.start - 0",
+          },
+          "id": "piece_group_piece6",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "end": "#part_group_part0.start + 0",
+        "start": 1235,
+      },
+      "id": "part_group_part9",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part9",
+      "priority": -1,
+    },
+    {
+      "children": [
+        {
+          "enable": {
+            "start": 0,
+          },
+          "id": "part_group_firstobject_part0",
+          "layer": "group_first_object",
+          "partInstanceId": "part0",
+          "priority": 0,
+        },
+        {
+          "classes": [
+            "current_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece0",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece0.end + 0",
+            "start": "#piece_group_control_piece0.start - 0",
+          },
+          "id": "piece_group_piece0",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "start": "now",
+      },
+      "id": "part_group_part0",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+  ],
+  "timingContext": {
+    "currentPartDuration": undefined,
+    "currentPartGroup": {
+      "children": 3,
+      "content": {
+        "deviceType": "ABSTRACT",
+        "objects": [],
+        "type": "group",
+      },
+      "enable": {
+        "start": "now",
+      },
+      "id": "part_group_part0",
+      "isGroup": true,
+      "layer": "",
+      "metaData": {
+        "isPieceTimeline": true,
+      },
+      "objectType": "rundown",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+    "nextPartGroup": undefined,
+    "previousPartOverlap": 0,
+  },
+}
+`;
+
+exports[`buildTimelineObjsForRundown infinite pieces infinite ending with previous excludeDuringPartKeepalive=true 1`] = `
+{
+  "timeline": [
+    {
+      "classes": [
+        "rundown_active",
+        "last_part",
+      ],
+      "enable": {
+        "while": 1,
+      },
+      "id": "mockPlaylist_status",
+      "layer": "rundown_status",
+      "partInstanceId": null,
+      "priority": 0,
+    },
+    {
+      "children": [
+        {
+          "classes": [
+            "previous_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece9",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece9.end + 0",
+            "start": "#piece_group_control_piece9.start - 0",
+          },
+          "id": "piece_group_piece9",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+        {
+          "children": [
+            {
+              "classes": [
+                "previous_part",
+              ],
+              "enable": {
+                "start": 0,
+              },
+              "id": "piece_group_control_piece6",
+              "isPieceTimeline": true,
+              "priority": 5,
+            },
+            {
+              "children": [],
+              "enable": {
+                "end": "#piece_group_control_piece6.end + 0",
+                "start": "#piece_group_control_piece6.start - 0",
+              },
+              "id": "piece_group_piece6",
+              "isPieceTimeline": true,
+              "layer": "",
+              "priority": 0,
+            },
+          ],
+          "enable": {
+            "end": "#part_group_part9.end - 0",
+            "start": 0,
+          },
+          "id": "part_group_part9_no_keepalive",
+          "isPieceTimeline": true,
+          "layer": "",
+          "partInstanceId": "part9",
+          "priority": 5,
+        },
+      ],
+      "enable": {
+        "end": "#part_group_part0.start + 0",
+        "start": 1235,
+      },
+      "id": "part_group_part9",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part9",
+      "priority": -1,
+    },
+    {
+      "children": [
+        {
+          "enable": {
+            "start": 0,
+          },
+          "id": "part_group_firstobject_part0",
+          "layer": "group_first_object",
+          "partInstanceId": "part0",
+          "priority": 0,
+        },
+        {
+          "classes": [
+            "current_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece0",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece0.end + 0",
+            "start": "#piece_group_control_piece0.start - 0",
+          },
+          "id": "piece_group_piece0",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "start": "now",
+      },
+      "id": "part_group_part0",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+  ],
+  "timingContext": {
+    "currentPartDuration": undefined,
+    "currentPartGroup": {
+      "children": 3,
+      "content": {
+        "deviceType": "ABSTRACT",
+        "objects": [],
+        "type": "group",
+      },
+      "enable": {
+        "start": "now",
+      },
+      "id": "part_group_part0",
+      "isGroup": true,
+      "layer": "",
+      "metaData": {
+        "isPieceTimeline": true,
+      },
+      "objectType": "rundown",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+    "nextPartGroup": undefined,
+    "previousPartOverlap": 0,
+  },
+}
+`;
+
+exports[`buildTimelineObjsForRundown infinite pieces infinite starting in current 1`] = `
+{
+  "timeline": [
+    {
+      "classes": [
+        "rundown_active",
+        "last_part",
+      ],
+      "enable": {
+        "while": 1,
+      },
+      "id": "mockPlaylist_status",
+      "layer": "rundown_status",
+      "partInstanceId": null,
+      "priority": 0,
+    },
+    {
+      "children": [
+        {
+          "classes": [
+            "previous_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece9",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece9.end + 0",
+            "start": "#piece_group_control_piece9.start - 0",
+          },
+          "id": "piece_group_piece9",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "end": "#part_group_part0.start + 0",
+        "start": 1235,
+      },
+      "id": "part_group_part9",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part9",
+      "priority": -1,
+    },
+    {
+      "children": [
+        {
+          "classes": [
+            "current_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece1",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece1.end + 0",
+            "start": "#piece_group_control_piece1.start - 0",
+          },
+          "id": "piece_group_piece1",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "start": "#part_group_part0.start",
+      },
+      "id": "part_group_piece1_infinite",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part0",
+      "priority": 1,
+    },
+    {
+      "children": [
+        {
+          "enable": {
+            "start": 0,
+          },
+          "id": "part_group_firstobject_part0",
+          "layer": "group_first_object",
+          "partInstanceId": "part0",
+          "priority": 0,
+        },
+        {
+          "classes": [
+            "current_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece0",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece0.end + 0",
+            "start": "#piece_group_control_piece0.start - 0",
+          },
+          "id": "piece_group_piece0",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "start": "now",
+      },
+      "id": "part_group_part0",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+  ],
+  "timingContext": {
+    "currentPartDuration": undefined,
+    "currentPartGroup": {
+      "children": 3,
+      "content": {
+        "deviceType": "ABSTRACT",
+        "objects": [],
+        "type": "group",
+      },
+      "enable": {
+        "start": "now",
+      },
+      "id": "part_group_part0",
+      "isGroup": true,
+      "layer": "",
+      "metaData": {
+        "isPieceTimeline": true,
+      },
+      "objectType": "rundown",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+    "nextPartGroup": undefined,
+    "previousPartOverlap": 0,
+  },
+}
+`;
+
+exports[`buildTimelineObjsForRundown infinite pieces infinite stopping in current with autonext 1`] = `
+{
+  "timeline": [
+    {
+      "classes": [
+        "rundown_active",
+      ],
+      "enable": {
+        "while": 1,
+      },
+      "id": "mockPlaylist_status",
+      "layer": "rundown_status",
+      "partInstanceId": null,
+      "priority": 0,
+    },
+    {
+      "children": [
+        {
+          "classes": [
+            "current_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece6",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece6.end + 0",
+            "start": "#piece_group_control_piece6.start - 0",
+          },
+          "id": "piece_group_piece6",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "end": "#part_group_part0.end + 0",
+        "start": 123,
+      },
+      "id": "part_group_piece6_infinite",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part0",
+      "priority": 1,
+    },
+    {
+      "children": [
+        {
+          "enable": {
+            "start": 0,
+          },
+          "id": "part_group_firstobject_part0",
+          "layer": "group_first_object",
+          "partInstanceId": "part0",
+          "priority": 0,
+        },
+        {
+          "classes": [
+            "current_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece0",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece0.end + 0",
+            "start": "#piece_group_control_piece0.start - 0",
+          },
+          "id": "piece_group_piece0",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "duration": 5000,
+        "start": 1235,
+      },
+      "id": "part_group_part0",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+    {
+      "children": [
+        {
+          "enable": {
+            "start": 0,
+          },
+          "id": "part_group_firstobject_part1",
+          "layer": "group_first_object",
+          "partInstanceId": "part1",
+          "priority": 0,
+        },
+        {
+          "classes": [
+            "next_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece1",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece1.end + 0",
+            "start": "#piece_group_control_piece1.start - 0",
+          },
+          "id": "piece_group_piece1",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "start": "#part_group_part0.end - 0",
+      },
+      "id": "part_group_part1",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part1",
+      "priority": 5,
+    },
+  ],
+  "timingContext": {
+    "currentPartDuration": 5000,
+    "currentPartGroup": {
+      "children": 3,
+      "content": {
+        "deviceType": "ABSTRACT",
+        "objects": [],
+        "type": "group",
+      },
+      "enable": {
+        "duration": 5000,
+        "start": 1235,
+      },
+      "id": "part_group_part0",
+      "isGroup": true,
+      "layer": "",
+      "metaData": {
+        "isPieceTimeline": true,
+      },
+      "objectType": "rundown",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+    "nextPartGroup": {
+      "children": 3,
+      "content": {
+        "deviceType": "ABSTRACT",
+        "objects": [],
+        "type": "group",
+      },
+      "enable": {
+        "start": "#part_group_part0.end - 0",
+      },
+      "id": "part_group_part1",
+      "isGroup": true,
+      "layer": "",
+      "metaData": {
+        "isPieceTimeline": true,
+      },
+      "objectType": "rundown",
+      "partInstanceId": "part1",
+      "priority": 5,
+    },
+    "nextPartOverlap": 0,
+  },
+}
+`;
+
+exports[`buildTimelineObjsForRundown infinite pieces infinite stopping in current with autonext excludeDuringPartKeepalive=true 1`] = `
+{
+  "timeline": [
+    {
+      "classes": [
+        "rundown_active",
+      ],
+      "enable": {
+        "while": 1,
+      },
+      "id": "mockPlaylist_status",
+      "layer": "rundown_status",
+      "partInstanceId": null,
+      "priority": 0,
+    },
+    {
+      "children": [
+        {
+          "classes": [
+            "current_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece6",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece6.end + 0",
+            "start": "#piece_group_control_piece6.start - 0",
+          },
+          "id": "piece_group_piece6",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "end": "#part_group_part0.end + -100",
+        "start": 123,
+      },
+      "id": "part_group_piece6_infinite",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part0",
+      "priority": 1,
+    },
+    {
+      "children": [
+        {
+          "enable": {
+            "start": 0,
+          },
+          "id": "part_group_firstobject_part0",
+          "layer": "group_first_object",
+          "partInstanceId": "part0",
+          "priority": 0,
+        },
+        {
+          "classes": [
+            "current_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece0",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece0.end + 0",
+            "start": "#piece_group_control_piece0.start - 0",
+          },
+          "id": "piece_group_piece0",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "duration": 5000,
+        "start": 1235,
+      },
+      "id": "part_group_part0",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+    {
+      "children": [
+        {
+          "enable": {
+            "start": 0,
+          },
+          "id": "part_group_firstobject_part1",
+          "layer": "group_first_object",
+          "partInstanceId": "part1",
+          "priority": 0,
+        },
+        {
+          "classes": [
+            "next_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece1",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece1.end + 0",
+            "start": "#piece_group_control_piece1.start - 0",
+          },
+          "id": "piece_group_piece1",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "start": "#part_group_part0.end - 0",
+      },
+      "id": "part_group_part1",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part1",
+      "priority": 5,
+    },
+  ],
+  "timingContext": {
+    "currentPartDuration": 5000,
+    "currentPartGroup": {
+      "children": 3,
+      "content": {
+        "deviceType": "ABSTRACT",
+        "objects": [],
+        "type": "group",
+      },
+      "enable": {
+        "duration": 5000,
+        "start": 1235,
+      },
+      "id": "part_group_part0",
+      "isGroup": true,
+      "layer": "",
+      "metaData": {
+        "isPieceTimeline": true,
+      },
+      "objectType": "rundown",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+    "nextPartGroup": {
+      "children": 3,
+      "content": {
+        "deviceType": "ABSTRACT",
+        "objects": [],
+        "type": "group",
+      },
+      "enable": {
+        "start": "#part_group_part0.end - 0",
+      },
+      "id": "part_group_part1",
+      "isGroup": true,
+      "layer": "",
+      "metaData": {
+        "isPieceTimeline": true,
+      },
+      "objectType": "rundown",
+      "partInstanceId": "part1",
+      "priority": 5,
+    },
+    "nextPartOverlap": 0,
+  },
+}
+`;
+
+exports[`buildTimelineObjsForRundown next part no autonext 1`] = `
+{
+  "timeline": [
+    {
+      "classes": [
+        "rundown_active",
+      ],
+      "enable": {
+        "while": 1,
+      },
+      "id": "mockPlaylist_status",
+      "layer": "rundown_status",
+      "partInstanceId": null,
+      "priority": 0,
+    },
+    {
+      "children": [
+        {
+          "enable": {
+            "start": 0,
+          },
+          "id": "part_group_firstobject_part0",
+          "layer": "group_first_object",
+          "partInstanceId": "part0",
+          "priority": 0,
+        },
+        {
+          "classes": [
+            "current_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece0",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece0.end + 0",
+            "start": "#piece_group_control_piece0.start - 0",
+          },
+          "id": "piece_group_piece0",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "start": "now",
+      },
+      "id": "part_group_part0",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+  ],
+  "timingContext": {
+    "currentPartDuration": undefined,
+    "currentPartGroup": {
+      "children": 3,
+      "content": {
+        "deviceType": "ABSTRACT",
+        "objects": [],
+        "type": "group",
+      },
+      "enable": {
+        "start": "now",
+      },
+      "id": "part_group_part0",
+      "isGroup": true,
+      "layer": "",
+      "metaData": {
+        "isPieceTimeline": true,
+      },
+      "objectType": "rundown",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+    "nextPartGroup": undefined,
+  },
+}
+`;
+
+exports[`buildTimelineObjsForRundown next part with autonext 1`] = `
+{
+  "timeline": [
+    {
+      "classes": [
+        "rundown_active",
+      ],
+      "enable": {
+        "while": 1,
+      },
+      "id": "mockPlaylist_status",
+      "layer": "rundown_status",
+      "partInstanceId": null,
+      "priority": 0,
+    },
+    {
+      "children": [
+        {
+          "enable": {
+            "start": 0,
+          },
+          "id": "part_group_firstobject_part0",
+          "layer": "group_first_object",
+          "partInstanceId": "part0",
+          "priority": 0,
+        },
+        {
+          "classes": [
+            "current_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece0",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece0.end + 0",
+            "start": "#piece_group_control_piece0.start - 0",
+          },
+          "id": "piece_group_piece0",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "duration": 5000,
+        "start": "now",
+      },
+      "id": "part_group_part0",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+    {
+      "children": [
+        {
+          "enable": {
+            "start": 0,
+          },
+          "id": "part_group_firstobject_part1",
+          "layer": "group_first_object",
+          "partInstanceId": "part1",
+          "priority": 0,
+        },
+        {
+          "classes": [
+            "next_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece1",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece1.end + 0",
+            "start": "#piece_group_control_piece1.start - 0",
+          },
+          "id": "piece_group_piece1",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "start": "#part_group_part0.end - 0",
+      },
+      "id": "part_group_part1",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part1",
+      "priority": 5,
+    },
+  ],
+  "timingContext": {
+    "currentPartDuration": 5000,
+    "currentPartGroup": {
+      "children": 3,
+      "content": {
+        "deviceType": "ABSTRACT",
+        "objects": [],
+        "type": "group",
+      },
+      "enable": {
+        "duration": 5000,
+        "start": "now",
+      },
+      "id": "part_group_part0",
+      "isGroup": true,
+      "layer": "",
+      "metaData": {
+        "isPieceTimeline": true,
+      },
+      "objectType": "rundown",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+    "nextPartGroup": {
+      "children": 3,
+      "content": {
+        "deviceType": "ABSTRACT",
+        "objects": [],
+        "type": "group",
+      },
+      "enable": {
+        "start": "#part_group_part0.end - 0",
+      },
+      "id": "part_group_part1",
+      "isGroup": true,
+      "layer": "",
+      "metaData": {
+        "isPieceTimeline": true,
+      },
+      "objectType": "rundown",
+      "partInstanceId": "part1",
+      "priority": 5,
+    },
+    "nextPartOverlap": 0,
+  },
+}
+`;
+
+exports[`buildTimelineObjsForRundown overlap and keepalive autonext into next part 1`] = `
+{
+  "timeline": [
+    {
+      "classes": [
+        "rundown_active",
+      ],
+      "enable": {
+        "while": 1,
+      },
+      "id": "mockPlaylist_status",
+      "layer": "rundown_status",
+      "partInstanceId": null,
+      "priority": 0,
+    },
+    {
+      "children": [
+        {
+          "enable": {
+            "start": 0,
+          },
+          "id": "part_group_firstobject_part0",
+          "layer": "group_first_object",
+          "partInstanceId": "part0",
+          "priority": 0,
+        },
+        {
+          "classes": [
+            "current_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece0",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece0.end + 0",
+            "start": "#piece_group_control_piece0.start - 0",
+          },
+          "id": "piece_group_piece0",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "duration": 5000,
+        "start": "now",
+      },
+      "id": "part_group_part0",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+    {
+      "children": [
+        {
+          "enable": {
+            "start": 0,
+          },
+          "id": "part_group_firstobject_part1",
+          "layer": "group_first_object",
+          "partInstanceId": "part1",
+          "priority": 0,
+        },
+        {
+          "classes": [
+            "next_part",
+          ],
+          "enable": {
+            "start": 500,
+          },
+          "id": "piece_group_control_piece1",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece1.end + 0",
+            "start": "#piece_group_control_piece1.start - 0",
+          },
+          "id": "piece_group_piece1",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "start": "#part_group_part0.end - 900",
+      },
+      "id": "part_group_part1",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part1",
+      "priority": 5,
+    },
+  ],
+  "timingContext": {
+    "currentPartDuration": 5000,
+    "currentPartGroup": {
+      "children": 3,
+      "content": {
+        "deviceType": "ABSTRACT",
+        "objects": [],
+        "type": "group",
+      },
+      "enable": {
+        "duration": 5000,
+        "start": "now",
+      },
+      "id": "part_group_part0",
+      "isGroup": true,
+      "layer": "",
+      "metaData": {
+        "isPieceTimeline": true,
+      },
+      "objectType": "rundown",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+    "nextPartGroup": {
+      "children": 3,
+      "content": {
+        "deviceType": "ABSTRACT",
+        "objects": [],
+        "type": "group",
+      },
+      "enable": {
+        "start": "#part_group_part0.end - 900",
+      },
+      "id": "part_group_part1",
+      "isGroup": true,
+      "layer": "",
+      "metaData": {
+        "isPieceTimeline": true,
+      },
+      "objectType": "rundown",
+      "partInstanceId": "part1",
+      "priority": 5,
+    },
+    "nextPartOverlap": 900,
+  },
+}
+`;
+
+exports[`buildTimelineObjsForRundown overlap and keepalive autonext into next part with excludeDuringPartKeepalive 1`] = `
+{
+  "timeline": [
+    {
+      "classes": [
+        "rundown_active",
+      ],
+      "enable": {
+        "while": 1,
+      },
+      "id": "mockPlaylist_status",
+      "layer": "rundown_status",
+      "partInstanceId": null,
+      "priority": 0,
+    },
+    {
+      "children": [
+        {
+          "enable": {
+            "start": 0,
+          },
+          "id": "part_group_firstobject_part0",
+          "layer": "group_first_object",
+          "partInstanceId": "part0",
+          "priority": 0,
+        },
+        {
+          "classes": [
+            "current_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece0",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece0.end + 0",
+            "start": "#piece_group_control_piece0.start - 0",
+          },
+          "id": "piece_group_piece0",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+        {
+          "children": [
+            {
+              "classes": [
+                "current_part",
+              ],
+              "enable": {
+                "start": 0,
+              },
+              "id": "piece_group_control_piece9",
+              "isPieceTimeline": true,
+              "priority": 5,
+            },
+            {
+              "children": [],
+              "enable": {
+                "end": "#piece_group_control_piece9.end + 0",
+                "start": "#piece_group_control_piece9.start - 0",
+              },
+              "id": "piece_group_piece9",
+              "isPieceTimeline": true,
+              "layer": "",
+              "priority": 0,
+            },
+          ],
+          "enable": {
+            "end": "#part_group_part0.end - 100",
+            "start": 0,
+          },
+          "id": "part_group_part0_no_keepalive",
+          "isPieceTimeline": true,
+          "layer": "",
+          "partInstanceId": "part0",
+          "priority": 5,
+        },
+      ],
+      "enable": {
+        "duration": 5000,
+        "start": 1235,
+      },
+      "id": "part_group_part0",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+    {
+      "children": [
+        {
+          "enable": {
+            "start": 0,
+          },
+          "id": "part_group_firstobject_part1",
+          "layer": "group_first_object",
+          "partInstanceId": "part1",
+          "priority": 0,
+        },
+        {
+          "classes": [
+            "next_part",
+          ],
+          "enable": {
+            "start": 500,
+          },
+          "id": "piece_group_control_piece1",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece1.end + 0",
+            "start": "#piece_group_control_piece1.start - 0",
+          },
+          "id": "piece_group_piece1",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "start": "#part_group_part0.end - 900",
+      },
+      "id": "part_group_part1",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part1",
+      "priority": 5,
+    },
+  ],
+  "timingContext": {
+    "currentPartDuration": 5000,
+    "currentPartGroup": {
+      "children": 4,
+      "content": {
+        "deviceType": "ABSTRACT",
+        "objects": [],
+        "type": "group",
+      },
+      "enable": {
+        "duration": 5000,
+        "start": 1235,
+      },
+      "id": "part_group_part0",
+      "isGroup": true,
+      "layer": "",
+      "metaData": {
+        "isPieceTimeline": true,
+      },
+      "objectType": "rundown",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+    "nextPartGroup": {
+      "children": 3,
+      "content": {
+        "deviceType": "ABSTRACT",
+        "objects": [],
+        "type": "group",
+      },
+      "enable": {
+        "start": "#part_group_part0.end - 900",
+      },
+      "id": "part_group_part1",
+      "isGroup": true,
+      "layer": "",
+      "metaData": {
+        "isPieceTimeline": true,
+      },
+      "objectType": "rundown",
+      "partInstanceId": "part1",
+      "priority": 5,
+    },
+    "nextPartOverlap": 900,
+  },
+}
+`;
+
+exports[`buildTimelineObjsForRundown overlap and keepalive current and previous parts 1`] = `
+{
+  "timeline": [
+    {
+      "classes": [
+        "rundown_active",
+        "last_part",
+      ],
+      "enable": {
+        "while": 1,
+      },
+      "id": "mockPlaylist_status",
+      "layer": "rundown_status",
+      "partInstanceId": null,
+      "priority": 0,
+    },
+    {
+      "children": [
+        {
+          "classes": [
+            "previous_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece9",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece9.end + 0",
+            "start": "#piece_group_control_piece9.start - 0",
+          },
+          "id": "piece_group_piece9",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+        {
+          "classes": [
+            "previous_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece8",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece8.end + 0",
+            "start": "#piece_group_control_piece8.start - 0",
+          },
+          "id": "piece_group_piece8",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "end": "#part_group_part0.start + 900",
+        "start": 1235,
+      },
+      "id": "part_group_part9",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part9",
+      "priority": -1,
+    },
+    {
+      "children": [
+        {
+          "enable": {
+            "start": 0,
+          },
+          "id": "part_group_firstobject_part0",
+          "layer": "group_first_object",
+          "partInstanceId": "part0",
+          "priority": 0,
+        },
+        {
+          "classes": [
+            "current_part",
+          ],
+          "enable": {
+            "start": 500,
+          },
+          "id": "piece_group_control_piece0",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece0.end + 0",
+            "start": "#piece_group_control_piece0.start - 0",
+          },
+          "id": "piece_group_piece0",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "start": "now",
+      },
+      "id": "part_group_part0",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+  ],
+  "timingContext": {
+    "currentPartDuration": undefined,
+    "currentPartGroup": {
+      "children": 3,
+      "content": {
+        "deviceType": "ABSTRACT",
+        "objects": [],
+        "type": "group",
+      },
+      "enable": {
+        "start": "now",
+      },
+      "id": "part_group_part0",
+      "isGroup": true,
+      "layer": "",
+      "metaData": {
+        "isPieceTimeline": true,
+      },
+      "objectType": "rundown",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+    "nextPartGroup": undefined,
+    "previousPartOverlap": 900,
+  },
+}
+`;
+
+exports[`buildTimelineObjsForRundown overlap and keepalive current and previous parts with excludeDuringPartKeepalive 1`] = `
+{
+  "timeline": [
+    {
+      "classes": [
+        "rundown_active",
+        "last_part",
+      ],
+      "enable": {
+        "while": 1,
+      },
+      "id": "mockPlaylist_status",
+      "layer": "rundown_status",
+      "partInstanceId": null,
+      "priority": 0,
+    },
+    {
+      "children": [
+        {
+          "classes": [
+            "previous_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece9",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece9.end + 0",
+            "start": "#piece_group_control_piece9.start - 0",
+          },
+          "id": "piece_group_piece9",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+        {
+          "children": [
+            {
+              "classes": [
+                "previous_part",
+              ],
+              "enable": {
+                "start": 0,
+              },
+              "id": "piece_group_control_piece8",
+              "isPieceTimeline": true,
+              "priority": 5,
+            },
+            {
+              "children": [],
+              "enable": {
+                "end": "#piece_group_control_piece8.end + 0",
+                "start": "#piece_group_control_piece8.start - 0",
+              },
+              "id": "piece_group_piece8",
+              "isPieceTimeline": true,
+              "layer": "",
+              "priority": 0,
+            },
+          ],
+          "enable": {
+            "end": "#part_group_part9.end - 100",
+            "start": 0,
+          },
+          "id": "part_group_part9_no_keepalive",
+          "isPieceTimeline": true,
+          "layer": "",
+          "partInstanceId": "part9",
+          "priority": 5,
+        },
+      ],
+      "enable": {
+        "end": "#part_group_part0.start + 900",
+        "start": 1235,
+      },
+      "id": "part_group_part9",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part9",
+      "priority": -1,
+    },
+    {
+      "children": [
+        {
+          "enable": {
+            "start": 0,
+          },
+          "id": "part_group_firstobject_part0",
+          "layer": "group_first_object",
+          "partInstanceId": "part0",
+          "priority": 0,
+        },
+        {
+          "classes": [
+            "current_part",
+          ],
+          "enable": {
+            "start": 500,
+          },
+          "id": "piece_group_control_piece0",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece0.end + 0",
+            "start": "#piece_group_control_piece0.start - 0",
+          },
+          "id": "piece_group_piece0",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "start": "now",
+      },
+      "id": "part_group_part0",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+  ],
+  "timingContext": {
+    "currentPartDuration": undefined,
+    "currentPartGroup": {
+      "children": 3,
+      "content": {
+        "deviceType": "ABSTRACT",
+        "objects": [],
+        "type": "group",
+      },
+      "enable": {
+        "start": "now",
+      },
+      "id": "part_group_part0",
+      "isGroup": true,
+      "layer": "",
+      "metaData": {
+        "isPieceTimeline": true,
+      },
+      "objectType": "rundown",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+    "nextPartGroup": undefined,
+    "previousPartOverlap": 900,
+  },
+}
+`;
+
+exports[`buildTimelineObjsForRundown simple current part 1`] = `
+{
+  "timeline": [
+    {
+      "classes": [
+        "rundown_active",
+        "last_part",
+      ],
+      "enable": {
+        "while": 1,
+      },
+      "id": "mockPlaylist_status",
+      "layer": "rundown_status",
+      "partInstanceId": null,
+      "priority": 0,
+    },
+    {
+      "children": [
+        {
+          "enable": {
+            "start": 0,
+          },
+          "id": "part_group_firstobject_part0",
+          "layer": "group_first_object",
+          "partInstanceId": "part0",
+          "priority": 0,
+        },
+        {
+          "classes": [
+            "current_part",
+          ],
+          "enable": {
+            "start": 0,
+          },
+          "id": "piece_group_control_piece0",
+          "isPieceTimeline": true,
+          "priority": 5,
+        },
+        {
+          "children": [],
+          "enable": {
+            "end": "#piece_group_control_piece0.end + 0",
+            "start": "#piece_group_control_piece0.start - 0",
+          },
+          "id": "piece_group_piece0",
+          "isPieceTimeline": true,
+          "layer": "",
+          "priority": 0,
+        },
+      ],
+      "enable": {
+        "start": "now",
+      },
+      "id": "part_group_part0",
+      "isPieceTimeline": true,
+      "layer": "",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+  ],
+  "timingContext": {
+    "currentPartDuration": undefined,
+    "currentPartGroup": {
+      "children": 3,
+      "content": {
+        "deviceType": "ABSTRACT",
+        "objects": [],
+        "type": "group",
+      },
+      "enable": {
+        "start": "now",
+      },
+      "id": "part_group_part0",
+      "isGroup": true,
+      "layer": "",
+      "metaData": {
+        "isPieceTimeline": true,
+      },
+      "objectType": "rundown",
+      "partInstanceId": "part0",
+      "priority": 5,
+    },
+    "nextPartGroup": undefined,
+  },
+}
+`;

--- a/packages/job-worker/src/playout/timeline/__tests__/rundown.test.ts
+++ b/packages/job-worker/src/playout/timeline/__tests__/rundown.test.ts
@@ -1,0 +1,853 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { DBRundownPlaylist, SelectedPartInstance } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
+import { setupDefaultJobEnvironment } from '../../../__mocks__/context'
+import { buildTimelineObjsForRundown, RundownTimelineResult, RundownTimelineTimingContext } from '../rundown'
+import { protectString } from '@sofie-automation/corelib/dist/protectedString'
+import { SelectedPartInstancesTimelineInfo, SelectedPartInstanceTimelineInfo } from '../generate'
+import { PartCalculatedTimings } from '@sofie-automation/corelib/dist/playout/timings'
+import { DBPartInstance } from '@sofie-automation/corelib/dist/dataModel/PartInstance'
+import { DBPart } from '@sofie-automation/corelib/dist/dataModel/Part'
+import { transformTimeline } from '@sofie-automation/corelib/dist/playout/timeline'
+import { deleteAllUndefinedProperties, getRandomId } from '@sofie-automation/corelib/dist/lib'
+import { PieceInstance, PieceInstancePiece } from '@sofie-automation/corelib/dist/dataModel/PieceInstance'
+import { PieceInstanceWithTimings } from '@sofie-automation/corelib/dist/playout/processAndPrune'
+import { EmptyPieceTimelineObjectsBlob } from '@sofie-automation/corelib/dist/dataModel/Piece'
+import { IBlueprintPieceType, PieceLifespan } from '@sofie-automation/blueprints-integration'
+import { getPartGroupId } from '@sofie-automation/corelib/dist/playout/ids'
+
+const DEFAULT_PART_TIMINGS: PartCalculatedTimings = Object.freeze({
+	inTransitionStart: null,
+	toPartDelay: 0,
+	toPartPostroll: 0,
+	fromPartRemaining: 0,
+	fromPartPostroll: 0,
+	fromPartKeepalive: 0,
+})
+
+function transformTimelineIntoSimplifiedForm(res: RundownTimelineResult) {
+	const deepTimeline = transformTimeline(res.timeline)
+
+	function simplifyTimelineObject(obj: any): any {
+		const newObj = {
+			id: obj.id,
+			enable: obj.enable,
+			layer: obj.layer,
+			partInstanceId: obj.partInstanceId,
+			priority: obj.priority,
+			children: obj.children?.map(simplifyTimelineObject),
+			isPieceTimeline: obj.metaData?.isPieceTimeline,
+			classes: obj.classes?.length > 0 ? obj.classes : undefined,
+		}
+
+		deleteAllUndefinedProperties(newObj)
+
+		return newObj
+	}
+
+	return {
+		timeline: deepTimeline.map(simplifyTimelineObject),
+		timingContext: res.timingContext
+			? ({
+					...res.timingContext,
+					currentPartGroup: {
+						...res.timingContext.currentPartGroup,
+						children: res.timingContext.currentPartGroup.children.length as any,
+					},
+					nextPartGroup: res.timingContext.nextPartGroup
+						? {
+								...res.timingContext.nextPartGroup,
+								children: res.timingContext.nextPartGroup.children.length as any,
+						  }
+						: undefined,
+			  } satisfies RundownTimelineTimingContext)
+			: undefined,
+	}
+}
+
+/**
+ * This is a set of tests to get a general overview of the shape of the generated timeline.
+ * It is not intended to look in much detail at everything, it is expected that methods used
+ * inside of this will have their own tests to stress difference scenarios.
+ */
+describe('buildTimelineObjsForRundown', () => {
+	function createMockPlaylist(selectedPartInfos: SelectedPartInstancesTimelineInfo): DBRundownPlaylist {
+		function convertSelectedPartInstance(
+			info: SelectedPartInstanceTimelineInfo | undefined
+		): SelectedPartInstance | null {
+			if (!info) return null
+			return {
+				partInstanceId: info.partInstance._id,
+				rundownId: info.partInstance.rundownId,
+				manuallySelected: false,
+				consumesQueuedSegmentId: false,
+			}
+		}
+		return {
+			_id: protectString('mockPlaylist'),
+			nextPartInfo: convertSelectedPartInstance(selectedPartInfos.next),
+			currentPartInfo: convertSelectedPartInstance(selectedPartInfos.current),
+			previousPartInfo: convertSelectedPartInstance(selectedPartInfos.previous),
+			activationId: protectString('mockActivationId'),
+			rehearsal: false,
+		} as Partial<DBRundownPlaylist> as any
+	}
+	function createMockPartInstance(
+		id: string,
+		partProps?: Partial<DBPart>,
+		partInstanceProps?: Partial<DBPartInstance>
+	): DBPartInstance {
+		return {
+			_id: protectString(id),
+			part: {
+				...partProps,
+			} as Partial<DBPart> as any,
+			...partInstanceProps,
+		} as Partial<DBPartInstance> as any
+	}
+	function createMockPieceInstance(
+		id: string,
+		pieceProps?: Partial<PieceInstancePiece>,
+		pieceInstanceProps?: Partial<PieceInstance>
+	): PieceInstanceWithTimings {
+		return {
+			_id: protectString(id),
+
+			piece: {
+				enable: { start: 0 },
+				pieceType: IBlueprintPieceType.Normal,
+				timelineObjectsString: EmptyPieceTimelineObjectsBlob,
+				...pieceProps,
+			} as Partial<PieceInstancePiece> as any,
+
+			resolvedEndCap: undefined,
+			priority: 5,
+
+			...pieceInstanceProps,
+		} as Partial<PieceInstanceWithTimings> as any
+	}
+	function createMockInfinitePieceInstance(
+		id: string,
+		pieceProps?: Partial<PieceInstancePiece>,
+		pieceInstanceProps?: Partial<PieceInstance>,
+		infiniteIndex = 0
+	): PieceInstanceWithTimings {
+		return createMockPieceInstance(
+			id,
+			{
+				lifespan: PieceLifespan.OutOnSegmentEnd,
+				...pieceProps,
+			},
+			{
+				plannedStartedPlayback: 123,
+				...pieceInstanceProps,
+				infinite: {
+					infinitePieceId: getRandomId(),
+					infiniteInstanceId: getRandomId(),
+					infiniteInstanceIndex: infiniteIndex,
+					fromPreviousPart: infiniteIndex !== 0,
+				},
+			}
+		)
+	}
+	function continueInfinitePiece(piece: PieceInstanceWithTimings): PieceInstanceWithTimings {
+		if (!piece.infinite) throw new Error('Not an infinite piece!')
+		return {
+			...piece,
+			_id: protectString(piece._id + 'b'),
+			infinite: {
+				...piece.infinite,
+				fromPreviousPart: true,
+				infiniteInstanceIndex: piece.infinite.infiniteInstanceIndex + 1,
+			},
+		}
+	}
+
+	it('playlist with no parts', () => {
+		const context = setupDefaultJobEnvironment()
+
+		const selectedPartInfos: SelectedPartInstancesTimelineInfo = {}
+
+		const playlist = createMockPlaylist(selectedPartInfos)
+		const objs = buildTimelineObjsForRundown(context, playlist, selectedPartInfos)
+
+		expect(objs.timeline).toHaveLength(1)
+		expect(objs.timingContext).toBeUndefined()
+		expect(objs.timeline).toEqual([
+			{
+				classes: ['rundown_active', 'before_first_part', 'last_part'],
+				content: {
+					deviceType: 'ABSTRACT',
+				},
+				enable: {
+					while: 1,
+				},
+				id: 'mockPlaylist_status',
+				layer: 'rundown_status',
+				metaData: undefined,
+				objectType: 'rundown',
+				partInstanceId: null,
+				priority: 0,
+			},
+		])
+	})
+
+	it('with previous and but no current part', () => {
+		const context = setupDefaultJobEnvironment()
+
+		const selectedPartInfos: SelectedPartInstancesTimelineInfo = {
+			previous: {
+				nowInPart: 1234,
+				partStarted: 5678,
+				partInstance: createMockPartInstance('part0'),
+				pieceInstances: [],
+				calculatedTimings: DEFAULT_PART_TIMINGS,
+			},
+		}
+
+		const playlist = createMockPlaylist(selectedPartInfos)
+		const objs = buildTimelineObjsForRundown(context, playlist, selectedPartInfos)
+
+		expect(objs.timeline).toHaveLength(1)
+		expect(objs.timingContext).toBeUndefined()
+	})
+
+	it('simple current part', () => {
+		const context = setupDefaultJobEnvironment()
+
+		const selectedPartInfos: SelectedPartInstancesTimelineInfo = {
+			current: {
+				nowInPart: 1234,
+				partStarted: 5678,
+				partInstance: createMockPartInstance('part0'),
+				pieceInstances: [createMockPieceInstance('piece0')],
+				calculatedTimings: DEFAULT_PART_TIMINGS,
+			},
+		}
+
+		const playlist = createMockPlaylist(selectedPartInfos)
+		const objs = buildTimelineObjsForRundown(context, playlist, selectedPartInfos)
+
+		expect(objs.timeline).not.toHaveLength(0)
+		expect(objs.timingContext).not.toBeUndefined()
+		expect(transformTimelineIntoSimplifiedForm(objs)).toMatchSnapshot()
+
+		expect(objs.timingContext?.currentPartGroup.enable).toEqual({
+			start: 'now',
+		})
+	})
+
+	it('current part with startedPlayback', () => {
+		const context = setupDefaultJobEnvironment()
+
+		const selectedPartInfos: SelectedPartInstancesTimelineInfo = {
+			current: {
+				nowInPart: 1234,
+				partStarted: 5678,
+				partInstance: createMockPartInstance(
+					'part0',
+					{},
+					{
+						timings: {
+							plannedStartedPlayback: 5678,
+						},
+					}
+				),
+				pieceInstances: [createMockPieceInstance('piece0')],
+				calculatedTimings: DEFAULT_PART_TIMINGS,
+			},
+		}
+
+		const playlist = createMockPlaylist(selectedPartInfos)
+		const objs = buildTimelineObjsForRundown(context, playlist, selectedPartInfos)
+
+		expect(objs.timeline).not.toHaveLength(0)
+		expect(objs.timingContext).not.toBeUndefined()
+		expect(transformTimelineIntoSimplifiedForm(objs)).toMatchSnapshot()
+
+		expect(objs.timingContext?.currentPartGroup.enable).toEqual({
+			start: 5678,
+		})
+	})
+
+	it('next part no autonext', () => {
+		const context = setupDefaultJobEnvironment()
+
+		const selectedPartInfos: SelectedPartInstancesTimelineInfo = {
+			current: {
+				nowInPart: 1234,
+				partStarted: 5678,
+				partInstance: createMockPartInstance('part0'),
+				pieceInstances: [createMockPieceInstance('piece0')],
+				calculatedTimings: DEFAULT_PART_TIMINGS,
+			},
+			next: {
+				nowInPart: 0,
+				partStarted: undefined,
+				partInstance: createMockPartInstance('part1'),
+				pieceInstances: [createMockPieceInstance('piece1')],
+				calculatedTimings: DEFAULT_PART_TIMINGS,
+			},
+		}
+
+		const playlist = createMockPlaylist(selectedPartInfos)
+		const objs = buildTimelineObjsForRundown(context, playlist, selectedPartInfos)
+
+		expect(objs.timeline).not.toHaveLength(0)
+		expect(objs.timingContext).not.toBeUndefined()
+		expect(transformTimelineIntoSimplifiedForm(objs)).toMatchSnapshot()
+
+		// make sure the next part was not generated
+		expect(objs.timingContext?.nextPartGroup).toBeUndefined()
+		const nextPartGroupId = getPartGroupId(selectedPartInfos.next!.partInstance)
+		expect(objs.timeline.find((obj) => obj.id === nextPartGroupId)).toBeUndefined()
+	})
+
+	it('next part with autonext', () => {
+		const context = setupDefaultJobEnvironment()
+
+		const selectedPartInfos: SelectedPartInstancesTimelineInfo = {
+			current: {
+				nowInPart: 1234,
+				partStarted: 5678,
+				partInstance: createMockPartInstance('part0', { autoNext: true, expectedDuration: 5000 }),
+				pieceInstances: [createMockPieceInstance('piece0')],
+				calculatedTimings: DEFAULT_PART_TIMINGS,
+			},
+			next: {
+				nowInPart: 0,
+				partStarted: undefined,
+				partInstance: createMockPartInstance('part1'),
+				pieceInstances: [createMockPieceInstance('piece1')],
+				calculatedTimings: DEFAULT_PART_TIMINGS,
+			},
+		}
+
+		const playlist = createMockPlaylist(selectedPartInfos)
+		const objs = buildTimelineObjsForRundown(context, playlist, selectedPartInfos)
+
+		expect(objs.timeline).not.toHaveLength(0)
+		expect(objs.timingContext).toBeTruthy()
+		expect(transformTimelineIntoSimplifiedForm(objs)).toMatchSnapshot()
+
+		// make sure the next part was generated
+		expect(objs.timingContext?.nextPartGroup).toBeTruthy()
+		const nextPartGroupId = getPartGroupId(selectedPartInfos.next!.partInstance)
+		expect(objs.timeline.find((obj) => obj.id === nextPartGroupId)).toBeTruthy()
+	})
+
+	it('current and previous parts', () => {
+		const context = setupDefaultJobEnvironment()
+
+		const selectedPartInfos: SelectedPartInstancesTimelineInfo = {
+			previous: {
+				nowInPart: 9999,
+				partStarted: 1234,
+				partInstance: createMockPartInstance(
+					'part9',
+					{ autoNext: true, expectedDuration: 5000 },
+					{
+						timings: {
+							plannedStartedPlayback: 1235,
+						},
+					}
+				),
+				pieceInstances: [createMockPieceInstance('piece9')],
+				calculatedTimings: DEFAULT_PART_TIMINGS,
+			},
+			current: {
+				nowInPart: 1234,
+				partStarted: 5678,
+				partInstance: createMockPartInstance('part0'),
+				pieceInstances: [createMockPieceInstance('piece0')],
+				calculatedTimings: DEFAULT_PART_TIMINGS,
+			},
+		}
+
+		const playlist = createMockPlaylist(selectedPartInfos)
+		const objs = buildTimelineObjsForRundown(context, playlist, selectedPartInfos)
+
+		expect(objs.timeline).not.toHaveLength(0)
+		expect(objs.timingContext).not.toBeUndefined()
+		expect(transformTimelineIntoSimplifiedForm(objs)).toMatchSnapshot()
+
+		// make sure the previous part was generated
+		const previousPartGroupId = getPartGroupId(selectedPartInfos.previous!.partInstance)
+		expect(objs.timeline.find((obj) => obj.id === previousPartGroupId)).toBeTruthy()
+		expect(objs.timingContext?.previousPartOverlap).not.toBeUndefined()
+	})
+
+	describe('overlap and keepalive', () => {
+		it('current and previous parts', () => {
+			const context = setupDefaultJobEnvironment()
+
+			const selectedPartInfos: SelectedPartInstancesTimelineInfo = {
+				previous: {
+					nowInPart: 9999,
+					partStarted: 1234,
+					partInstance: createMockPartInstance(
+						'part9',
+						{ autoNext: true, expectedDuration: 5000 },
+						{
+							timings: {
+								plannedStartedPlayback: 1235,
+							},
+						}
+					),
+					pieceInstances: [createMockPieceInstance('piece9'), createMockPieceInstance('piece8')],
+					calculatedTimings: DEFAULT_PART_TIMINGS,
+				},
+				current: {
+					nowInPart: 1234,
+					partStarted: 5678,
+					partInstance: createMockPartInstance('part0'),
+					pieceInstances: [createMockPieceInstance('piece0')],
+					calculatedTimings: {
+						inTransitionStart: 200,
+						toPartDelay: 500,
+						toPartPostroll: 0,
+						fromPartRemaining: 500 + 400,
+						fromPartPostroll: 400,
+						fromPartKeepalive: 100,
+					},
+				},
+			}
+
+			const playlist = createMockPlaylist(selectedPartInfos)
+			const objs = buildTimelineObjsForRundown(context, playlist, selectedPartInfos)
+
+			expect(objs.timeline).not.toHaveLength(0)
+			expect(objs.timingContext).not.toBeUndefined()
+			expect(transformTimelineIntoSimplifiedForm(objs)).toMatchSnapshot()
+
+			// make sure the previous part was generated
+			const previousPartGroupId = getPartGroupId(selectedPartInfos.previous!.partInstance)
+			expect(objs.timeline.find((obj) => obj.id === previousPartGroupId)).toBeTruthy()
+			expect(objs.timingContext?.previousPartOverlap).not.toBeUndefined()
+		})
+
+		it('current and previous parts with excludeDuringPartKeepalive', () => {
+			const context = setupDefaultJobEnvironment()
+
+			const selectedPartInfos: SelectedPartInstancesTimelineInfo = {
+				previous: {
+					nowInPart: 9999,
+					partStarted: 1234,
+					partInstance: createMockPartInstance(
+						'part9',
+						{ autoNext: true, expectedDuration: 5000 },
+						{
+							timings: {
+								plannedStartedPlayback: 1235,
+							},
+						}
+					),
+					pieceInstances: [
+						createMockPieceInstance('piece9'),
+						createMockPieceInstance('piece8', {
+							excludeDuringPartKeepalive: true,
+						}),
+					],
+					calculatedTimings: DEFAULT_PART_TIMINGS,
+				},
+				current: {
+					nowInPart: 1234,
+					partStarted: 5678,
+					partInstance: createMockPartInstance('part0'),
+					pieceInstances: [createMockPieceInstance('piece0')],
+					calculatedTimings: {
+						inTransitionStart: 200,
+						toPartDelay: 500,
+						toPartPostroll: 0,
+						fromPartRemaining: 500 + 400,
+						fromPartPostroll: 400,
+						fromPartKeepalive: 100,
+					},
+				},
+			}
+
+			const playlist = createMockPlaylist(selectedPartInfos)
+			const objs = buildTimelineObjsForRundown(context, playlist, selectedPartInfos)
+
+			expect(objs.timeline).not.toHaveLength(0)
+			expect(objs.timingContext).not.toBeUndefined()
+			expect(transformTimelineIntoSimplifiedForm(objs)).toMatchSnapshot()
+
+			// make sure the previous part was generated
+			const previousPartGroupId = getPartGroupId(selectedPartInfos.previous!.partInstance)
+			expect(objs.timeline.find((obj) => obj.id === previousPartGroupId)).toBeTruthy()
+			expect(objs.timingContext?.previousPartOverlap).not.toBeUndefined()
+		})
+
+		it('autonext into next part', () => {
+			const context = setupDefaultJobEnvironment()
+
+			const selectedPartInfos: SelectedPartInstancesTimelineInfo = {
+				current: {
+					nowInPart: 1234,
+					partStarted: 5678,
+					partInstance: createMockPartInstance('part0', { autoNext: true, expectedDuration: 5000 }),
+					pieceInstances: [createMockPieceInstance('piece0')],
+					calculatedTimings: DEFAULT_PART_TIMINGS,
+				},
+				next: {
+					nowInPart: 0,
+					partStarted: undefined,
+					partInstance: createMockPartInstance('part1'),
+					pieceInstances: [createMockPieceInstance('piece1')],
+					calculatedTimings: {
+						inTransitionStart: 200,
+						toPartDelay: 500,
+						toPartPostroll: 0,
+						fromPartRemaining: 500 + 400,
+						fromPartPostroll: 400,
+						fromPartKeepalive: 100,
+					},
+				},
+			}
+
+			const playlist = createMockPlaylist(selectedPartInfos)
+			const objs = buildTimelineObjsForRundown(context, playlist, selectedPartInfos)
+
+			expect(objs.timeline).not.toHaveLength(0)
+			expect(objs.timingContext).toBeTruthy()
+			expect(transformTimelineIntoSimplifiedForm(objs)).toMatchSnapshot()
+
+			// make sure the next part was generated
+			expect(objs.timingContext?.nextPartGroup).toBeTruthy()
+			const nextPartGroupId = getPartGroupId(selectedPartInfos.next!.partInstance)
+			expect(objs.timeline.find((obj) => obj.id === nextPartGroupId)).toBeTruthy()
+		})
+
+		it('autonext into next part with excludeDuringPartKeepalive', () => {
+			const context = setupDefaultJobEnvironment()
+
+			jest.spyOn(global.Date, 'now').mockImplementation(() => 3000)
+
+			const selectedPartInfos: SelectedPartInstancesTimelineInfo = {
+				current: {
+					nowInPart: 1234,
+					partStarted: 5678,
+					partInstance: createMockPartInstance(
+						'part0',
+						{ autoNext: true, expectedDuration: 5000 },
+						{
+							timings: {
+								plannedStartedPlayback: 1235,
+							},
+						}
+					),
+					pieceInstances: [
+						createMockPieceInstance('piece0'),
+						createMockPieceInstance('piece9', {
+							excludeDuringPartKeepalive: true,
+						}),
+					],
+					calculatedTimings: DEFAULT_PART_TIMINGS,
+				},
+				next: {
+					nowInPart: 0,
+					partStarted: undefined,
+					partInstance: createMockPartInstance(
+						'part1',
+						{},
+						{
+							timings: {
+								plannedStartedPlayback: 5000,
+							},
+						}
+					),
+					pieceInstances: [createMockPieceInstance('piece1')],
+					calculatedTimings: {
+						inTransitionStart: 200,
+						toPartDelay: 500,
+						toPartPostroll: 0,
+						fromPartRemaining: 500 + 400,
+						fromPartPostroll: 400,
+						fromPartKeepalive: 100,
+					},
+				},
+			}
+
+			const playlist = createMockPlaylist(selectedPartInfos)
+			const objs = buildTimelineObjsForRundown(context, playlist, selectedPartInfos)
+
+			expect(objs.timeline).not.toHaveLength(0)
+			expect(objs.timingContext).not.toBeUndefined()
+			expect(transformTimelineIntoSimplifiedForm(objs)).toMatchSnapshot()
+
+			// make sure the previous part was generated
+			expect(objs.timingContext?.nextPartGroup).toBeTruthy()
+			const nextPartGroupId = getPartGroupId(selectedPartInfos.next!.partInstance)
+			expect(objs.timeline.find((obj) => obj.id === nextPartGroupId)).toBeTruthy()
+		})
+	})
+
+	describe('infinite pieces', () => {
+		const PREVIOUS_PART_INSTANCE: SelectedPartInstanceTimelineInfo = {
+			nowInPart: 9999,
+			partStarted: 1234,
+			partInstance: createMockPartInstance(
+				'part9',
+				{ autoNext: true, expectedDuration: 5000 },
+				{
+					timings: {
+						plannedStartedPlayback: 1235,
+					},
+				}
+			),
+			pieceInstances: [createMockPieceInstance('piece9')],
+			calculatedTimings: DEFAULT_PART_TIMINGS,
+		}
+
+		it('infinite starting in current', () => {
+			const context = setupDefaultJobEnvironment()
+
+			const selectedPartInfos: SelectedPartInstancesTimelineInfo = {
+				previous: PREVIOUS_PART_INSTANCE,
+				current: {
+					nowInPart: 1234,
+					partStarted: 5678,
+					partInstance: createMockPartInstance('part0'),
+					pieceInstances: [
+						createMockPieceInstance('piece0'),
+						createMockInfinitePieceInstance('piece1', {}, { plannedStartedPlayback: undefined }),
+					],
+					calculatedTimings: DEFAULT_PART_TIMINGS,
+				},
+			}
+
+			const playlist = createMockPlaylist(selectedPartInfos)
+			const objs = buildTimelineObjsForRundown(context, playlist, selectedPartInfos)
+
+			expect(objs.timeline).not.toHaveLength(0)
+			expect(objs.timingContext).not.toBeUndefined()
+			expect(transformTimelineIntoSimplifiedForm(objs)).toMatchSnapshot()
+		})
+
+		it('infinite ending with previous', () => {
+			const context = setupDefaultJobEnvironment()
+
+			const selectedPartInfos: SelectedPartInstancesTimelineInfo = {
+				previous: {
+					...PREVIOUS_PART_INSTANCE,
+					pieceInstances: [
+						...PREVIOUS_PART_INSTANCE.pieceInstances,
+						createMockInfinitePieceInstance('piece6', {}, {}, 1),
+					],
+				},
+				current: {
+					nowInPart: 1234,
+					partStarted: 5678,
+					partInstance: createMockPartInstance('part0'),
+					pieceInstances: [createMockPieceInstance('piece0')],
+					calculatedTimings: DEFAULT_PART_TIMINGS,
+				},
+			}
+
+			const playlist = createMockPlaylist(selectedPartInfos)
+			const objs = buildTimelineObjsForRundown(context, playlist, selectedPartInfos)
+
+			expect(objs.timeline).not.toHaveLength(0)
+			expect(objs.timingContext).not.toBeUndefined()
+			expect(transformTimelineIntoSimplifiedForm(objs)).toMatchSnapshot()
+		})
+
+		it('infinite ending with previous excludeDuringPartKeepalive=true', () => {
+			const context = setupDefaultJobEnvironment()
+
+			const selectedPartInfos: SelectedPartInstancesTimelineInfo = {
+				previous: {
+					...PREVIOUS_PART_INSTANCE,
+					pieceInstances: [
+						...PREVIOUS_PART_INSTANCE.pieceInstances,
+						createMockInfinitePieceInstance('piece6', { excludeDuringPartKeepalive: true }, {}, 1),
+					],
+				},
+				current: {
+					nowInPart: 1234,
+					partStarted: 5678,
+					partInstance: createMockPartInstance('part0'),
+					pieceInstances: [createMockPieceInstance('piece0')],
+					calculatedTimings: DEFAULT_PART_TIMINGS,
+				},
+			}
+
+			const playlist = createMockPlaylist(selectedPartInfos)
+			const objs = buildTimelineObjsForRundown(context, playlist, selectedPartInfos)
+
+			expect(objs.timeline).not.toHaveLength(0)
+			expect(objs.timingContext).not.toBeUndefined()
+			expect(transformTimelineIntoSimplifiedForm(objs)).toMatchSnapshot()
+		})
+
+		it('infinite continuing from previous', () => {
+			const context = setupDefaultJobEnvironment()
+
+			const infinitePiece = createMockInfinitePieceInstance('piece6')
+
+			const selectedPartInfos: SelectedPartInstancesTimelineInfo = {
+				previous: {
+					...PREVIOUS_PART_INSTANCE,
+					pieceInstances: [...PREVIOUS_PART_INSTANCE.pieceInstances, infinitePiece],
+				},
+				current: {
+					nowInPart: 1234,
+					partStarted: 5678,
+					partInstance: createMockPartInstance('part0'),
+					pieceInstances: [createMockPieceInstance('piece0'), continueInfinitePiece(infinitePiece)],
+					calculatedTimings: DEFAULT_PART_TIMINGS,
+				},
+			}
+
+			const playlist = createMockPlaylist(selectedPartInfos)
+			const objs = buildTimelineObjsForRundown(context, playlist, selectedPartInfos)
+
+			expect(objs.timeline).not.toHaveLength(0)
+			expect(objs.timingContext).not.toBeUndefined()
+			expect(transformTimelineIntoSimplifiedForm(objs)).toMatchSnapshot()
+		})
+
+		it('infinite continuing into next with autonext', () => {
+			const context = setupDefaultJobEnvironment()
+
+			const infinitePiece = createMockInfinitePieceInstance('piece6')
+
+			const selectedPartInfos: SelectedPartInstancesTimelineInfo = {
+				current: {
+					nowInPart: 1234,
+					partStarted: 5678,
+					partInstance: createMockPartInstance(
+						'part0',
+						{ autoNext: true, expectedDuration: 5000 },
+						{
+							timings: {
+								plannedStartedPlayback: 1235,
+							},
+						}
+					),
+					pieceInstances: [createMockPieceInstance('piece0'), infinitePiece],
+					calculatedTimings: DEFAULT_PART_TIMINGS,
+				},
+				next: {
+					nowInPart: 0,
+					partStarted: undefined,
+					partInstance: createMockPartInstance(
+						'part1',
+						{},
+						{
+							timings: {
+								plannedStartedPlayback: 5000,
+							},
+						}
+					),
+					pieceInstances: [createMockPieceInstance('piece1'), continueInfinitePiece(infinitePiece)],
+					calculatedTimings: DEFAULT_PART_TIMINGS,
+				},
+			}
+
+			const playlist = createMockPlaylist(selectedPartInfos)
+			const objs = buildTimelineObjsForRundown(context, playlist, selectedPartInfos)
+
+			expect(objs.timeline).not.toHaveLength(0)
+			expect(objs.timingContext).not.toBeUndefined()
+			expect(transformTimelineIntoSimplifiedForm(objs)).toMatchSnapshot()
+		})
+
+		it('infinite stopping in current with autonext', () => {
+			const context = setupDefaultJobEnvironment()
+
+			const selectedPartInfos: SelectedPartInstancesTimelineInfo = {
+				current: {
+					nowInPart: 1234,
+					partStarted: 5678,
+					partInstance: createMockPartInstance(
+						'part0',
+						{ autoNext: true, expectedDuration: 5000 },
+						{
+							timings: {
+								plannedStartedPlayback: 1235,
+							},
+						}
+					),
+					pieceInstances: [createMockPieceInstance('piece0'), createMockInfinitePieceInstance('piece6')],
+					calculatedTimings: DEFAULT_PART_TIMINGS,
+				},
+				next: {
+					nowInPart: 0,
+					partStarted: undefined,
+					partInstance: createMockPartInstance(
+						'part1',
+						{},
+						{
+							timings: {
+								plannedStartedPlayback: 5000,
+							},
+						}
+					),
+					pieceInstances: [createMockPieceInstance('piece1')],
+					calculatedTimings: {
+						...DEFAULT_PART_TIMINGS,
+						fromPartKeepalive: 100,
+					},
+				},
+			}
+
+			const playlist = createMockPlaylist(selectedPartInfos)
+			const objs = buildTimelineObjsForRundown(context, playlist, selectedPartInfos)
+
+			expect(objs.timeline).not.toHaveLength(0)
+			expect(objs.timingContext).not.toBeUndefined()
+			expect(transformTimelineIntoSimplifiedForm(objs)).toMatchSnapshot()
+		})
+
+		it('infinite stopping in current with autonext excludeDuringPartKeepalive=true', () => {
+			const context = setupDefaultJobEnvironment()
+
+			const selectedPartInfos: SelectedPartInstancesTimelineInfo = {
+				current: {
+					nowInPart: 1234,
+					partStarted: 5678,
+					partInstance: createMockPartInstance(
+						'part0',
+						{ autoNext: true, expectedDuration: 5000 },
+						{
+							timings: {
+								plannedStartedPlayback: 1235,
+							},
+						}
+					),
+					pieceInstances: [
+						createMockPieceInstance('piece0'),
+						createMockInfinitePieceInstance('piece6', { excludeDuringPartKeepalive: true }),
+					],
+					calculatedTimings: DEFAULT_PART_TIMINGS,
+				},
+				next: {
+					nowInPart: 0,
+					partStarted: undefined,
+					partInstance: createMockPartInstance(
+						'part1',
+						{},
+						{
+							timings: {
+								plannedStartedPlayback: 5000,
+							},
+						}
+					),
+					pieceInstances: [createMockPieceInstance('piece1')],
+					calculatedTimings: {
+						...DEFAULT_PART_TIMINGS,
+						fromPartKeepalive: 100,
+					},
+				},
+			}
+
+			const playlist = createMockPlaylist(selectedPartInfos)
+			const objs = buildTimelineObjsForRundown(context, playlist, selectedPartInfos)
+
+			expect(objs.timeline).not.toHaveLength(0)
+			expect(objs.timingContext).not.toBeUndefined()
+			expect(transformTimelineIntoSimplifiedForm(objs)).toMatchSnapshot()
+		})
+	})
+})

--- a/packages/job-worker/src/playout/timeline/generate.ts
+++ b/packages/job-worker/src/playout/timeline/generate.ts
@@ -336,12 +336,7 @@ async function getTimelineRundown(
 				logger.warn(`Missing Baseline objects for Rundown "${activeRundown.rundown._id}"`)
 			}
 
-			const rundownTimelineResult = buildTimelineObjsForRundown(
-				context,
-				playoutModel,
-				activeRundown.rundown,
-				partInstancesInfo
-			)
+			const rundownTimelineResult = buildTimelineObjsForRundown(context, playoutModel.playlist, partInstancesInfo)
 
 			timelineObjs = timelineObjs.concat(rundownTimelineResult.timeline)
 			timelineObjs = timelineObjs.concat(await pLookaheadObjs)

--- a/packages/job-worker/src/playout/timeline/pieceGroup.ts
+++ b/packages/job-worker/src/playout/timeline/pieceGroup.ts
@@ -42,8 +42,11 @@ export function createPieceGroupAndCap(
 	partGroup?: TimelineObjRundown,
 	pieceStartOffset?: number
 ): {
+	/** The 'control' object which defines the bounds of the group. This triggers the timing, and does not include and pre/postroll */
 	controlObj: TimelineObjPieceAbstract & OnGenerateTimelineObjExt<PieceTimelineMetadata>
+	/** The 'group' object that should contain all the content. This uses the control object for its timing, and adds the pre/postroll. */
 	childGroup: TimelineObjGroupRundown & OnGenerateTimelineObjExt<PieceTimelineMetadata>
+	/** Any additional objects which are used to determine points in time that the piece should start/end relative to. */
 	capObjs: Array<TimelineObjRundown & OnGenerateTimelineObjExt<PieceTimelineMetadata>>
 } {
 	const controlObj = literal<TimelineObjPieceAbstract & OnGenerateTimelineObjExt<PieceTimelineMetadata>>({

--- a/packages/webui/src/client/lib/__tests__/rundownTiming.test.ts
+++ b/packages/webui/src/client/lib/__tests__/rundownTiming.test.ts
@@ -1450,6 +1450,7 @@ describe('rundown Timing Calculator', () => {
 			toPartPostroll: 500,
 			fromPartRemaining: 0,
 			fromPartPostroll: 0,
+			fromPartKeepalive: 0,
 		}
 		const partInstance2 = wrapPartToTemporaryInstance(protectString(''), parts[1])
 		partInstance2.isTemporary = false
@@ -1463,6 +1464,7 @@ describe('rundown Timing Calculator', () => {
 			toPartPostroll: 0,
 			fromPartRemaining: 500,
 			fromPartPostroll: 500,
+			fromPartKeepalive: 0,
 		}
 		const partInstances = [partInstance1, partInstance2, ...convertPartsToPartInstances([parts[2], parts[3]])]
 		const partInstancesMap: Map<PartId, PartInstance> = new Map()


### PR DESCRIPTION


## About the Contributor
This pull request is posted on behalf of the BBC


## Type of Contribution

This is a: Feature

## Current Behavior

All pieces from a part are included in the keepalive region of a part during a transition. This can lead to unintended effects, such as graphics starting their out animation too late.


## New Behavior

Each piece can opt out of being included in this keepalive region.


## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [x] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

This adds some framework and initial tests for the timeline generation, focusing specifically on how the part and piece groups are arranged.

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
* 
-->

This PR affects the timeline generation. 

## Time Frame
<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->

When reviewing, I would recommend reviewing the first commit of pure refactoring before the rest of the changes

## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
