### PR TITLE
feat(Test Tools): show AB-Session in Timeline

### DIFF
--- a/packages/webui/src/client/ui/TestTools/Timeline.tsx
+++ b/packages/webui/src/client/ui/TestTools/Timeline.tsx
@@ -258,6 +258,12 @@ function renderTimelineState(state: TimelineState, filter: RegExp | string | und
 			<td>{(o.classes ?? []).join('<br />')}</td>
 			<td style={{ whiteSpace: 'pre' }}>
 				<pre>{JSON.stringify(o.content, undefined, '\t')}</pre>
+				<pre>
+					{
+						//@ts-expect-error - abSessions is not in the type but are still in the object if used:
+						o.abSessions && 'AB-Sessions:' + '\n' + JSON.stringify(o.abSessions, undefined, '\t')
+					}
+				</pre>
 			</td>
 		</tr>
 	))

--- a/packages/webui/src/client/ui/TestTools/Timeline.tsx
+++ b/packages/webui/src/client/ui/TestTools/Timeline.tsx
@@ -258,12 +258,10 @@ function renderTimelineState(state: TimelineState, filter: RegExp | string | und
 			<td>{(o.classes ?? []).join('<br />')}</td>
 			<td style={{ whiteSpace: 'pre' }}>
 				<pre>{JSON.stringify(o.content, undefined, '\t')}</pre>
-				<pre>
-					{
+				{o.abSessions && <pre>{
 						//@ts-expect-error - abSessions is not in the type but are still in the object if used:
-						o.abSessions && 'AB-Sessions:' + '\n' + JSON.stringify(o.abSessions, undefined, '\t')
-					}
-				</pre>
+						'AB-Sessions:' + '\n' + JSON.stringify(o.abSessions, undefined, '\t')
+				}</pre>}
 			</td>
 		</tr>
 	))


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
This PR is made on behalf of BBC

## Type of Contribution
This is a feature

## Current Behavior
Currently there's no way to see abSessions in test tools

## New Behavior
if there's an abSessions object in the TimelineObject, AB-Sessions will be displayed in the timeline after the content.
As the abSessions are not part of the `ResolvedTimelineObjectInstance<Content>` but still in the object, a ts-expect-error has been added.

## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas
Only the testtools timeline

## Time Frame
<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
