### PR TITLE
Feature: Show screen-name in screen-saver

### DIFF
--- a/packages/webui/src/client/styles/studioScreenSaver.scss
+++ b/packages/webui/src/client/styles/studioScreenSaver.scss
@@ -72,5 +72,12 @@
 			font-size: 2em;
 			letter-spacing: -0.03em;
 		}
+
+		.studio-screen-saver__info__screen-name {
+			font-size: 0.5em;
+			text-align: right;
+			letter-spacing: 0.05em;
+			margin: 0.5em;
+		}
 	}
 }

--- a/packages/webui/src/client/ui/ClockView/ClockView.tsx
+++ b/packages/webui/src/client/ui/ClockView/ClockView.tsx
@@ -11,9 +11,11 @@ import { RundownPlaylists } from '../../collections'
 import { StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { CameraScreen } from './CameraScreen'
 import { MeteorPubSub } from '@sofie-automation/meteor-lib/dist/api/pubsub'
+import { useTranslation } from 'react-i18next'
 
 export function ClockView({ studioId }: Readonly<{ studioId: StudioId }>): JSX.Element {
 	useSubscription(MeteorPubSub.rundownPlaylistForStudio, studioId, true)
+	const { t } = useTranslation()
 
 	const playlist = useTracker(
 		() =>
@@ -32,7 +34,7 @@ export function ClockView({ studioId }: Readonly<{ studioId: StudioId }>): JSX.E
 						<PresenterScreen playlistId={playlist._id} studioId={studioId} />
 					</RundownTimingProvider>
 				) : (
-					<StudioScreenSaver studioId={studioId} ownBackground={true} />
+					<StudioScreenSaver studioId={studioId} ownBackground={true} screenName={t('Presenter Screen')} />
 				)}
 			</Route>
 			<Route path="/countdowns/:studioId/overlay">

--- a/packages/webui/src/client/ui/Prompter/PrompterView.tsx
+++ b/packages/webui/src/client/ui/Prompter/PrompterView.tsx
@@ -558,7 +558,7 @@ export class PrompterViewContent extends React.Component<Translated<IProps & ITr
 						{this.renderAccessRequestButtons()}
 					</>
 				) : this.props.studio ? (
-					<StudioScreenSaver studioId={this.props.studio._id} />
+					<StudioScreenSaver studioId={this.props.studio._id} screenName={t('Prompter View')} />
 				) : this.props.studioId ? (
 					this.renderMessage(t("This studio doesn't exist."))
 				) : (

--- a/packages/webui/src/client/ui/Prompter/PrompterView.tsx
+++ b/packages/webui/src/client/ui/Prompter/PrompterView.tsx
@@ -558,7 +558,7 @@ export class PrompterViewContent extends React.Component<Translated<IProps & ITr
 						{this.renderAccessRequestButtons()}
 					</>
 				) : this.props.studio ? (
-					<StudioScreenSaver studioId={this.props.studio._id} screenName={t('Prompter View')} />
+					<StudioScreenSaver studioId={this.props.studio._id} screenName={t('Prompter Screen')} />
 				) : this.props.studioId ? (
 					this.renderMessage(t("This studio doesn't exist."))
 				) : (

--- a/packages/webui/src/client/ui/StudioScreenSaver/StudioScreenSaver.tsx
+++ b/packages/webui/src/client/ui/StudioScreenSaver/StudioScreenSaver.tsx
@@ -18,7 +18,7 @@ import { withTranslation } from 'react-i18next'
 interface IProps {
 	// the studio to be displayed in the screen saver
 	studioId: StudioId
-
+	screenName?: string
 	ownBackground?: boolean
 }
 
@@ -359,6 +359,9 @@ const StudioScreenSaverContent = withTranslation()(
 							this.props.studio?.name && (
 								<div className="studio-screen-saver__info__rundown">{this.props.studio?.name}</div>
 							)
+						)}
+						{this.props.screenName && (
+							<div className="studio-screen-saver__info__screen-name">{this.props.screenName}</div>
 						)}
 					</div>
 				</div>


### PR DESCRIPTION
## About the Contributor
This feature has been made on behalf of BBC

## Type of 
Feature

## Current Behavior
Currently you can't see if a screen is the prompter, presenter or director screen when the screen saver is active.

## New Behavior
A screenName option has been added to the screensaver
<img width="654" alt="image" src="https://github.com/user-attachments/assets/ef2bc5ba-dd2b-466a-99ee-30e17751a686" />


## Testing

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas
UI

## Time Frame


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [X] PR is ready to be reviewed.
- [X] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
