### PR TITLE
feat(Blueprint API): Expose Segments in blueprint contexts

### DIFF
--- a/packages/blueprints-integration/src/context/onSetAsNextContext.ts
+++ b/packages/blueprints-integration/src/context/onSetAsNextContext.ts
@@ -6,6 +6,7 @@ import {
 	IBlueprintPieceDB,
 	IBlueprintPieceInstance,
 	IBlueprintResolvedPieceInstance,
+	IBlueprintSegment,
 	IEventContext,
 	IShowStyleUserContext,
 } from '..'
@@ -49,6 +50,8 @@ export interface IOnSetAsNextContext extends IShowStyleUserContext, IEventContex
 	getPartInstanceForPreviousPiece(piece: IBlueprintPieceInstance): Promise<IBlueprintPartInstance>
 	/** Gets the Part for a Piece retrieved from findLastScriptedPieceOnLayer. This primarily allows for accessing metadata of the Part */
 	getPartForPreviousPiece(piece: IBlueprintPieceDB): Promise<IBlueprintPart | undefined>
+	/** Gets the Segment. This primarily allows for accessing metadata */
+	getSegment(segment: 'current' | 'next'): Promise<IBlueprintSegment | undefined>
 
 	/**
 	 * Creative actions

--- a/packages/blueprints-integration/src/context/partsAndPieceActionContext.ts
+++ b/packages/blueprints-integration/src/context/partsAndPieceActionContext.ts
@@ -6,6 +6,7 @@ import {
 	IBlueprintPieceDB,
 	IBlueprintPieceInstance,
 	IBlueprintResolvedPieceInstance,
+	IBlueprintSegment,
 	Time,
 } from '..'
 import { BlueprintQuickLookInfo } from './quickLoopInfo'
@@ -44,6 +45,8 @@ export interface IPartAndPieceActionContext {
 	getPartInstanceForPreviousPiece(piece: IBlueprintPieceInstance): Promise<IBlueprintPartInstance>
 	/** Gets the Part for a Piece retrieved from findLastScriptedPieceOnLayer. This primarily allows for accessing metadata of the Part */
 	getPartForPreviousPiece(piece: IBlueprintPieceDB): Promise<IBlueprintPart | undefined>
