### PR TITLE
fix(EAV-555): make prompter animations compatible with bootstrap

### DIFF
--- a/packages/webui/src/client/ui/Prompter/PrompterView.tsx
+++ b/packages/webui/src/client/ui/Prompter/PrompterView.tsx
@@ -367,7 +367,7 @@ export class PrompterViewContent extends React.Component<Translated<IProps & ITr
 		this._lastAnimation = animate(window.scrollY, scrollToPosition, {
 			duration: 0.4,
 			ease: 'easeOut',
-			onUpdate: (latest) => window.scrollTo(0, latest),
+			onUpdate: (latest) => window.scrollTo({ left: 0, top: latest, behavior: 'instant' }),
 		})
 	}
 	listAnchorPositions(startY: number, endY: number, sortDirection = 1): [number, Element][] {


### PR DESCRIPTION
This PR updates the code from the previous PR (https://github.com/nrkno/sofie-core/pull/1436) to be forwards-compatible with Bootstrap, introduced with release53. In release52 this will have no effect.