### PR TITLE
fix: duration of pieces with 'now' start time

### DIFF
--- a/packages/job-worker/src/playout/timeline/multi-gateway.ts
+++ b/packages/job-worker/src/playout/timeline/multi-gateway.ts
@@ -173,9 +173,9 @@ function deNowifyCurrentPieces(
 		const objMetadata = obj.metaData as Partial<PieceTimelineMetadata> | undefined
 		if (objMetadata?.isPieceTimeline && !Array.isArray(obj.enable) && obj.enable.start === 'now') {
 			if (obj.inGroup === timingContext.currentPartGroup.id) {
-				obj.enable = { start: nowInPart }
+				obj.enable = { ...obj.enable, start: nowInPart }
 			} else if (!obj.inGroup) {
-				obj.enable = { start: targetNowTime }
+				obj.enable = { ...obj.enable, start: targetNowTime }
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This PR is opened on behalf of TV 2 Norge

## Type of Contribution

This is a:
<!-- (pick one) -->
Bug fix 


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->
In multi-gateway mode, when dynamically inserting a Piece with a `start: 'now'` into the current Part, duration of the piece is not respected. The piece correctly starts immediately, and is shown in the UI as having a defined duration, but on the playout side it lasts till the end of the Part.

## New Behavior
<!--
What is the new behavior?
-->
Piece ends according to its duration.

## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
* 
-->
This PR affects playout, specifically adlib pieces (or actions that insert pieces that start 'now')

## Time Frame
<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->
Technical details: piece control groups had their `duration` lost in `deNowifyCurrentPieces`.

This fix is tricky in terms of adding regression tests or asserting that that it does not introduce any other regressions because this area does not seem covered by existing unit tests, therefore I didn't implement any new. It would be greatly appreciated if the coverage was improved to have something to start from

## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