+	/** Gets the Segment. This primarily allows for accessing metadata */
+	getSegment(segment: 'current' | 'next'): Promise<IBlueprintSegment | undefined>
 
 	/**
 	 * Creative actions

--- a/packages/job-worker/src/blueprints/__tests__/context-OnSetAsNextContext.test.ts
+++ b/packages/job-worker/src/blueprints/__tests__/context-OnSetAsNextContext.test.ts
@@ -53,6 +53,14 @@ describe('Test blueprint api context', () => {
 			expect(mockActionService.getResolvedPieceInstances).toHaveBeenCalledWith('current')
 		})
 
+		test('getSegment', async () => {
+			const { context, mockActionService } = await getTestee()
+
+			await context.getSegment('current')
+			expect(mockActionService.getSegment).toHaveBeenCalledTimes(1)
+			expect(mockActionService.getSegment).toHaveBeenCalledWith('current')
+		})
+
 		test('findLastPieceOnLayer', async () => {
 			const { context, mockActionService } = await getTestee()
 

--- a/packages/job-worker/src/blueprints/__tests__/context-OnTakeContext.test.ts
+++ b/packages/job-worker/src/blueprints/__tests__/context-OnTakeContext.test.ts
@@ -53,6 +53,14 @@ describe('Test blueprint api context', () => {
 			expect(mockActionService.getResolvedPieceInstances).toHaveBeenCalledWith('current')
 		})
 
+		test('getSegment', async () => {
+			const { context, mockActionService } = await getTestee()
+
+			await context.getSegment('current')
+			expect(mockActionService.getSegment).toHaveBeenCalledTimes(1)
+			expect(mockActionService.getSegment).toHaveBeenCalledWith('current')
+		})
+
 		test('findLastPieceOnLayer', async () => {
 			const { context, mockActionService } = await getTestee()
 

--- a/packages/job-worker/src/blueprints/__tests__/context-adlibActions.test.ts
+++ b/packages/job-worker/src/blueprints/__tests__/context-adlibActions.test.ts
@@ -55,6 +55,14 @@ describe('Test blueprint api context', () => {
 			expect(mockActionService.getResolvedPieceInstances).toHaveBeenCalledWith('current')
 		})
 
+		test('getSegment', async () => {
+			const { context, mockActionService } = await getTestee()
+
+			await context.getSegment('current')
+			expect(mockActionService.getSegment).toHaveBeenCalledTimes(1)
+			expect(mockActionService.getSegment).toHaveBeenCalledWith('current')
+		})
+
 		test('findLastPieceOnLayer', async () => {
 			const { context, mockActionService } = await getTestee()
 

--- a/packages/job-worker/src/blueprints/context/OnSetAsNextContext.ts
+++ b/packages/job-worker/src/blueprints/context/OnSetAsNextContext.ts
@@ -9,6 +9,7 @@ import {
 	IBlueprintPieceDB,
 	IBlueprintPieceInstance,
 	IBlueprintResolvedPieceInstance,
+	IBlueprintSegment,
 	IEventContext,
 	IOnSetAsNextContext,
 } from '@sofie-automation/blueprints-integration'
@@ -65,6 +66,10 @@ export class OnSetAsNextContext
 
 	async getResolvedPieceInstances(part: 'current' | 'next'): Promise<IBlueprintResolvedPieceInstance<unknown>[]> {
 		return this.partAndPieceInstanceService.getResolvedPieceInstances(part)
+	}
+
+	async getSegment(segment: 'current' | 'next'): Promise<IBlueprintSegment | undefined> {
+		return this.partAndPieceInstanceService.getSegment(segment)
 	}
 
 	async findLastPieceOnLayer(

--- a/packages/job-worker/src/blueprints/context/OnTakeContext.ts
+++ b/packages/job-worker/src/blueprints/context/OnTakeContext.ts
@@ -12,6 +12,7 @@ import {
 	TSR,
 	IBlueprintPlayoutDevice,
 	IOnTakeContext,
+	IBlueprintSegment,
 } from '@sofie-automation/blueprints-integration'
 import { PeripheralDeviceId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { ReadonlyDeep } from 'type-fest'
@@ -63,6 +64,9 @@ export class OnTakeContext extends ShowStyleUserContext implements IOnTakeContex
 	}
 	async getResolvedPieceInstances(part: 'current' | 'next'): Promise<IBlueprintResolvedPieceInstance[]> {
 		return this.partAndPieceInstanceService.getResolvedPieceInstances(part)
+	}
+	async getSegment(segment: 'current' | 'next'): Promise<IBlueprintSegment | undefined> {
+		return this.partAndPieceInstanceService.getSegment(segment)
 	}
 
 	async findLastPieceOnLayer(

--- a/packages/job-worker/src/blueprints/context/adlibActions.ts
+++ b/packages/job-worker/src/blueprints/context/adlibActions.ts
@@ -14,6 +14,7 @@ import {
 	TSR,
 	IBlueprintPlayoutDevice,
 	StudioRouteSet,
+	IBlueprintSegment,
 } from '@sofie-automation/blueprints-integration'
 import { PartInstanceId, PeripheralDeviceId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { ReadonlyDeep } from 'type-fest'
@@ -111,6 +112,10 @@ export class ActionExecutionContext extends ShowStyleUserContext implements IAct
 
 	async getResolvedPieceInstances(part: 'current' | 'next'): Promise<IBlueprintResolvedPieceInstance[]> {
 		return this.partAndPieceInstanceService.getResolvedPieceInstances(part)
+	}
+
+	async getSegment(segment: 'current' | 'next'): Promise<IBlueprintSegment | undefined> {
+		return this.partAndPieceInstanceService.getSegment(segment)
 	}
 
 	async findLastPieceOnLayer(

--- a/packages/job-worker/src/blueprints/context/services/PartAndPieceInstanceActionService.ts
+++ b/packages/job-worker/src/blueprints/context/services/PartAndPieceInstanceActionService.ts
@@ -9,6 +9,7 @@ import {
 	IBlueprintPieceDB,
 	IBlueprintPieceInstance,
 	IBlueprintResolvedPieceInstance,
+	IBlueprintSegment,
 	OmitId,
 	SomeContent,
 	Time,
@@ -22,6 +23,7 @@ import {
 	convertPieceInstanceToBlueprints,
 	convertPieceToBlueprints,
 	convertResolvedPieceInstanceToBlueprints,
+	convertSegmentToBlueprints,
 	createBlueprintQuickLoopInfo,
 	getMediaObjectDuration,
 } from '../lib'
@@ -137,6 +139,14 @@ export class PartAndPieceInstanceActionService {
 			partInstance
 		)
 		return resolvedInstances.map(convertResolvedPieceInstanceToBlueprints)
+	}
+	getSegment(segment: 'current' | 'next'): IBlueprintSegment | undefined {
+		const partInstance = this.#getPartInstance(segment)
+		if (!partInstance) return undefined
+
+		const segmentModel = this._playoutModel.findSegment(partInstance.partInstance.segmentId)
+
+		return segmentModel?.segment ? convertSegmentToBlueprints(segmentModel?.segment) : undefined
 	}
 
 	async findLastPieceOnLayer(


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This pull request is posted on behalf of the BBC.

## Type of Contribution

This is a: Enhancement
<!-- (pick one) -->


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

- Blueprints can set public and private data on segments but have no way to read this information back


## New Behavior
<!--
What is the new behavior?
-->
- Blueprints can use the getSegment method on the `Action`/ `OnSetAsNext `/ `OnTake` contexts

## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [x] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
* 
-->
This PR affects the blueprint contexts


## Time Frame
<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->
Not urgent, but we would like to get this merged into the in-development release.


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
