### PR TITLE
fix: `PeripheralDevice.configManifest` is an optional field

### DIFF
--- a/meteor/server/api/peripheralDevice.ts
+++ b/meteor/server/api/peripheralDevice.ts
@@ -34,7 +34,6 @@ import { PackageManagerIntegration } from './integration/expectedPackages'
 import { profiler } from './profiler'
 import { QueueStudioJob } from '../worker/worker'
 import { StudioJobs } from '@sofie-automation/corelib/dist/worker/studio'
-import { DeviceConfigManifest } from '@sofie-automation/corelib/dist/deviceConfig'
 import {
 	PlayoutChangedResults,
 	PeripheralDeviceInitOptions,
@@ -58,7 +57,7 @@ import { insertInputDeviceTriggerIntoPreview } from '../publications/deviceTrigg
 import { receiveInputDeviceTrigger } from './deviceTriggers/observer'
 import { upsertBundles, generateTranslationBundleOriginId } from './translationsBundles'
 import { isTranslatableMessage } from '@sofie-automation/corelib/dist/TranslatableMessage'
-import { JSONBlobParse, JSONBlobStringify } from '@sofie-automation/shared-lib/dist/lib/JSONBlob'
+import { JSONBlobParse } from '@sofie-automation/shared-lib/dist/lib/JSONBlob'
 import {
 	applyAndValidateOverrides,
 	SomeObjectOverrideOp,
@@ -128,16 +127,16 @@ export namespace ServerPeripheralDeviceAPI {
 						? {
 								...options.configManifest,
 								translations: undefined, // unset the translations
-							}
+						  }
 						: undefined,
 
 					documentationUrl: options.documentationUrl,
-				},
+				} satisfies Partial<PeripheralDevice>,
 				$unset:
 					newVersionsStr !== oldVersionsStr
 						? {
 								disableVersionChecks: 1,
-							}
+						  }
 						: undefined,
 			})
 		} else {
@@ -167,11 +166,8 @@ export namespace ServerPeripheralDeviceAPI {
 					? {
 							...options.configManifest,
 							translations: undefined,
-						}
-					: literal<DeviceConfigManifest>({
-							deviceConfigSchema: JSONBlobStringify({}),
-							subdeviceManifest: {},
-						}),
+					  }
+					: undefined,
 
 				documentationUrl: options.documentationUrl,
 			})

--- a/packages/corelib/src/dataModel/PeripheralDevice.ts
+++ b/packages/corelib/src/dataModel/PeripheralDevice.ts
@@ -79,7 +79,10 @@ export interface PeripheralDevice {
 	/** Ignore this device when computing status in the GUI (other status reports are unaffected) */
 	ignore?: boolean
 
-	configManifest: DeviceConfigManifest
+	/**
+	 * If this device is a parent-device, the config manifest for the device
+	 */
+	configManifest: DeviceConfigManifest | undefined
 
 	/** If this is an ingest gateway, the last tiem data was received */
 	lastDataReceived?: Time

--- a/packages/webui/src/client/ui/Settings/DeviceSettings.tsx
+++ b/packages/webui/src/client/ui/Settings/DeviceSettings.tsx
@@ -196,7 +196,9 @@ export default translateWithTracker<IDeviceSettingsProps, IDeviceSettingsState, 
 						</div>
 					</div>
 
-					<GenericAttahcedSubDeviceSettingsComponent device={device} subDevices={this.props.subDevices} />
+					{!device.parentDeviceId && (
+						<GenericAttahcedSubDeviceSettingsComponent device={device} subDevices={this.props.subDevices} />
+					)}
 
 					{device &&
 					device.type === PeripheralDeviceType.PACKAGE_MANAGER &&

--- a/packages/webui/src/client/ui/Settings/Studio/Devices/GenericSubDevices.tsx
+++ b/packages/webui/src/client/ui/Settings/Studio/Devices/GenericSubDevices.tsx
@@ -51,8 +51,8 @@ export function GenericSubDevicesTable({
 				literal<PeripheralDeviceTranslated>({
 					_id: device._id,
 					name: device.name || unprotectString(device._id),
-					subdeviceConfigSchema: device.configManifest.subdeviceConfigSchema,
-					subdeviceManifest: device.configManifest.subdeviceManifest,
+					subdeviceConfigSchema: device.configManifest?.subdeviceConfigSchema,
+					subdeviceManifest: device.configManifest?.subdeviceManifest ?? {},
 				})
 			)
 		}

--- a/packages/webui/src/client/ui/Settings/Studio/Devices/ParentDevices.tsx
+++ b/packages/webui/src/client/ui/Settings/Studio/Devices/ParentDevices.tsx
@@ -132,7 +132,7 @@ interface PeripheralDeviceTranslated {
 	_id: PeripheralDeviceId
 	name: string
 	lastSeen: number
-	deviceConfigSchema: JSONBlob<JSONSchema>
+	deviceConfigSchema: JSONBlob<JSONSchema> | undefined
 }
 
 interface ParentDevicesTableProps {
@@ -172,7 +172,7 @@ function GenericParentDevicesTable({
 					_id: device._id,
 					name: device.name || unprotectString(device._id),
 					lastSeen: device.lastSeen,
-					deviceConfigSchema: device.configManifest.deviceConfigSchema,
+					deviceConfigSchema: device.configManifest?.deviceConfigSchema,
 				})
 			)
 		}

--- a/packages/webui/src/client/ui/Settings/components/ConfigManifestOAuthFlow.tsx
+++ b/packages/webui/src/client/ui/Settings/components/ConfigManifestOAuthFlow.tsx
@@ -125,10 +125,12 @@ export const ConfigManifestOAuthFlowComponent = withTranslation()(
 				})
 		}
 
-		render(): JSX.Element {
+		render(): JSX.Element | null {
 			const { t } = this.props
 			const secretStatus = (this.props.device.secretSettingsStatus || {}) as IngestDeviceSecretSettingsStatus
 			const device = this.props.device
+
+			if (!device.configManifest) return null
 
 			return (
 				<div>

--- a/packages/webui/src/client/ui/Settings/components/GenericDeviceSettingsComponent.tsx
+++ b/packages/webui/src/client/ui/Settings/components/GenericDeviceSettingsComponent.tsx
@@ -53,7 +53,7 @@ export function GenericAttahcedSubDeviceSettingsComponent({
 
 	return (
 		<>
-			{Object.keys(device.configManifest.subdeviceManifest ?? {}).length > 0 && (
+			{Object.keys(device.configManifest?.subdeviceManifest ?? {}).length > 0 && (
 				<>
 					<h2 className="mb-4">{t('Attached Subdevices')}</h2>
 


### PR DESCRIPTION
## About the Contributor
This pull request is posted on behalf of the BBC


## Type of Contribution

This is a: Bug fix 

I haven't tested if this bug is present in R52, based on the findings it may want backporting

## Current Behavior

Navigating to the peripheraldevice page for a subdevice would crash, trying to read a property off undefined:

```
Cannot read properties of undefined (reading 'subdeviceManifest')

TypeError: Cannot read properties of undefined (reading 'subdeviceManifest')
    at GenericAttahcedSubDeviceSettingsComponent
```

This is because since R50, the `configManifest` property should not be set on subdevices. This is enforced by the migration `PeripheralDevice cleanup unused properties on child devices`.
But the types say the propery must exist, resulting in typescript not flagging the type error.

The types have been updated to reflect this, and the crash fixed


## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
* 
-->


## Time Frame
<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
