### PR TITLE
docs: Use docker compose profiles to select ingest gateway to run

### DIFF
--- a/packages/documentation/docs/user-guide/installation/installing-a-gateway/rundown-or-newsroom-system-connection/inews-gateway.md
+++ b/packages/documentation/docs/user-guide/installation/installing-a-gateway/rundown-or-newsroom-system-connection/inews-gateway.md
@@ -6,8 +6,10 @@ The iNEWS Gateway communicates with an iNEWS system to ingest and remain in sync
 
 The iNEWS Gateway allows you to create rundowns from within iNEWS and sync them with the _Sofie&nbsp;Core_. The rundowns will update in real time and any changes made will be seen from within your Playout Timeline.
 
-An example setup for the iNEWS Gateway is included in the example Docker Compose file found in the [Quick install](../../installing-sofie-server-core.md), but commented out.
+An example setup for the iNEWS Gateway is included in the example Docker Compose file found in the [Quick install](../../installing-sofie-server-core.md) with the `inews-gateway` profile.
 
-Remove the _\#_ symbol from the start of the lines beginning at `# inews-gateway:` and ending at the next blank line. Be careful not to change the indentation of the file.
+You can activate the profile by setting `COMPOSE_PROFILES=inews-gateway` as an environment variable or by writing that to a file called `.env` in the same folder as the docker-compose file. For more information, see the [docker documentation on Compose profiles](https://docs.docker.com/compose/how-tos/profiles/).
+
+If you are not using the example docker-compose, please follow the [instructions listed on the GitHub page](https://github.com/tv2/inews-ftp-gateway).
 
 Although the iNEWS Gateway is available free of charge, an iNEWS license is not. Visit [Avid's website](https://www.avid.com/solutions/news-production) to find an iNEWS reseller that handles your geographic area.

--- a/packages/documentation/docs/user-guide/installation/installing-a-gateway/rundown-or-newsroom-system-connection/installing-sofie-with-google-spreadsheet-support.md
+++ b/packages/documentation/docs/user-guide/installation/installing-a-gateway/rundown-or-newsroom-system-connection/installing-sofie-with-google-spreadsheet-support.md
@@ -2,6 +2,14 @@
 
 The Spreadsheet Gateway is an application for piping data between Sofie&nbsp;Core and Spreadsheets on Google Drive.
 
+### Installing the Spreadsheet Gateway
+
+If you are using the example Docker Compose file found in the [Quick install](../../installing-sofie-server-core.md), then the configuration for the Spreadsheet Gateway is includedin the `spreadsheet-gateway` docker-compose profile.
+
+You can activate the profile by setting `COMPOSE_PROFILES=spreadsheet-gateway` as an environment variable or by writing that to a file called `.env` in the same folder as the docker-compose file. For more information, see the [docker documentation on Compose profiles](https://docs.docker.com/compose/how-tos/profiles/).
+
+If you are not using the example docker-compose, please follow the [instructions listed on the GitHub page](https://github.com/SuperFlyTV/spreadsheet-gateway) labeled _Installation \(for developers\)_.
+
 ### Example Blueprints for Spreadsheet Gateway
 
 To begin with, you will need to install a set of Blueprints that can handle the data being sent from the _Gateway_ to _Sofie&nbsp;Core_. Download the `demo-blueprints-r*.zip` file containing the blueprints you need from the [Demo Blueprints GitHub Repository](https://github.com/SuperFlyTV/sofie-demo-blueprints/releases). It is recommended to choose the newest release but, an older _Sofie&nbsp;Core_ version may require a different Blueprint version. The _Rundown page_ will warn you about any issue and display the desired versions.
@@ -9,8 +17,6 @@ To begin with, you will need to install a set of Blueprints that can handle the 
 Instructions on how to install any Blueprint can be found in the [Installing Blueprints](../../installing-blueprints.md) section from earlier.
 
 ### Spreadsheet Gateway Configuration
-
-If you are using the example Docker Compose file found in the [Quick install](../../installing-sofie-server-core.md), then the configuration for the Spreadsheet Gateway is included but commented out. For those who are not, please follow the [instructions listed on the GitHub page](https://github.com/SuperFlyTV/spreadsheet-gateway) labeled _Installation \(for developers\)._
 
 Once the Gateway has been installed, you can navigate to the _Settings page_ and check the newly added Gateway is listed as _Spreadsheet Gateway_ under the _Devices section_.
 

--- a/packages/documentation/docs/user-guide/installation/installing-a-gateway/rundown-or-newsroom-system-connection/mos-gateway.md
+++ b/packages/documentation/docs/user-guide/installation/installing-a-gateway/rundown-or-newsroom-system-connection/mos-gateway.md
@@ -4,4 +4,10 @@ The MOS Gateway communicates with a device that supports the [MOS protocol](http
 
 The setup for the MOS Gateway is handled in the Docker Compose in the [Quick Install](../../installing-sofie-server-core.md) page.
 
+An example setup for the MOS Gateway is included in the example Docker Compose file found in the [Quick install](../../installing-sofie-server-core.md) with the `mos-gateway` profile.
+
+You can activate the profile by setting `COMPOSE_PROFILES=mos-gateway` as an environment variable or by writing that to a file called `.env` in the same folder as the docker-compose file. For more information, see the [docker documentation on Compose profiles](https://docs.docker.com/compose/how-tos/profiles/).
+
+Development of the MOS gateway is done as a package in the [sofie-core repository on GitHub](https://github.com/nrkno/sofie-core/tree/master/packages/mos-gateway).
+
 One thing to note if managing the mos-gateway manually: It needs a few ports open \(10540, 10541\) for MOS-messages to be pushed to it from the NCS.

--- a/packages/documentation/docs/user-guide/installation/installing-sofie-server-core.md
+++ b/packages/documentation/docs/user-guide/installation/installing-sofie-server-core.md
@@ -118,11 +118,19 @@ volumes:
 
 Create a `Sofie` folder, copy the above content, and save it as `docker-compose.yaml` within the `Sofie` folder.
 
-Navigate to the _ingest-gateway_ section of `docker-compose.yaml` and select which type of _ingest-gateway_ you'd like installed by uncommenting it. Save your changes. If you are using the [Rundown Editor](rundown-editor.md), then no ingest gateways need to be uncommented. Visit [Rundowns & Newsroom Systems](installing-a-gateway/rundown-or-newsroom-system-connection/intro.md) to see which _Ingest Gateway_ is best suited for _your_ production environment.
-
-Then open a terminal, `cd your-sofie-folder` and `sudo docker-compose up` \(just `docker-compose up` on Windows\).
-
 Once the installation is done, Sofie should be running on [http://localhost:3000](http://localhost:3000)
+
+You can now choose if you are using the [Rundown Editor](rundown-editor.md) or an _ingest-gateway_. Visit [Rundowns & Newsroom Systems](installing-a-gateway/rundown-or-newsroom-system-connection/intro.md) to see which _Ingest Gateway_ is best suited for _your_ production environment.
+
+Select the ingest gateway by creating using docker compose profiles. Create a file called `.env` in the same folder as docker compose with the contents:
+
+```
+COMPOSE_PROFILES=ingest-profile-name
+```
+
+But replacing `ingest-profile-name` with one of `spreadsheet-gateway`, `mos-gateway` or `inews-gateway`, or a comma separated list of more than one. For more information, see the [docker documentation on Compose profiles](https://docs.docker.com/compose/how-tos/profiles/).
+
+Then open a terminal, `cd your-sofie-folder` and `sudo docker-compose up` \(just `docker-compose up` on Windows or MacOS\).
 
 ### Tips for running in production
 

--- a/packages/documentation/docs/user-guide/installation/installing-sofie-server-core.md
+++ b/packages/documentation/docs/user-guide/installation/installing-sofie-server-core.md
@@ -72,36 +72,39 @@ services:
   # If using the Rundown Editor, then none of the below images are needed.
   # The Rundown Editor can be found here: https://github.com/SuperFlyTV/sofie-automation-rundown-editor
 
-  # spreadsheet-gateway:
-  #   image: superflytv/sofie-spreadsheet-gateway:latest
-  #   restart: always
-  #   command: yarn start -host core -port 3000 -id spreadsheetGateway0
-  #   networks:
-  #     - sofie
-  #   depends_on:
-  #     - core
+  spreadsheet-gateway:
+    image: superflytv/sofie-spreadsheet-gateway:latest
+    restart: always
+    command: yarn start -host core -port 3000 -id spreadsheetGateway0
+    networks:
+      - sofie
+    depends_on:
+      - core
+    profiles: [spreadsheet-gateway]
 
-  # mos-gateway:
-  #   image: sofietv/tv-automation-mos-gateway:release51
-  #   restart: always
-  #   ports:
-  #     - "10540:10540" # MOS Lower port
-  #     - "10541:10541" # MOS Upper port
-  #     # - "10542:10542" # MOS query port - not used
-  #   command: yarn start -host core -port 3000 -id mosGateway0
-  #   networks:
-  #     - sofie
-  #   depends_on:
-  #     - core
+  mos-gateway:
+    image: sofietv/tv-automation-mos-gateway:release51
+    restart: always
+    ports:
+      - "10540:10540" # MOS Lower port
+      - "10541:10541" # MOS Upper port
+      # - "10542:10542" # MOS query port - not used
+    command: yarn start -host core -port 3000 -id mosGateway0
+    networks:
+      - sofie
+    depends_on:
+      - core
+    profiles: [mos-gateway]
 
-  # inews-gateway:
-  #   image: tv2media/inews-ftp-gateway:1.37.0-in-testing.20
-  #   restart: always
-  #   command: yarn start -host core -port 3000 -id inewsGateway0
-  #   networks:
-  #     - sofie
-  #   depends_on:
-  #     - core
+  inews-gateway:
+    image: tv2media/inews-ftp-gateway:1.37.0-in-testing.20
+    restart: always
+    command: yarn start -host core -port 3000 -id inewsGateway0
+    networks:
+      - sofie
+    depends_on:
+      - core
+    profiles: [inews-gateway]
 
 networks:
   sofie:


### PR DESCRIPTION
## About the Contributor

This work was done on behalf of SuperflyTV

## Type of Contribution

This is a Documentation improvement

## Current Behaviour

There were complicated instructions about uncommenting sections of the example docker compose file.

## New Behaviour

Profiles have been added to the example docker compose file and 

## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

Suggested docker-compose configuration.


## Time Frame

* Not urgent, but we would like to get this merged into the in-development release.

## Status

- [ ] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
