### PR TITLE
Feat: OpenAPI move-next-part add ignoreQuickLoop as optional attribute

### DIFF
--- a/meteor/server/api/rest/v1/playlists.ts
+++ b/meteor/server/api/rest/v1/playlists.ts
@@ -275,7 +275,8 @@ class PlaylistsServerAPI implements PlaylistsRestAPI {
 		connection: Meteor.Connection,
 		event: string,
 		rundownPlaylistId: RundownPlaylistId,
-		delta: number
+		delta: number,
+		ignoreQuickLoop?: boolean
 	): Promise<ClientAPI.ClientResponse<PartId | null>> {
 		return ServerClientAPI.runUserActionInLogForPlaylistOnWorker(
 			this.context.getMethodContext(connection),
@@ -291,6 +292,7 @@ class PlaylistsServerAPI implements PlaylistsRestAPI {
 				playlistId: rundownPlaylistId,
 				partDelta: delta,
 				segmentDelta: 0,
+				ignoreQuickLoop,
 			}
 		)
 	}

--- a/meteor/server/lib/rest/v1/playlists.ts
+++ b/meteor/server/lib/rest/v1/playlists.ts
@@ -109,12 +109,14 @@ export interface PlaylistsRestAPI {
 	 * @param event User event string
 	 * @param rundownPlaylistId Playlist to target.
 	 * @param delta Amount to move next point by (+/-)
+	 * @param ignoreQuickLoop When moving the next part it should ignore any of the boundaries set by the QuickLoop feature
 	 */
 	moveNextPart(
 		connection: Meteor.Connection,
 		event: string,
 		rundownPlaylistId: RundownPlaylistId,
-		delta: number
+		delta: number,
+		ignoreQuickLoop?: boolean
 	): Promise<ClientAPI.ClientResponse<PartId | null>>
 	/**
 	 * Moves the next Segment point by `delta` places. Negative values are allowed to move "backwards" in the script.

--- a/packages/openapi/api/definitions/playlists.yaml
+++ b/packages/openapi/api/definitions/playlists.yaml
@@ -278,6 +278,9 @@ resources:
                 delta:
                   type: number
                   description: Amount to move next Segment point by (+/-). If delta results in an index that is greater than the number of Segments available, no action will be taken.
+                ignoreQuickLoop:
+                  type: boolean
+                  description: When true, the operation will ignore any boundaries set by the QuickLoop feature when moving to the next part
               required:
                 - delta
       responses:


### PR DESCRIPTION
## About the Contributor
This PR is made on behalf of BBC

## Type of Contribution
This is a feature

## Current Behavior
the openAPI currently does not include the ignoreQuickLoop option in move-next-part

## New Behavior
ignoreQuickLoop has been added as an optional attribute in move-next-part

## Testing

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

This affects only the openAPI

## Time Frame
* Not urgent, but we would like to get this merged into the in-development release.

## Status
The addition has not been tested locally, as this requires java engine to be installed.

- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
