### PR TITLE
Fix: Hot standby was not referring to the devices full name

### DIFF
--- a/packages/mos-gateway/src/mosHandler.ts
+++ b/packages/mos-gateway/src/mosHandler.ts
@@ -424,7 +424,8 @@ export class MosHandler {
 			for (const [deviceId, device] of Object.entries<{ options: MosDeviceConfig }>(devices)) {
 				if (device) {
 					if (device.options.secondary) {
-						this._openMediaHotStandby[device.options.secondary.id] =
+						const fullSecondaryId = this._settings?.mosId + '_' + device.options.secondary.id
+						this._openMediaHotStandby[fullSecondaryId] =
 							device.options.secondary?.openMediaHotStandby || false
 						// If the host isn't set, don't use secondary:
 						if (!device.options.secondary.host || !device.options.secondary.id)


### PR DESCRIPTION
## About the Contributor
this fix is made on behalf of BBC

## Type of Contribution
Bug fix


## Current Behavior
Currently hot standby was not registered correctly, and thus not active if enabled.


## New Behavior
Hotstandby is now testing for the full device name.


## Testing
- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas
This is only affecting mos-gateway in hotStandby mode.


## Time Frame
This is a priority bug fix from bbc.


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
