### PR TITLE
Upstream/presenter timing part segment remaining

### DIFF
--- a/packages/webui/src/client/styles/countdown/presenter.scss
+++ b/packages/webui/src/client/styles/countdown/presenter.scss
@@ -118,6 +118,10 @@ $hold-status-color: $liveline-timecode-color;
 			padding: 0 0.2em;
 			line-height: 1em;
 
+			> .overtime {
+				color: $general-late-color;
+			}
+
 			> img.freeze-icon {
 				width: 0.9em;
 				height: 0.9em;

--- a/packages/webui/src/client/ui/ClockView/PresenterScreen.tsx
+++ b/packages/webui/src/client/ui/ClockView/PresenterScreen.tsx
@@ -13,7 +13,7 @@ import { PieceIconContainer } from '../PieceIcons/PieceIcon'
 import { PieceNameContainer } from '../PieceIcons/PieceName'
 import { Timediff } from './Timediff'
 import { RundownUtils } from '../../lib/rundown'
-import { PieceLifespan } from '@sofie-automation/blueprints-integration'
+import { CountdownType, PieceLifespan } from '@sofie-automation/blueprints-integration'
 import { DBPart } from '@sofie-automation/corelib/dist/dataModel/Part'
 import { PieceCountdownContainer } from '../PieceIcons/PieceCountdown'
 import { PlaylistTiming } from '@sofie-automation/corelib/dist/playout/rundownTiming'
@@ -461,21 +461,24 @@ function PresenterScreenContentDefaultLayout({
 								/>
 							</div>
 							<div className="presenter-screen__part__piece-countdown">
-								<CurrentPartOrSegmentRemaining
-									currentPartInstanceId={currentPartInstance.instance._id}
-									heavyClassName="overtime"
-								/>
-								{/* <PieceCountdownContainer
-									partInstanceId={currentPartInstance.instance._id}
-									showStyleBaseId={currentShowStyleBaseId}
-									rundownIds={rundownIds}
-									partAutoNext={currentPartInstance.instance.part.autoNext || false}
-									partExpectedDuration={calculatePartInstanceExpectedDurationWithTransition(
-										currentPartInstance.instance
-									)}
-									partStartedPlayback={currentPartInstance.instance.timings?.plannedStartedPlayback}
-									playlistActivationId={playlist?.activationId}
-								/>  */}
+								{currentSegment?.segmentTiming?.countdownType === CountdownType.SEGMENT_BUDGET_DURATION ? (
+									<CurrentPartOrSegmentRemaining
+										currentPartInstanceId={currentPartInstance.instance._id}
+										heavyClassName="overtime"
+									/>
+								) : (
+									<PieceCountdownContainer
+										partInstanceId={currentPartInstance.instance._id}
+										showStyleBaseId={currentShowStyleBaseId}
+										rundownIds={rundownIds}
+										partAutoNext={currentPartInstance.instance.part.autoNext || false}
+										partExpectedDuration={calculatePartInstanceExpectedDurationWithTransition(
+											currentPartInstance.instance
+										)}
+										partStartedPlayback={currentPartInstance.instance.timings?.plannedStartedPlayback}
+										playlistActivationId={playlist?.activationId}
+									/>
+								)}
 							</div>
 							<div className="presenter-screen__part__part-countdown">
 								<Timediff time={currentPartOrSegmentCountdown} />

--- a/packages/webui/src/client/ui/ClockView/PresenterScreen.tsx
+++ b/packages/webui/src/client/ui/ClockView/PresenterScreen.tsx
@@ -41,6 +41,7 @@ import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 import { useSetDocumentClass } from '../util/useSetDocumentClass'
 import { useRundownAndShowStyleIdsForPlaylist } from '../util/useRundownAndShowStyleIdsForPlaylist'
 import { RundownPlaylistClientUtil } from '../../lib/rundownPlaylistUtil'
+import { CurrentPartOrSegmentRemaining } from '../RundownView/RundownTiming/CurrentPartOrSegmentRemaining'
 
 interface SegmentUi extends DBSegment {
 	items: Array<PartUi>
@@ -460,7 +461,11 @@ function PresenterScreenContentDefaultLayout({
 								/>
 							</div>
 							<div className="presenter-screen__part__piece-countdown">
-								<PieceCountdownContainer
+								<CurrentPartOrSegmentRemaining
+									currentPartInstanceId={currentPartInstance.instance._id}
+									heavyClassName="overtime"
+								/>
+								{/* <PieceCountdownContainer
 									partInstanceId={currentPartInstance.instance._id}
 									showStyleBaseId={currentShowStyleBaseId}
 									rundownIds={rundownIds}
@@ -470,7 +475,7 @@ function PresenterScreenContentDefaultLayout({
 									)}
 									partStartedPlayback={currentPartInstance.instance.timings?.plannedStartedPlayback}
 									playlistActivationId={playlist?.activationId}
-								/>
+								/>  */}
 							</div>
 							<div className="presenter-screen__part__part-countdown">
 								<Timediff time={currentPartOrSegmentCountdown} />


### PR DESCRIPTION
## About the Contributor
This PR is made on behalf of BBC

## Type of Contribution
This is a feature

## Current Behavior
Currently the timers in presenter is using the <PieceCountdownContainer/> that follows the NRK specs.

## New Behavior
If CountdownType.SEGMENT_BUDGET_DURATION is set as countdownType the `<CurrentPartOrSegmentRemaining/>` component will be used instead of the `<PieceCountdownContainer>`
If not SEGMENT_BUDGET_DURATION the presenter functionality is not changed.

## Testing

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas
This affects only presenter screen and only if CountdownType.SEGMENT_BUDGET_DURATION is being used.


## Time Frame

## Other Information
The PR is awaiting approval from BBC.

## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
