### PR TITLE
fix: prevent queued Part from hijacking infinite Pieces from the following Part(s)

### DIFF
--- a/packages/job-worker/src/blueprints/context/services/PartAndPieceInstanceActionService.ts
+++ b/packages/job-worker/src/blueprints/context/services/PartAndPieceInstanceActionService.ts
@@ -381,10 +381,9 @@ export class PartAndPieceInstanceActionService {
 			throw new Error('New part must contain at least one piece')
 		}
 
-		const newPart: Omit<DBPart, 'segmentId' | 'rundownId'> = {
+		const newPart: Omit<DBPart, 'segmentId' | 'rundownId' | '_rank'> = {
 			...rawPart,
 			_id: getRandomId(),
-			_rank: 99999, // Corrected in innerStartQueuedAdLib
 			notes: [],
 			invalid: false,
 			invalidReason: undefined,

--- a/packages/job-worker/src/ingest/__tests__/ingest.test.ts
+++ b/packages/job-worker/src/ingest/__tests__/ingest.test.ts
@@ -1733,7 +1733,6 @@ describe('Test ingest actions for rundowns and segments', () => {
 						currentPartInstance,
 						{
 							_id: protectString(`after_${currentPartInstance.partInstance._id}_part`),
-							_rank: 0,
 							externalId: `after_${currentPartInstance.partInstance._id}_externalId`,
 							title: 'New part',
 							expectedDurationWithTransition: undefined,

--- a/packages/job-worker/src/playout/adlibUtils.ts
+++ b/packages/job-worker/src/playout/adlibUtils.ts
@@ -40,9 +40,8 @@ export async function innerStartOrQueueAdLibPiece(
 	const span = context.startSpan('innerStartOrQueueAdLibPiece')
 	let queuedPartInstanceId: PartInstanceId | undefined
 	if (queue || adLibPiece.toBeQueued) {
-		const adlibbedPart: Omit<DBPart, 'segmentId' | 'rundownId'> = {
+		const adlibbedPart: Omit<DBPart, 'segmentId' | 'rundownId' | '_rank'> = {
 			_id: getRandomId(),
-			_rank: 99999, // Corrected in innerStartQueuedAdLib
 			externalId: '',
 			title: adLibPiece.name,
 			expectedDuration: adLibPiece.expectedDuration,
@@ -187,41 +186,29 @@ export async function innerFindLastScriptedPieceOnLayer(
 	return fullPiece
 }
 
-function updateRankForAdlibbedPartInstance(
-	_context: JobContext,
-	playoutModel: PlayoutModel,
-	newPartInstance: PlayoutPartInstanceModel
-) {
-	const currentPartInstance = playoutModel.currentPartInstance
-	if (!currentPartInstance) throw new Error('CurrentPartInstance not found')
-
-	// Parts are always integers spaced by one, and orphaned PartInstances will be decimals spaced between two Part
-	// so we can predict a 'safe' rank to get the desired position with some simple maths
-	newPartInstance.setRank(
-		getRank(
-			currentPartInstance.partInstance.part._rank,
-			Math.floor(currentPartInstance.partInstance.part._rank + 1)
-		)
-	)
-
-	updatePartInstanceRanksAfterAdlib(playoutModel, currentPartInstance, newPartInstance)
-}
-
 export async function insertQueuedPartWithPieces(
 	context: JobContext,
 	playoutModel: PlayoutModel,
 	rundown: PlayoutRundownModel,
 	currentPartInstance: PlayoutPartInstanceModel,
-	newPart: Omit<DBPart, 'segmentId' | 'rundownId'>,
+	newPart: Omit<DBPart, 'segmentId' | 'rundownId' | '_rank'>,
 	initialPieces: Omit<PieceInstancePiece, 'startPartId'>[],
 	fromAdlibId: PieceId | undefined
 ): Promise<PlayoutPartInstanceModel> {
 	const span = context.startSpan('insertQueuedPartWithPieces')
 
+	// Parts are always integers spaced by one, and orphaned PartInstances will be decimals spaced between two Part
+	// so we can predict a 'safe' rank to get the desired position with some simple maths
+	const newRank = getRank(
+		currentPartInstance.partInstance.part._rank,
+		Math.floor(currentPartInstance.partInstance.part._rank + 1)
+	)
+
 	const newPartFull: DBPart = {
 		...newPart,
 		segmentId: currentPartInstance.partInstance.segmentId,
 		rundownId: currentPartInstance.partInstance.rundownId,
+		_rank: newRank,
 	}
 
 	// Find any rundown defined infinites that we should inherit
@@ -237,13 +224,13 @@ export async function insertQueuedPartWithPieces(
 	)
 
 	const newPartInstance = playoutModel.createAdlibbedPartInstance(
-		newPart,
+		newPartFull,
 		initialPieces,
 		fromAdlibId,
 		infinitePieceInstances
 	)
 
-	updateRankForAdlibbedPartInstance(context, playoutModel, newPartInstance)
+	updatePartInstanceRanksAfterAdlib(playoutModel, currentPartInstance, newPartInstance)
 
 	await setNextPart(context, playoutModel, newPartInstance, false)
 


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This pull request is posted on behalf of TV 2 Norge


## Type of Contribution

This is a:
<!-- (pick one) -->
Bug fix


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->
Pieces that should start at the beginning of the Part following the dynamically inserted one, will start in the dynamically inserted Part instead. See: https://github.com/nrkno/sofie-core/issues/1392
The problem is in the rank of the inserted part, initially set to a placeholder 99999, which tricks the logic finding infinites to continue into believing that the inserted part is the very last part of the segment.

## New Behavior
<!--
What is the new behavior?
-->
In order to fix the bug, the operations are reordered: first the new rank of the part is calculated, then the infinites to continue are gathered.

## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [x] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
* 
-->
This PR affects the Sofie Core playout logic around adlibbing, specifically queueing adlib parts.

## Time Frame
<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->
We consider the bug to be severe, because it leads to unexpected results on the PGM output when some future infinites are hijacked, so it would be great to merge this fix into release52

## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
