### PR TITLE
chore: add check to install-and-build script to disallow yarn 1

### DIFF
--- a/scripts/install-and-build.mjs
+++ b/scripts/install-and-build.mjs
@@ -1,3 +1,4 @@
+import cp from "child_process";
 import process from "process";
 import concurrently from "concurrently";
 import { EXTRA_PACKAGES, config } from "./lib.js";
@@ -5,8 +6,36 @@ import { EXTRA_PACKAGES, config } from "./lib.js";
 function hr() {
 	// write regular dashes if this is a "simple" output stream ()
 	if (!process.stdout.hasColors || !process.stdout.hasColors())
-		return '-'.repeat(process.stdout.columns ?? 40)
-	return '─'.repeat(process.stdout.columns ?? 40)
+		return "-".repeat(process.stdout.columns ?? 40);
+	return "─".repeat(process.stdout.columns ?? 40);
+}
+function exec(cmd) {
+	return new Promise((resolve, reject) => {
+		cp.exec(cmd, (err, stdout, stderr) => {
+			if (err) reject(err);
+			resolve({ stdout, stderr });
+		});
+	});
+}
+const yarnVersion = await exec("yarn -v");
+
+// Require yarn > 1:
+if (
+	yarnVersion.stdout.startsWith("0.") ||
+	yarnVersion.stdout.startsWith("1.")
+) {
+	console.error(
+		"It seems like you're using an old version of yarn. Please upgrade to yarn 2 or later"
+	);
+	console.error(`Detected yarn version: ${yarnVersion.stdout.trim()}`);
+	console.error(`--`);
+	console.error(`Tip:`);
+	console.error(
+		`To uninstall yarn classic, you can find where it's installed by running 'which yarn' or 'where yarn'`
+	);
+	console.error(`After you have uninstalled it, run 'corepack enable'`);
+
+	process.exit(1);
 }
 
 try {
@@ -41,9 +70,9 @@ try {
 	console.log(" 🪛  Build packages...");
 	console.log(hr());
 
-	const buildArgs = ['--ignore @sofie-automation/webui']
+	const buildArgs = ["--ignore @sofie-automation/webui"];
 	if (config.uiOnly) {
-		buildArgs.push(...EXTRA_PACKAGES.map((pkg) => `--ignore ${pkg}`))
+		buildArgs.push(...EXTRA_PACKAGES.map((pkg) => `--ignore ${pkg}`));
 	}
 
 	await concurrently(


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->

This pull request is posted on behalf of the NRK.

## Type of Contribution

This is a: Code improvement 


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

If I have yarn 1 / yarn classic installed on my system, I get some errors such as `'run' not a executable command` and the like, which are hard to troubleshoot for a new developer.


## New Behavior
<!--
What is the new behavior?
-->
When running install-and-build, the script will catch the issue early and provide a user friendlier feedback.


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
