### PR TITLE
fix: some snapshots not restoring correctly due to id generation order & publications lost errors

### DIFF
--- a/meteor/server/publications/lib/PromiseDebounce.ts
+++ b/meteor/server/publications/lib/PromiseDebounce.ts
@@ -38,6 +38,7 @@ export class PromiseDebounce<TResult = void, TArgs extends unknown[] = []> {
 
 	/**
 	 * Trigger an execution, but don't report the result.
+	 * Warning: If the function throws an error, that will not be logged or reported to the caller
 	 */
 	trigger = (...args: TArgs): void => {
 		// If an execution is 'imminent', don't do anything


### PR DESCRIPTION

## About the Contributor
This pull request is posted on behalf of the BBC


## Type of Contribution

This is a: Bug fix

## Current Behavior

This contains a couple of fixes:

Some publications which use PromiseDebounce (specifically using the `trigger()` method), are not reporting errors due to the behaviour of PromiseDebounce. This adds some simple try/catch logging.

When restoring some snapshots, I was having issues with the ids in the ingest cache collections not lining up. This adjusts how the ids are generated to make those link up correctly.

## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
* 
-->


## Time Frame
<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
