### PR TITLE
fix: Improve clock accuracy

### DIFF
--- a/packages/webui/jest.config.cjs
+++ b/packages/webui/jest.config.cjs
@@ -7,6 +7,7 @@ module.exports = {
 	globals: {},
 	moduleFileExtensions: ['js', 'ts', 'tsx'],
 	moduleNameMapper: {
+		'sha.js': 'sha.js',
 		'meteor/(.*)': '<rootDir>/src/meteor/$1',
 		'(.+)\\.js$': '$1',
 	},

--- a/packages/webui/src/client/lib/__tests__/lib.test.ts
+++ b/packages/webui/src/client/lib/__tests__/lib.test.ts
@@ -1,0 +1,50 @@
+import { useCurrentTime } from '../lib' // Adjust the import path as needed
+import { act, renderHook } from '@testing-library/react'
+
+describe('useCurrentTime Hook', () => {
+	it('should return the current time in milliseconds initially', () => {
+		const initialTime = Date.now()
+		const { result } = renderHook(() => useCurrentTime())
+		expect(result.current).toBeGreaterThanOrEqual(initialTime)
+		expect(result.current).toBeLessThanOrEqual(initialTime + 50) // Allow for a small margin
+	})
+
+	it('should update the time after the default refresh period (1000ms)', () => {
+		jest.useFakeTimers() // Enable Jest's fake timers
+		const { result } = renderHook(() => useCurrentTime())
+		const initialTime = result.current
+
+		act(() => {
+			jest.advanceTimersByTime(1000) // Advance the timers by the default refresh period
+		})
+
+		const nextSecond = Math.ceil((initialTime + 1) / 1000) * 1000 // Round to the next second
+		expect(result.current).toBeGreaterThanOrEqual(nextSecond)
+		expect(result.current).toBeLessThanOrEqual(nextSecond + 50) // Allow for a small margin
+	})
+
+	it('should update the time after a custom refresh period', () => {
+		jest.useFakeTimers() // Enable Jest's fake timers
+		const refreshPeriod = 500
+		const { result } = renderHook(() => useCurrentTime(refreshPeriod))
+		const initialTime = result.current
+
+		act(() => {
+			jest.advanceTimersByTime(refreshPeriod)
+		})
+
+		const nextInterval = Math.ceil((initialTime + 1) / refreshPeriod) * refreshPeriod // Round to the next refreshPeriod
+		expect(result.current).toBeGreaterThanOrEqual(nextInterval - 50)
+		expect(result.current).toBeLessThanOrEqual(nextInterval + 50) // Allow for a small margin
+	})
+
+	it('should clear the timeout on unmount', () => {
+		const { unmount } = renderHook(() => useCurrentTime())
+		const mockClearTimeout = jest.spyOn(global, 'clearTimeout')
+
+		unmount()
+
+		expect(mockClearTimeout).toHaveBeenCalledTimes(1)
+		// You could also assert that the timeout ID stored in the ref was passed to clearTimeout
+	})
+})


### PR DESCRIPTION
## Type of Contribution

This is a Bug fix

## Current Behaviour

Clocks on screensaver pages etc. start counting when they are loaded and update approximately every second after that. This means they are an average of 0.5 seconds behind and can be .999 seconds behind in the worst case.

Here's an example of 4 clocks running together, with the system clock visible at the top right:

https://github.com/user-attachments/assets/1731b0ea-a412-4893-9107-207b9ba27b36

## New Behaviour

Clocks will update at the next whole interval, e.g. if they are loaded at 12:00:00.523, they will try to update 477ms later at 12:00:01.000 exactly.

Here's an example of 4 clocks running together, with the system clock visible at the top right:

https://github.com/user-attachments/assets/e85fb2ff-8f79-42e4-8343-f272a6d29a26

They are now in sync to within a few frames. My machine was running a bit slowly at the time - on a faster machine it would be even more in sync.

## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [x] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

This PR affects ticking clocks on screensavers and timelines etc. It also affects when warnings and system status happen - they will now always happen on a 5s boundary, rather than every 5s from when they were loaded.

## Time Frame

* Not urgent, but we would like to get this merged into the in-development release.

## Other Information

I had to hack the Jest config because sha.js wasn't being imported correctly when running tests.

## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
